### PR TITLE
Ensure notify errors don't interrupt sending

### DIFF
--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -1,5 +1,4 @@
 const { asyncMiddleware } = require('../utils/middleware')
-const logger = require('../../log.js')
 
 module.exports = ({ licenceService, prisonerService, notificationService, audit }) => router => {
   router.get('/:destination/:bookingId', async (req, res) => {
@@ -34,21 +33,14 @@ module.exports = ({ licenceService, prisonerService, notificationService, audit 
 
       auditEvent(req.user.username, bookingId, transition.type, submissionTarget)
 
-      try {
-        await notificationService.sendNotifications({
-          bookingId,
-          prisoner: res.locals.prisoner,
-          notificationType: transition.notificationType,
-          submissionTarget,
-          sendingUserName: req.user.username,
-          token: res.locals.token,
-        })
-      } catch (error) {
-        logger.warn(
-          `Error sending notification for bookingId: ${bookingId}, transition: ${transition.type}`,
-          error.stack
-        )
-      }
+      notificationService.sendNotifications({
+        bookingId,
+        prisoner: res.locals.prisoner,
+        notificationType: transition.notificationType,
+        submissionTarget,
+        sendingUserName: req.user.username,
+        token: res.locals.token,
+      })
 
       res.redirect(`/hdc/sent/${transition.receiver}/${transition.type}/${bookingId}`)
     })

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -111,21 +111,28 @@ module.exports = function createNotificationService(
     sendingUserName,
     token,
   }) {
-    const notifications = await getNotificationData({
-      prisoner,
-      token,
-      notificationType,
-      submissionTarget,
-      bookingId,
-      sendingUserName,
-    })
+    try {
+      const notifications = await getNotificationData({
+        prisoner,
+        token,
+        notificationType,
+        submissionTarget,
+        bookingId,
+        sendingUserName,
+      })
 
-    notify({
-      sendingUserName,
-      notificationType,
-      bookingId,
-      notifications,
-    })
+      await notify({
+        sendingUserName,
+        notificationType,
+        bookingId,
+        notifications,
+      })
+    } catch (error) {
+      logger.warn(
+        `Error sending notification for bookingId: ${bookingId}, transition: ${notificationType}`,
+        error.stack
+      )
+    }
   }
 
   async function notify({ sendingUserName, type, bookingId, notifications } = {}) {

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -14,7 +14,14 @@ module.exports = function createNotificationService(
   notifyClient,
   audit
 ) {
-  async function getNotificationData({ prisoner, token, notificationType, submissionTarget, bookingId, sendingUser }) {
+  async function getNotificationData({
+    prisoner,
+    token,
+    notificationType,
+    submissionTarget,
+    bookingId,
+    sendingUserName,
+  }) {
     const common = {
       offender_name: [prisoner.firstName, prisoner.lastName].join(' '),
       offender_dob: prisoner.dateOfBirth,
@@ -31,18 +38,18 @@ module.exports = function createNotificationService(
     }
 
     return notificationDataMethod[notificationType]
-      ? notificationDataMethod[notificationType]({ common, token, submissionTarget, bookingId, sendingUser })
+      ? notificationDataMethod[notificationType]({ common, token, submissionTarget, bookingId, sendingUserName })
       : []
   }
 
-  async function getCaNotificationData({ common, submissionTarget, sendingUser }) {
+  async function getCaNotificationData({ common, submissionTarget, sendingUserName }) {
     const mailboxes = await configClient.getMailboxes(submissionTarget.agencyId, 'CA')
 
     if (isEmpty(mailboxes)) {
       logger.error(`Missing CA notification email addresses for agencyId: ${submissionTarget.agencyId}`)
       return []
     }
-    const personalisation = { ...common, sender_name: sendingUser.username }
+    const personalisation = { ...common, sender_name: sendingUserName }
 
     return mailboxes.map(mailbox => {
       return { personalisation, email: mailbox.email }
@@ -96,7 +103,32 @@ module.exports = function createNotificationService(
     })
   }
 
-  async function notify({ user, type, bookingId, notifications } = {}) {
+  async function sendNotifications({
+    prisoner,
+    notificationType,
+    submissionTarget,
+    bookingId,
+    sendingUserName,
+    token,
+  }) {
+    const notifications = await getNotificationData({
+      prisoner,
+      token,
+      notificationType,
+      submissionTarget,
+      bookingId,
+      sendingUserName,
+    })
+
+    notify({
+      sendingUserName,
+      notificationType,
+      bookingId,
+      notifications,
+    })
+  }
+
+  async function notify({ sendingUserName, type, bookingId, notifications } = {}) {
     if (isEmpty(notifyKey) || notifyKey === 'NOTIFY_OFF') {
       logger.warn('No notification API key - notifications disabled')
       return
@@ -131,7 +163,7 @@ module.exports = function createNotificationService(
           })
       }
     })
-    auditEvent(user, bookingId, type, notifications)
+    auditEvent(sendingUserName, bookingId, type, notifications)
   }
 
   function auditEvent(user, bookingId, notificationType, notifications) {
@@ -144,6 +176,7 @@ module.exports = function createNotificationService(
 
   return {
     getNotificationData,
+    sendNotifications,
     notify,
   }
 }

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -127,11 +127,14 @@ module.exports = function createNotificationService(
         bookingId,
         notifications,
       })
+
+      return notifications
     } catch (error) {
       logger.warn(
         `Error sending notification for bookingId: ${bookingId}, transition: ${notificationType}`,
         error.stack
       )
+      return []
     }
   }
 

--- a/test/routes/sendTest.js
+++ b/test/routes/sendTest.js
@@ -278,7 +278,14 @@ describe('send', () => {
       })
 
       it('shows sent confirmation', () => {
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService }, 'dmUser')
+        const app = createApp(
+          {
+            licenceServiceStub: licenceService,
+            prisonerServiceStub: prisonerService,
+            notificationServiceStub: notificationService,
+          },
+          'dmUser'
+        )
 
         return request(app)
           .post('/hdc/send/return/123')

--- a/test/routes/sendTest.js
+++ b/test/routes/sendTest.js
@@ -18,7 +18,6 @@ describe('send', () => {
   let userAdminService
   let notificationService
 
-  const notificationsData = [{ email: 'email1@email.com' }, { email: 'email2@email.com' }]
   const prisoner = { firstName: 'first', lastName: 'last', dateOfBirth: 'off-dob', offenderNo: 'AB1234A' }
   const submissionTarget = { premise: 'HMP Blah', agencyId: 'LT1', com: { name: 'Something', deliusId: 'delius' } }
 
@@ -38,10 +37,10 @@ describe('send', () => {
 
     userAdminService.getRoUserByDeliusId = sinon.stub().resolves({ orgEmail: 'expected@email' })
 
-    notificationService.getNotificationData = sinon.stub().resolves(notificationsData)
+    notificationService.sendNotifications = sinon.stub().resolves({})
 
     auditStub.record.reset()
-    notificationService.notify.reset()
+    notificationService.sendNotifications.reset()
   })
 
   describe('Get send/:destination/:bookingId', () => {
@@ -314,25 +313,14 @@ describe('send', () => {
         return request(app)
           .post('/hdc/send/addressReview/123')
           .expect(() => {
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledOnce()
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('RO', '123', 'token')
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledOnce()
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith('123', 'token')
-            expect(notificationService.getNotificationData).to.be.calledOnce()
-            expect(notificationService.getNotificationData).to.be.calledWith({
+            expect(notificationService.sendNotifications).to.be.calledOnce()
+            expect(notificationService.sendNotifications).to.be.calledWith({
               prisoner,
-              token: 'token',
+              bookingId: '123',
               notificationType: 'RO_NEW',
+              sendingUserName: sinon.match.any,
               submissionTarget,
-              bookingId: '123',
-              sendingUser: sinon.match.any,
-            })
-            expect(notificationService.notify).to.be.calledOnce()
-            expect(notificationService.notify).to.be.calledWith({
-              user: 'CA_USER_TEST',
-              type: 'RO_NEW',
-              bookingId: '123',
-              notifications: notificationsData,
+              token: 'token',
             })
           })
       })
@@ -351,25 +339,14 @@ describe('send', () => {
         return request(app)
           .post('/hdc/send/finalChecks/123')
           .expect(() => {
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledOnce()
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('CA', '123', 'system-token')
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledOnce()
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith('123', 'system-token')
-            expect(notificationService.getNotificationData).to.be.calledOnce()
-            expect(notificationService.getNotificationData).to.be.calledWith({
+            expect(notificationService.sendNotifications).to.be.calledOnce()
+            expect(notificationService.sendNotifications).to.be.calledWith({
               prisoner,
               token: 'system-token',
               notificationType: 'CA_RETURN',
               submissionTarget,
               bookingId: '123',
-              sendingUser: sinon.match.any,
-            })
-            expect(notificationService.notify).to.be.calledOnce()
-            expect(notificationService.notify).to.be.calledWith({
-              user: 'RO_USER',
-              type: 'CA_RETURN',
-              bookingId: '123',
-              notifications: notificationsData,
+              sendingUserName: sinon.match.any,
             })
           })
       })
@@ -388,25 +365,14 @@ describe('send', () => {
         return request(app)
           .post('/hdc/send/approval/123')
           .expect(() => {
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledOnce()
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('DM', '123', 'token')
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledOnce()
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith('123', 'token')
-            expect(notificationService.getNotificationData).to.be.calledOnce()
-            expect(notificationService.getNotificationData).to.be.calledWith({
+            expect(notificationService.sendNotifications).to.be.calledOnce()
+            expect(notificationService.sendNotifications).to.be.calledWith({
               prisoner,
               token: 'token',
               notificationType: 'DM_NEW',
               submissionTarget,
               bookingId: '123',
-              sendingUser: sinon.match.any,
-            })
-            expect(notificationService.notify).to.be.calledOnce()
-            expect(notificationService.notify).to.be.calledWith({
-              user: 'CA_USER_TEST',
-              type: 'DM_NEW',
-              bookingId: '123',
-              notifications: notificationsData,
+              sendingUserName: sinon.match.any,
             })
           })
       })
@@ -425,26 +391,39 @@ describe('send', () => {
         return request(app)
           .post('/hdc/send/decided/123')
           .expect(() => {
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledOnce()
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('CA', '123', 'token')
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledOnce()
-            expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith('123', 'token')
-            expect(notificationService.getNotificationData).to.be.calledOnce()
-            expect(notificationService.getNotificationData).to.be.calledWith({
+            expect(notificationService.sendNotifications).to.be.calledOnce()
+            expect(notificationService.sendNotifications).to.be.calledWith({
               prisoner,
               token: 'token',
               notificationType: 'CA_DECISION',
               submissionTarget,
               bookingId: '123',
-              sendingUser: sinon.match.any,
+              sendingUserName: sinon.match.any,
             })
-            expect(notificationService.notify).to.be.calledOnce()
-            expect(notificationService.notify).to.be.calledWith({
-              user: 'DM_USER',
-              type: 'CA_DECISION',
-              bookingId: '123',
-              notifications: notificationsData,
-            })
+          })
+      })
+
+      it('Completes the sending process even when errors arise from notify', () => {
+        notificationService.sendNotifications.rejects(new Error('dead'))
+
+        const app = createApp(
+          {
+            licenceServiceStub: licenceService,
+            prisonerServiceStub: prisonerService,
+            userAdminServiceStub: userAdminService,
+            notificationServiceStub: notificationService,
+          },
+          'dmUser'
+        )
+
+        return request(app)
+          .post('/hdc/send/return/123')
+          .expect(() => {
+            expect(prisonerService.getOrganisationContactDetails).to.be.calledOnce()
+            expect(licenceService.markForHandover).to.be.calledOnce()
+            expect(licenceService.removeDecision).to.be.calledOnce()
+            expect(auditStub.record).to.be.calledOnce()
+            expect(notificationService.sendNotifications).to.be.calledOnce()
           })
       })
     })

--- a/test/routes/sendTest.js
+++ b/test/routes/sendTest.js
@@ -409,30 +409,6 @@ describe('send', () => {
             })
           })
       })
-
-      it('Completes the sending process even when errors arise from notify', () => {
-        notificationService.sendNotifications.rejects(new Error('dead'))
-
-        const app = createApp(
-          {
-            licenceServiceStub: licenceService,
-            prisonerServiceStub: prisonerService,
-            userAdminServiceStub: userAdminService,
-            notificationServiceStub: notificationService,
-          },
-          'dmUser'
-        )
-
-        return request(app)
-          .post('/hdc/send/return/123')
-          .expect(() => {
-            expect(prisonerService.getOrganisationContactDetails).to.be.calledOnce()
-            expect(licenceService.markForHandover).to.be.calledOnce()
-            expect(licenceService.removeDecision).to.be.calledOnce()
-            expect(auditStub.record).to.be.calledOnce()
-            expect(notificationService.sendNotifications).to.be.calledOnce()
-          })
-      })
     })
   })
 })

--- a/test/services/notificationServiceTest.js
+++ b/test/services/notificationServiceTest.js
@@ -36,49 +36,49 @@ describe('notificationService', () => {
   describe('notify', () => {
     it('should do nothing if no template id configured', async () => {
       const notifications = [{ email: ['email@email.com'] }]
-      await service.notify({ user: 'username', type: 'UNKNOWN_TYPE', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'UNKNOWN_TYPE', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).not.to.be.calledOnce()
     })
 
     it('should do nothing if empty data', async () => {
       const notifications = [{}]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).not.to.be.calledOnce()
     })
 
     it('should do nothing if empty emails', async () => {
       const notifications = [{ email: [] }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).not.to.be.calledOnce()
     })
 
     it('should call sendEmail from notifyClient', async () => {
       const notifications = [{ email: 'email@email.com' }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).to.be.calledOnce()
     })
 
     it('should pass in the template id', async () => {
       const notifications = [{ email: ['email@email.com'] }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).to.be.calledWith(templates.CA_RETURN.templateId, sinon.match.any, sinon.match.any)
     })
 
     it('should pass in the email address', async () => {
       const notifications = [{ email: 'email@email.com' }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).to.be.calledWith(sinon.match.any, 'email@email.com', sinon.match.any)
     })
 
     it('should pass in the data', async () => {
       const notifications = [{ personalisation: { a: 'a' }, email: ['email@email.com'] }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).to.be.calledWith(sinon.match.any, sinon.match.any, { personalisation: { a: 'a' } })
     })
 
     it('should audit the event', async () => {
       const notifications = [{ personalisation: { a: 'a' }, email: 'email@email.com' }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(audit.record).to.be.calledOnce()
       expect(audit.record).to.be.calledWith('NOTIFY', 'username', {
         bookingId: 123,
@@ -89,7 +89,7 @@ describe('notificationService', () => {
 
     it('should call sendEmail from notifyClient once for each email', async () => {
       const notifications = [{ email: '1@1.com' }, { email: '2@2.com' }, { email: '3@3.com' }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(notifyClient.sendEmail).to.be.calledThrice()
       expect(notifyClient.sendEmail).to.be.calledWith(sinon.match.any, '1@1.com', sinon.match.any)
       expect(notifyClient.sendEmail).to.be.calledWith(sinon.match.any, '2@2.com', sinon.match.any)
@@ -98,7 +98,7 @@ describe('notificationService', () => {
 
     it('should audit the event only once when multiple email addresses', async () => {
       const notifications = [{ email: '1@1.com' }, { email: '2@2.com' }, { email: '3@3.com' }]
-      await service.notify({ user: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
+      await service.notify({ sendingUserName: 'username', type: 'CA_RETURN', bookingId: 123, notifications })
       expect(audit.record).to.be.calledOnce()
       expect(audit.record).to.be.calledWith('NOTIFY', 'username', {
         bookingId: 123,
@@ -190,7 +190,7 @@ describe('notificationService', () => {
           notificationType: 'RO_NEW',
           submissionTarget: { com: { deliusId: 'deliusId', name: 'RO Name' } },
           bookingId: '123',
-          sendingUser: 'sender',
+          sendingUserName: 'sender',
         })
 
         expect(prisonerService.getEstablishmentForPrisoner).to.be.calledOnce()
@@ -242,7 +242,7 @@ describe('notificationService', () => {
           notificationType: 'CA_RETURN',
           submissionTarget: { agencyId: 'LT1' },
           bookingId: '123',
-          sendingUser: { username: 'sender' },
+          sendingUserName: 'sender',
         })
 
         expect(data).to.eql([
@@ -282,7 +282,7 @@ describe('notificationService', () => {
           notificationType: 'DM_NEW',
           submissionTarget: { agencyId: 'LT1' },
           bookingId: '123',
-          sendingUser: { username: 'sender' },
+          sendingUserName: 'sender',
         })
 
         expect(data).to.eql([

--- a/test/services/notificationServiceTest.js
+++ b/test/services/notificationServiceTest.js
@@ -304,4 +304,21 @@ describe('notificationService', () => {
       })
     })
   })
+
+  describe('sendNotifications', () => {
+    it('Should not error if internal errors, just return empty', async () => {
+      prisonerService.getEstablishmentForPrisoner.rejects(new Error('dead'))
+      const inputs = {
+        prisoner: {},
+        notificationType: {},
+        submissionTarget: {},
+        bookingId: {},
+        sendingUserName: {},
+        token: {},
+      }
+
+      const result = await service.sendNotifications(inputs)
+      expect(result).to.eql([])
+    })
+  })
 })


### PR DESCRIPTION
Also clean up send route by moving to notification service.

Notifications are non-critical so if an error occurs it only needs to be logged but should not cause the handover to fail. Therefore have re-ordered code so that errors during notify will not affect send.

Also if the handover fails then notifications should not be sent, so now the order ensures that too.