### PR TITLE
Services to find due/overdue cases and send notifications

### DIFF
--- a/server/data/licenceClient.js
+++ b/server/data/licenceClient.js
@@ -125,6 +125,28 @@ module.exports = {
 
     return db.query(query)
   },
+
+  async getLicencesInStageBetweenDates(stage, from, upto) {
+    const query = {
+      text: `select l.booking_id, l.transition_date
+                   from licences l where stage = $1 and transition_date >= $2 and transition_date < $3`,
+      values: [stage, from, upto],
+    }
+
+    const { rows } = await db.query(query)
+    return rows
+  },
+
+  async getLicencesInStageBeforeDate(stage, upto) {
+    const query = {
+      text: `select l.booking_id, l.transition_date
+                   from licences l where stage = $1 and transition_date < $2`,
+      values: [stage, upto],
+    }
+
+    const { rows } = await db.query(query)
+    return rows
+  },
 }
 
 async function updateVersion(bookingId, postRelease) {

--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,7 @@ const createUserAdminService = require('./services/userAdminService')
 const createUserService = require('./services/userService')
 const createNotificationService = require('./services/notificationService')
 const createNomisPushService = require('./services/nomisPushService')
+const createDeadlineService = require('./services/deadlineService')
 
 const signInService = createSignInService(audit)
 const licenceService = createLicenceService(licenceClient)
@@ -34,9 +35,11 @@ const pdfService = createPdfService(logger, licenceService, conditionsService, p
 const reportingService = createReportingService(audit)
 const userAdminService = createUserAdminService(nomisClientBuilder, userClient)
 const userService = createUserService(nomisClientBuilder)
+const deadlineService = createDeadlineService(licenceClient)
 const notificationService = createNotificationService(
   prisonerService,
   userAdminService,
+  deadlineService,
   configClient,
   notifyClient,
   audit
@@ -55,6 +58,7 @@ const app = createApp({
   notificationService,
   userService,
   nomisPushService,
+  deadlineService,
   configClient,
   audit,
 })

--- a/server/services/config/notificationTemplates.js
+++ b/server/services/config/notificationTemplates.js
@@ -8,6 +8,15 @@ module.exports = {
   RO_NEW: {
     templateId: '9afc4ab7-5d3f-4703-805b-8d5b7c0c7cea',
   },
+  RO_TWO_DAYS: {
+    templateId: '7f37bc44-de7f-4992-8e3a-bb158efab70d',
+  },
+  RO_DUE: {
+    templateId: '6db64b32-eaf5-4f8a-b3b3-980787232bc2',
+  },
+  RO_OVERDUE: {
+    templateId: '7d1b70f5-f27b-4e7d-ac8d-ecfe48c8b496',
+  },
   DM_NEW: {
     templateId: 'b06bfd70-0b7b-4ccf-9b6d-9e577e282ed1',
   },

--- a/server/services/deadlineService.js
+++ b/server/services/deadlineService.js
@@ -16,23 +16,13 @@ module.exports = function createDeadlineService(licenceClient) {
     }
     rejectIfUnknown(role)
     const { from, upto } = dueDateMethods[role].due(days)
-    try {
-      return licenceClient.getLicencesInStageBetweenDates(roleStages[role], from, upto)
-    } catch (error) {
-      logger.error('Error getting due licences', error.stack)
-      throw error
-    }
+    return licenceClient.getLicencesInStageBetweenDates(roleStages[role], from, upto)
   }
 
   async function getOverdue(role) {
     rejectIfUnknown(role)
     const upto = dueDateMethods[role].overdue()
-    try {
-      return licenceClient.getLicencesInStageBeforeDate(roleStages[role], upto)
-    } catch (error) {
-      logger.error('Error getting overdue licences', error.stack)
-      throw error
-    }
+    return licenceClient.getLicencesInStageBeforeDate(roleStages[role], upto)
   }
 
   function rejectIfUnknown(role) {

--- a/server/services/deadlineService.js
+++ b/server/services/deadlineService.js
@@ -1,0 +1,47 @@
+const logger = require('../../log.js')
+const { getRoOverdueCasesDate, getRoDueCasesDates } = require('../utils/dueDates')
+
+const roleStages = {
+  RO: 'PROCESSING_RO',
+}
+
+const dueDateMethods = {
+  RO: { due: getRoDueCasesDates, overdue: getRoOverdueCasesDate },
+}
+
+module.exports = function createDeadlineService(licenceClient) {
+  async function getDueInDays(role, days) {
+    if (!Number.isInteger(days) || days < 0) {
+      throw new Error('Days must be a whole number')
+    }
+    rejectIfUnknown(role)
+    const { from, upto } = dueDateMethods[role].due(days)
+    try {
+      return licenceClient.getLicencesInStageBetweenDates(roleStages[role], from, upto)
+    } catch (error) {
+      logger.error('Error getting due licences', error.stack)
+      throw error
+    }
+  }
+
+  async function getOverdue(role) {
+    rejectIfUnknown(role)
+    const upto = dueDateMethods[role].overdue()
+    try {
+      return licenceClient.getLicencesInStageBeforeDate(roleStages[role], upto)
+    } catch (error) {
+      logger.error('Error getting overdue licences', error.stack)
+      throw error
+    }
+  }
+
+  function rejectIfUnknown(role) {
+    if (!roleStages[role] || !dueDateMethods[role]) {
+      const message = `Unmatched role code for getting due dates: ${role}`
+      logger.error()
+      throw new Error(message)
+    }
+  }
+
+  return { getDueInDays, getOverdue }
+}

--- a/server/utils/dueDates.js
+++ b/server/utils/dueDates.js
@@ -2,18 +2,59 @@ const moment = require('moment-business-days')
 const { dueDateFormat, roNewCaseWorkingDays, roNewCaseTodayCutOff } = require('../config').notifications
 
 module.exports = {
+  getRoCaseDueDate,
   getRoNewCaseDueDate,
+  getRoOverdueCasesDate,
+  getRoDueCasesDates,
 }
 
-function getRoNewCaseDueDate() {
-  const now = moment().locale('en-holidays')
-  const daysToAdd = now.hour() >= roNewCaseTodayCutOff ? roNewCaseWorkingDays + 1 : roNewCaseWorkingDays
+const holidaysLocalName = 'holidaysLocale'
 
-  return now.businessAdd(daysToAdd).format(dueDateFormat)
+function getRoNewCaseDueDate() {
+  return addRoWorkingDays(moment().locale(holidaysLocalName))
+}
+
+function getRoCaseDueDate(startMoment) {
+  if (!moment.isMoment(startMoment)) {
+    return null
+  }
+
+  return addRoWorkingDays(startMoment.locale(holidaysLocalName))
+}
+
+function addRoWorkingDays(startMoment) {
+  const extraDaysAllowance = startMoment.hour() >= roNewCaseTodayCutOff ? 1 : 0
+  return startMoment.businessAdd(roNewCaseWorkingDays + extraDaysAllowance).format(dueDateFormat)
+}
+
+function getRoOverdueCasesDate() {
+  const now = moment().locale(holidaysLocalName)
+
+  return now
+    .businessSubtract(roNewCaseWorkingDays + 1)
+    .hour(roNewCaseTodayCutOff - 1)
+    .format('YYYY-MM-DD HH:59:59')
+}
+
+function getRoDueCasesDates(workingDaysUntilDue) {
+  const now = moment().locale(holidaysLocalName)
+  const workingDaysBefore = roNewCaseWorkingDays - workingDaysUntilDue
+
+  return {
+    upto: now
+      .businessSubtract(workingDaysBefore)
+      .hour(roNewCaseTodayCutOff - 1)
+      .format('YYYY-MM-DD HH:59:59'),
+    from: now
+      .businessSubtract(workingDaysBefore + 1)
+      .hour(roNewCaseTodayCutOff)
+      .format('YYYY-MM-DD HH:00:00'),
+  }
 }
 
 // Use a custom locale to avoid conflict with other customisations of the en locale eg caseListFormatter.js
-moment.defineLocale('en-holidays', {
+const holidaysLocale = holidaysLocalName
+moment.defineLocale(holidaysLocale, {
   parentLocale: 'en',
   holidays: [
     '19-04-2019',

--- a/test/data/licenceClientTest.js
+++ b/test/data/licenceClientTest.js
@@ -311,23 +311,6 @@ describe('licenceClient', () => {
   })
 
   describe('getLicencesInStageBetweenDates', () => {
-    it('should call query', () => {
-      licencesProxy().getLicencesInStageBetweenDates('stage', 'from', 'upto')
-      expect(queryStub).to.have.callCount(1)
-    })
-
-    it('should pass in the correct sql', () => {
-      const expectedSelectClause = 'select l.booking_id, l.transition_date'
-      const expectedWhereClause = 'where stage = $1 and transition_date >= $2 and transition_date < $3'
-
-      const result = licencesProxy().getLicencesInStageBetweenDates('stage', 'from', 'upto')
-
-      return result.then(() => {
-        expect(queryStub.getCalls()[0].args[0].text).includes(expectedSelectClause)
-        expect(queryStub.getCalls()[0].args[0].text).includes(expectedWhereClause)
-      })
-    })
-
     it('should pass in the correct parameters', () => {
       const expectedParameters = ['stage', 'from', 'upto']
 
@@ -341,23 +324,6 @@ describe('licenceClient', () => {
   })
 
   describe('getLicencesInStageBeforeDate', () => {
-    it('should call query', () => {
-      licencesProxy().getLicencesInStageBeforeDate('stage', 'upto')
-      expect(queryStub).to.have.callCount(1)
-    })
-
-    it('should pass in the correct sql', () => {
-      const expectedSelectClause = 'select l.booking_id, l.transition_date'
-      const expectedWhereClause = 'where stage = $1 and transition_date < $2'
-
-      const result = licencesProxy().getLicencesInStageBeforeDate('stage', 'upto')
-
-      return result.then(() => {
-        expect(queryStub.getCalls()[0].args[0].text).includes(expectedWhereClause)
-        expect(queryStub.getCalls()[0].args[0].text).includes(expectedSelectClause)
-      })
-    })
-
     it('should pass in the correct parameters', () => {
       const expectedParameters = ['stage', 'upto']
 

--- a/test/data/licenceClientTest.js
+++ b/test/data/licenceClientTest.js
@@ -296,7 +296,7 @@ describe('licenceClient', () => {
       expect(sql).to.include(expectedContents3)
     })
 
-    it('should then update the vary_version it postApproval', async () => {
+    it('should then update the vary_version if postApproval', async () => {
       const expectedContents = 'SET vary_version = vary_version + 1'
       const expectedContents2 = 'WHERE booking_id = $1 and vary_version'
       const expectedContents3 = 'SELECT max(vary_version'
@@ -307,6 +307,66 @@ describe('licenceClient', () => {
       expect(sql).to.include(expectedContents)
       expect(sql).to.include(expectedContents2)
       expect(sql).to.include(expectedContents3)
+    })
+  })
+
+  describe('getLicencesInStageBetweenDates', () => {
+    it('should call query', () => {
+      licencesProxy().getLicencesInStageBetweenDates('stage', 'from', 'upto')
+      expect(queryStub).to.have.callCount(1)
+    })
+
+    it('should pass in the correct sql', () => {
+      const expectedSelectClause = 'select l.booking_id, l.transition_date'
+      const expectedWhereClause = 'where stage = $1 and transition_date >= $2 and transition_date < $3'
+
+      const result = licencesProxy().getLicencesInStageBetweenDates('stage', 'from', 'upto')
+
+      return result.then(() => {
+        expect(queryStub.getCalls()[0].args[0].text).includes(expectedSelectClause)
+        expect(queryStub.getCalls()[0].args[0].text).includes(expectedWhereClause)
+      })
+    })
+
+    it('should pass in the correct parameters', () => {
+      const expectedParameters = ['stage', 'from', 'upto']
+
+      const result = licencesProxy().getLicencesInStageBetweenDates('stage', 'from', 'upto')
+
+      return result.then(() => {
+        const { values } = queryStub.getCalls()[0].args[0]
+        expect(values).to.eql(expectedParameters)
+      })
+    })
+  })
+
+  describe('getLicencesInStageBeforeDate', () => {
+    it('should call query', () => {
+      licencesProxy().getLicencesInStageBeforeDate('stage', 'upto')
+      expect(queryStub).to.have.callCount(1)
+    })
+
+    it('should pass in the correct sql', () => {
+      const expectedSelectClause = 'select l.booking_id, l.transition_date'
+      const expectedWhereClause = 'where stage = $1 and transition_date < $2'
+
+      const result = licencesProxy().getLicencesInStageBeforeDate('stage', 'upto')
+
+      return result.then(() => {
+        expect(queryStub.getCalls()[0].args[0].text).includes(expectedWhereClause)
+        expect(queryStub.getCalls()[0].args[0].text).includes(expectedSelectClause)
+      })
+    })
+
+    it('should pass in the correct parameters', () => {
+      const expectedParameters = ['stage', 'upto']
+
+      const result = licencesProxy().getLicencesInStageBeforeDate('stage', 'upto')
+
+      return result.then(() => {
+        const { values } = queryStub.getCalls()[0].args[0]
+        expect(values).to.eql(expectedParameters)
+      })
     })
   })
 })

--- a/test/services/deadlineServiceTest.js
+++ b/test/services/deadlineServiceTest.js
@@ -1,0 +1,106 @@
+const createDeadlineService = require('../../server/services/deadlineService')
+
+describe('deadlineService', () => {
+  let licenceClient
+  let service
+  let clock
+
+  const transitionDate = '2019-01-01 12:00:00'
+
+  beforeEach(() => {
+    licenceClient = {
+      getLicencesInStageBeforeDate: sinon
+        .stub()
+        .resolves([
+          { booking_id: 1, transition_date: transitionDate },
+          { booking_id: 2, transition_date: transitionDate },
+        ]),
+      getLicencesInStageBetweenDates: sinon
+        .stub()
+        .resolves([
+          { booking_id: 3, transition_date: transitionDate },
+          { booking_id: 4, transition_date: transitionDate },
+        ]),
+    }
+    service = createDeadlineService(licenceClient)
+    clock = sinon.useFakeTimers(new Date('April 25, 2019 01:00:00').getTime())
+  })
+
+  afterEach(() => {
+    clock.restore()
+  })
+
+  describe('getOverdue', () => {
+    it('should reject unknown role code', () => {
+      return expect(service.getOverdue('none')).to.eventually.be.rejected()
+    })
+
+    it('should request matching licences from client', () => {
+      service.getOverdue('RO')
+      expect(licenceClient.getLicencesInStageBeforeDate).to.be.calledOnce()
+      expect(licenceClient.getLicencesInStageBeforeDate).to.be.calledWith('PROCESSING_RO', '2019-04-08 14:59:59')
+    })
+
+    it('should return booking IDs and transition dates', () => {
+      return expect(service.getOverdue('RO')).to.eventually.eql([
+        { booking_id: 1, transition_date: transitionDate },
+        { booking_id: 2, transition_date: transitionDate },
+      ])
+    })
+
+    it('should throw if error getting licence', () => {
+      licenceClient.getLicencesInStageBeforeDate.rejects()
+      return expect(service.getOverdue('RO')).to.eventually.be.rejected()
+    })
+  })
+
+  describe('getDueInDays', () => {
+    it('should reject if days not a number', () => {
+      return expect(service.getDueInDays('RO', '')).to.eventually.be.rejected()
+    })
+
+    it('should reject if days not a whole number', () => {
+      return expect(service.getDueInDays('RO', 2.5)).to.eventually.be.rejected()
+    })
+
+    it('should reject if days not a positive number', () => {
+      return expect(service.getDueInDays('RO', -2)).to.eventually.be.rejected()
+    })
+
+    it('should reject unknown role code', () => {
+      return expect(service.getDueInDays('none', 2)).to.eventually.be.rejected()
+    })
+
+    it('should request matching licences from client', () => {
+      service.getDueInDays('RO', 2)
+      expect(licenceClient.getLicencesInStageBetweenDates).to.be.calledOnce()
+      expect(licenceClient.getLicencesInStageBetweenDates).to.be.calledWith(
+        'PROCESSING_RO',
+        '2019-04-10 15:00:00',
+        '2019-04-11 14:59:59'
+      )
+    })
+
+    it('should return booking IDs and transition dates', () => {
+      return expect(service.getDueInDays('RO', 2)).to.eventually.eql([
+        { booking_id: 3, transition_date: transitionDate },
+        { booking_id: 4, transition_date: transitionDate },
+      ])
+    })
+
+    it('should allow 0 days as input', () => {
+      service.getDueInDays('RO', 0)
+      expect(licenceClient.getLicencesInStageBetweenDates).to.be.calledOnce()
+      expect(licenceClient.getLicencesInStageBetweenDates).to.be.calledWith(
+        'PROCESSING_RO',
+        '2019-04-08 15:00:00',
+        '2019-04-09 14:59:59'
+      )
+    })
+
+    it('should throw if error getting licence', () => {
+      licenceClient.getLicencesInStageBetweenDates.rejects()
+      return expect(service.getDueInDays('RO', 2)).to.eventually.be.rejected()
+    })
+  })
+})

--- a/test/utils/dueDatesTest.js
+++ b/test/utils/dueDatesTest.js
@@ -1,40 +1,109 @@
-const { getRoNewCaseDueDate } = require('../../server/utils/dueDates')
+const moment = require('moment')
+const {
+  getRoCaseDueDate,
+  getRoNewCaseDueDate,
+  getRoOverdueCasesDate,
+  getRoDueCasesDates,
+} = require('../../server/utils/dueDates')
 
-describe('getRoNewCaseDueDate', () => {
-  let clock
+describe('Due dates calcuations', () => {
+  context('specified time basis', () => {
+    describe('getRoCaseDueDate', () => {
+      it('should return null if input is missing', async () => {
+        expect(getRoCaseDueDate()).to.eql(null)
+      })
 
-  afterEach(() => {
-    clock.restore()
+      it('should return null if input is not a moment', async () => {
+        expect(getRoCaseDueDate('2019-03-11 14:59:59')).to.eql(null)
+      })
+
+      it('should add 10 working days if before 3pm', async () => {
+        expect(getRoCaseDueDate(moment('2019-03-11 14:59:59'))).to.eql('Monday 25th March')
+      })
+
+      it('should add 11 working days if 3pm or later', async () => {
+        expect(getRoCaseDueDate(moment('2019-03-11 15:00:00'))).to.eql('Tuesday 26th March')
+      })
+    })
   })
 
-  it('should add 10 working days if before 3pm', async () => {
-    clock = sinon.useFakeTimers(new Date('March 11, 2019 14:59:59').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Monday 25th March')
-  })
+  context('current time basis', () => {
+    let clock
 
-  it('should add 11 working days if exactly 3pm', async () => {
-    clock = sinon.useFakeTimers(new Date('March 11, 2019 15:00:00').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Tuesday 26th March')
-  })
+    afterEach(() => {
+      clock.restore()
+    })
 
-  it('should add 11 working days if after 3pm', async () => {
-    clock = sinon.useFakeTimers(new Date('March 11, 2019 15:00:01').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Tuesday 26th March')
-  })
+    describe('getRoNewCaseDueDate', () => {
+      it('should add 10 working days if before 3pm', async () => {
+        clock = sinon.useFakeTimers(new Date('March 11, 2019 14:59:59').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Monday 25th March')
+      })
 
-  it('should recognise christmas day and boxing as bank holidays', async () => {
-    clock = sinon.useFakeTimers(new Date('December 10, 2019 14:59:59').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Tuesday 24th December')
+      it('should add 11 working days if exactly 3pm', async () => {
+        clock = sinon.useFakeTimers(new Date('March 11, 2019 15:00:00').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Tuesday 26th March')
+      })
 
-    clock = sinon.useFakeTimers(new Date('December 11, 2019 14:59:59').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Friday 27th December')
-  })
+      it('should add 11 working days if after 3pm', async () => {
+        clock = sinon.useFakeTimers(new Date('March 11, 2019 15:00:01').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Tuesday 26th March')
+      })
 
-  it('should recognise good friday and easter monday as bank holidays', async () => {
-    clock = sinon.useFakeTimers(new Date('March 26, 2020 14:59:59').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Thursday 9th April')
+      it('should recognise christmas day and boxing as bank holidays', async () => {
+        clock = sinon.useFakeTimers(new Date('December 10, 2019 14:59:59').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Tuesday 24th December')
 
-    clock = sinon.useFakeTimers(new Date('March 27, 2020 14:59:59').getTime())
-    expect(getRoNewCaseDueDate()).to.eql('Tuesday 14th April')
+        clock = sinon.useFakeTimers(new Date('December 11, 2019 14:59:59').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Friday 27th December')
+      })
+
+      it('should recognise good friday and easter monday as bank holidays', async () => {
+        clock = sinon.useFakeTimers(new Date('March 26, 2020 14:59:59').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Thursday 9th April')
+
+        clock = sinon.useFakeTimers(new Date('March 27, 2020 14:59:59').getTime())
+        expect(getRoNewCaseDueDate()).to.eql('Tuesday 14th April')
+      })
+    })
+
+    describe('Due date calculations', () => {
+      // For a case created april 5th post 15:00
+      // (weekend in between)
+      // or april 8th pre 15:00
+      // then the due date (10 working days, 4 weekend days, 2 holidays) = 8+16 = april 24th
+
+      describe('getRoDueCasesDates', () => {
+        // if today is 18th, then anything from 15:00 on the 5th up to 14:59 on the 8th is due in 2 days
+        describe('getRoDueCasesDates - due in 2 days', () => {
+          it('Should account for weekends and holidays', async () => {
+            clock = sinon.useFakeTimers(new Date('April 18, 2019 01:00:00').getTime())
+            const range = getRoDueCasesDates(2)
+            expect(range.from).to.eql('2019-04-05 15:00:00')
+            expect(range.upto).to.eql('2019-04-08 14:59:59')
+          })
+        })
+
+        // if today is 24th, then anything from 15:00 on the 5th up to 14:59 on the 8th is due today
+        describe('getRoDueCasesDates - due today', () => {
+          it('Should account for weekends and holidays', async () => {
+            clock = sinon.useFakeTimers(new Date('April 24, 2019 01:00:00').getTime())
+            const range = getRoDueCasesDates(0)
+            expect(range.from).to.eql('2019-04-05 15:00:00')
+            expect(range.upto).to.eql('2019-04-08 14:59:59')
+          })
+        })
+      })
+
+      describe('getRoOverdueCasesDate', () => {
+        // if today is 25th, then anything before 15:00 on 8th is now overdue
+        describe('getRoOverdueCasesDate', () => {
+          it('Should account for weekends and holidays', async () => {
+            clock = sinon.useFakeTimers(new Date('April 25, 2019 01:00:00').getTime())
+            expect(getRoOverdueCasesDate()).to.eql('2019-04-08 14:59:59')
+          })
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Sorry there's quite a bit of code in this. Two main bits - find all the cases where the dates mean they are due or due soon or overdue. There's some working day calculations required to enable this. Then send reminder notifications for each of those cases. It will be triggered by an overnight batch job in the early hours, which I've split into a subsequent PR.

I've purposely made the sending part sequential because with similar batch jobs in the batchloader app we found that it quickly caused timeouts from the nomis API. The volumes here are hard to predict but although it's quite likely there could be enough to cause timeouts if we bombard the nomis api, there won't be so many that it would take too long for an over night batch job.