### PR TITLE
Send approval status and refusal reason codes to nomis

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -354,16 +354,13 @@ module.exports = function createApp({
   app.use('/hdc/sent/', secureRoute(sentRouter({ licenceService, prisonerService })))
   app.use('/user/', secureRoute(userRouter({ userService })))
 
-  app.use('/hdc/proposedAddress/', secureRoute(addressRouter({ licenceService })))
-  app.use(
-    '/hdc/approval/',
-    secureRoute(approvalRouter({ licenceService, prisonerService, nomisPushService, signInService }))
-  )
+  app.use('/hdc/proposedAddress/', secureRoute(addressRouter({ licenceService, nomisPushService })))
+  app.use('/hdc/approval/', secureRoute(approvalRouter({ licenceService, prisonerService, nomisPushService })))
   app.use('/hdc/bassReferral/', secureRoute(bassReferralRouter({ licenceService })))
   app.use('/hdc/licenceConditions/', secureRoute(conditionsRouter({ licenceService, conditionsService })))
   app.use('/hdc/curfew/', secureRoute(curfewRouter({ licenceService })))
-  app.use('/hdc/eligibility/', secureRoute(eligibilityRouter({ licenceService })))
-  app.use('/hdc/finalChecks/', secureRoute(finalChecksRouter({ licenceService, signInService, nomisPushService })))
+  app.use('/hdc/eligibility/', secureRoute(eligibilityRouter({ licenceService, nomisPushService })))
+  app.use('/hdc/finalChecks/', secureRoute(finalChecksRouter({ licenceService, nomisPushService })))
   app.use('/hdc/review/', secureRoute(reviewRouter({ licenceService, conditionsService, prisonerService })))
   app.use('/hdc/reporting/', secureRoute(reportingRouter({ licenceService })))
   app.use('/hdc/risk/', secureRoute(riskRouter({ licenceService })))

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -129,9 +129,9 @@ module.exports = token => {
       return nomisPut({ path, body })
     },
 
-    async putApprovalStatus(bookingId, approvalStatus) {
+    async putApprovalStatus(bookingId, { approvalStatus, refusedReason }) {
       const path = `${apiUrl}/offender-sentences/booking/${bookingId}/home-detention-curfews/latest/approval-status`
-      const body = { approvalStatus, date: moment().format('YYYY-MM-DD') }
+      const body = { approvalStatus, refusedReason, date: moment().format('YYYY-MM-DD') }
 
       return nomisPut({ path, body })
     },

--- a/server/routes/approval.js
+++ b/server/routes/approval.js
@@ -1,14 +1,23 @@
-const { asyncMiddleware } = require('../utils/middleware')
-const { getIn, firstItem, isEmpty, pickBy, getFieldName } = require('../utils/functionalHelpers')
-const logger = require('../../log')
 const formConfig = require('./config/approval')
-const { getPathFor } = require('../utils/routes')
+const { asyncMiddleware } = require('../utils/middleware')
+const createStandardRoutes = require('./routeWorkers/standard')
+const { getIn, firstItem } = require('../utils/functionalHelpers')
+const logger = require('../../log')
 
 module.exports = ({ licenceService, prisonerService, nomisPushService, signInService }) => (
   router,
   audited,
-  { pushToNomis }
+  config
 ) => {
+  const standard = createStandardRoutes({
+    formConfig,
+    licenceService,
+    sectionName: 'approval',
+    nomisPushService,
+    signInService,
+    config,
+  })
+
   router.get('/release/:bookingId', asyncMiddleware(approvalGets('release')))
   router.get('/refuseReason/:bookingId', asyncMiddleware(approvalGets('refuseReason')))
 
@@ -34,52 +43,7 @@ module.exports = ({ licenceService, prisonerService, nomisPushService, signInSer
     }
   }
 
-  router.post(
-    '/:formName/:bookingId',
-    audited,
-    asyncMiddleware(async (req, res) => {
-      const { formName, bookingId } = req.params
-
-      const expectedFields = formConfig[formName].fields.map(getFieldName)
-      const inputForExpectedFields = pickBy((val, key) => expectedFields.includes(key), req.body)
-      const errors = licenceService.validateForm({
-        formResponse: inputForExpectedFields,
-        pageConfig: formConfig[formName],
-        formType: formName,
-        bespokeConditions: {
-          confiscationOrder: res.locals.licenceStatus.decisions.confiscationOrder,
-        },
-      })
-
-      if (!isEmpty(errors)) {
-        req.flash('errors', errors)
-        req.flash('userInput', inputForExpectedFields)
-        return res.redirect(`/hdc/approval/${formName}/${bookingId}`)
-      }
-
-      const updatedLicence = await licenceService.update({
-        bookingId,
-        originalLicence: res.locals.licence,
-        config: formConfig[formName],
-        userInput: req.body,
-        licenceSection: 'approval',
-        formName: 'release',
-        postRelease: res.locals.postRelease,
-      })
-
-      if (pushToNomis) {
-        const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
-        await nomisPushService.pushStatus(
-          bookingId,
-          { approval: getIn(updatedLicence, ['approval', 'release', 'decision']) },
-          systemToken
-        )
-      }
-
-      const nextPath = getPathFor({ data: req.body, config: formConfig[formName] })
-      res.redirect(`${nextPath}${bookingId}`)
-    })
-  )
+  router.post('/:formName/:bookingId', audited, asyncMiddleware(standard.post))
 
   return router
 }

--- a/server/routes/config/approval.js
+++ b/server/routes/config/approval.js
@@ -32,6 +32,10 @@ module.exports = {
         },
       },
     ],
+    nomisPush: {
+      status: ['approval', 'release', 'decision'],
+      reason: ['approval', 'release', 'reason'],
+    },
     nextPath: {
       path: '/hdc/send/decided/',
     },

--- a/server/routes/config/eligibility.js
+++ b/server/routes/config/eligibility.js
@@ -18,6 +18,10 @@ module.exports = {
       },
     ],
     validate: true,
+    nomisPush: {
+      status: ['eligibility', 'excluded', 'decision'],
+      reason: ['eligibility', 'excluded', 'reason'],
+    },
     nextPath: {
       decisions: [
         {
@@ -74,6 +78,10 @@ module.exports = {
       },
     ],
     validate: true,
+    nomisPush: {
+      status: ['eligibility', 'exceptionalCircumstances', 'decision'],
+      reason: ['eligibility', 'suitability', 'reason'],
+    },
     nextPath: {
       decisions: [
         {

--- a/server/routes/config/finalChecks.js
+++ b/server/routes/config/finalChecks.js
@@ -79,6 +79,10 @@ module.exports = {
         },
       },
     ],
+    nomisPush: {
+      status: ['finalChecks', 'postpone', 'decision'],
+      reason: ['finalChecks', 'postpone', 'postponeReason'],
+    },
     nextPath: {
       path: '/hdc/taskList/',
     },
@@ -99,6 +103,10 @@ module.exports = {
     pageDataMap: ['licence', 'finalChecks', 'refusal'],
     saveSection: ['finalChecks', 'refusal'],
     fields: [{ decision: {} }, { reason: {} }, { outOfTimeReasons: {} }],
+    nomisPush: {
+      status: ['finalChecks', 'refusal', 'decision'],
+      reason: ['finalChecks', 'refusal', 'reason'],
+    },
     nextPath: {
       path: '/hdc/taskList/',
     },

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -2,8 +2,15 @@ const formConfig = require('./config/eligibility')
 const { asyncMiddleware } = require('../utils/middleware')
 const createStandardRoutes = require('./routeWorkers/standard')
 
-module.exports = ({ licenceService }) => (router, audited) => {
-  const standard = createStandardRoutes({ formConfig, licenceService, sectionName: 'eligibility' })
+module.exports = ({ licenceService, signInService, nomisPushService }) => (router, audited, config) => {
+  const standard = createStandardRoutes({
+    formConfig,
+    licenceService,
+    sectionName: 'eligibility',
+    signInService,
+    nomisPushService,
+    config,
+  })
 
   router.get('/:formName/:bookingId', asyncMiddleware(standard.get))
   router.post('/:formName/:bookingId', audited, asyncMiddleware(standard.post))

--- a/server/routes/finalChecks.js
+++ b/server/routes/finalChecks.js
@@ -1,58 +1,16 @@
+const formConfig = require('./config/finalChecks')
 const { asyncMiddleware } = require('../utils/middleware')
 const createStandardRoutes = require('./routeWorkers/standard')
-const { getIn, isEmpty, pickBy, getFieldName } = require('../utils/functionalHelpers')
-const { getPathFor } = require('../utils/routes')
-const formConfig = require('./config/finalChecks')
 
-module.exports = ({ licenceService, signInService, nomisPushService }) => (router, audited, { pushToNomis }) => {
-  const standard = createStandardRoutes({ formConfig, licenceService, sectionName: 'finalChecks' })
-
-  router.post(
-    '/postpone/:bookingId',
-    audited,
-    asyncMiddleware(async (req, res) => {
-      const { bookingId } = req.params
-
-      const expectedFields = formConfig.postpone.fields.map(getFieldName)
-      const inputForExpectedFields = pickBy((val, key) => expectedFields.includes(key), req.body)
-      const errors = licenceService.validateForm({
-        formResponse: inputForExpectedFields,
-        pageConfig: formConfig.postpone,
-        formType: 'postpone',
-      })
-
-      if (!isEmpty(errors)) {
-        req.flash('errors', errors)
-        req.flash('userInput', inputForExpectedFields)
-        return res.redirect(`/hdc/finalChecks/postpone/${bookingId}`)
-      }
-
-      const updatedLicence = await licenceService.update({
-        bookingId,
-        originalLicence: res.locals.licence,
-        config: formConfig.postpone,
-        userInput: req.body,
-        licenceSection: 'finalChecks',
-        formName: 'postpone',
-        postRelease: res.locals.postRelease,
-      })
-
-      if (pushToNomis) {
-        const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
-        await nomisPushService.pushStatus(
-          bookingId,
-          {
-            postpone: getIn(updatedLicence, ['finalChecks', 'postpone', 'decision']),
-            postponeReason: getIn(updatedLicence, ['finalChecks', 'postpone', 'postponeReason']),
-          },
-          systemToken
-        )
-      }
-
-      const nextPath = getPathFor({ data: req.body, config: formConfig.postpone })
-      res.redirect(`${nextPath}${bookingId}`)
-    })
-  )
+module.exports = ({ licenceService, signInService, nomisPushService }) => (router, audited, config) => {
+  const standard = createStandardRoutes({
+    formConfig,
+    licenceService,
+    sectionName: 'finalChecks',
+    signInService,
+    nomisPushService,
+    config,
+  })
 
   router.get('/:formName/:bookingId', asyncMiddleware(standard.get))
   router.post('/:formName/:bookingId', audited, asyncMiddleware(standard.post))

--- a/server/services/config/approvalStatuses.js
+++ b/server/services/config/approvalStatuses.js
@@ -1,0 +1,53 @@
+module.exports = {
+  statusValues: {
+    release: {
+      Yes: { approvalStatus: 'APPROVED' },
+    },
+    optOut: {
+      Yes: { approvalStatus: 'OPT_OUT', refusedReason: 'INM_REQUEST' },
+    },
+  },
+
+  statusReasonValues: {
+    release: {
+      No: {
+        addressUnsuitable: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        noAvailableAddress: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        insufficientTime: { approvalStatus: 'REJECTED', refusedReason: 'LIMITS' },
+        outOfTime: { approvalStatus: 'REJECTED', refusedReason: 'UNDER_14DAYS' },
+      },
+    },
+    postpone: {
+      Yes: {
+        investigation: { approvalStatus: 'PP INVEST', refusedReason: 'OUTSTANDING' },
+        outstandingRisk: { approvalStatus: 'PP OUT RISK', refusedReason: 'OUTSTANDING' },
+      },
+    },
+    refusal: {
+      Yes: {
+        addressUnsuitable: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+      },
+    },
+    excluded: {
+      Yes: {
+        sexOffenderRegister: { approvalStatus: 'INELIGIBLE', refusedReason: 'SEX_OFFENCE' },
+        convictedSexOffences: { approvalStatus: 'INELIGIBLE', refusedReason: 'EXT_SENT' },
+        rotlFail: { approvalStatus: 'INELIGIBLE', refusedReason: 'FAIL_RTN' },
+        communityCurfew: { approvalStatus: 'INELIGIBLE', refusedReason: 'CURFEW' },
+        returnedAtRisk: { approvalStatus: 'INELIGIBLE', refusedReason: 'S116' },
+        hdcCurfewConditions: { approvalStatus: 'INELIGIBLE', refusedReason: 'HDC_RECALL' },
+        servingRecall: { approvalStatus: 'INELIGIBLE' },
+        deportation: { approvalStatus: 'INELIGIBLE', refusedReason: 'FNP' },
+      },
+    },
+    exceptionalCircumstances: {
+      No: {
+        sexOffender: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'UNSUIT_SEX' },
+        deportationLiable: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'DEPORT' },
+        immigrationStatusUnclear: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'DEPORT' },
+        recalled: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'CUR' },
+        sentenceCategory: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'UNSUIT_OFF' },
+      },
+    },
+  },
+}

--- a/server/services/config/approvalStatuses.js
+++ b/server/services/config/approvalStatuses.js
@@ -26,6 +26,7 @@ module.exports = {
     refusal: {
       Yes: {
         addressUnsuitable: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        insufficientTime: { approvalStatus: 'REJECTED', refusedReason: 'LIMITS' },
       },
     },
     excluded: {

--- a/server/services/nomisPushService.js
+++ b/server/services/nomisPushService.js
@@ -1,23 +1,21 @@
 const logger = require('../../log.js')
-const { keys, intersection } = require('../utils/functionalHelpers')
+const { getIn } = require('../utils/functionalHelpers')
+const { statusValues, statusReasonValues } = require('./config/approvalStatuses')
 
-module.exports = nomisClientBuilder => {
-  async function pushStatus(bookingId, dataObject, systemToken) {
-    const nomisClient = nomisClientBuilder(systemToken)
+module.exports = (nomisClientBuilder, signInService) => {
+  async function pushStatus(bookingId, dataObject, userName) {
+    const approvalStatus = getApprovalStatus(dataObject)
 
-    const statusMethods = {
-      approval: getApprovalStatus,
-      postpone: getPostponeStatus,
-    }
-    const methodKey = intersection(keys(dataObject), keys(statusMethods))[0]
-    const status = statusMethods[methodKey](dataObject)
-
-    if (!status) {
+    if (!approvalStatus) {
       logger.info('No approval status to push to nomis')
       return null
     }
 
-    return nomisClient.putApprovalStatus(bookingId, status, systemToken)
+    const systemToken = await signInService.getClientCredentialsTokens(userName)
+    const nomisClient = nomisClientBuilder(systemToken)
+
+    logger.info('Pushing approval status to nomis', approvalStatus)
+    return nomisClient.putApprovalStatus(bookingId, approvalStatus)
   }
 
   return {
@@ -25,21 +23,10 @@ module.exports = nomisClientBuilder => {
   }
 }
 
-function getApprovalStatus({ approval }) {
-  const statusValues = {
-    Yes: 'APPROVED',
-    No: 'REJECTED',
-  }
-  return statusValues[approval]
+function getApprovalStatus({ type, status, reason }) {
+  return reason ? getIn(statusReasonValues, [type, status, pick(reason)]) : getIn(statusValues, [type, status])
 }
 
-function getPostponeStatus({ postpone, postponeReason }) {
-  if (postpone === 'Yes') {
-    const statusValues = {
-      investigation: 'PP INVEST',
-      outstandingRisk: 'PP OUT RISK',
-    }
-    return statusValues[postponeReason]
-  }
-  return null
+function pick(reason) {
+  return [].concat(reason)[0]
 }

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -468,20 +468,40 @@ describe('nomisClient', () => {
     })
 
     it('should inject bookingId into api endpoint', () => {
-      fakeNomis.put('/offender-sentences/booking/aaa/home-detention-curfews/latest/approval-status').reply(200, {})
+      fakeNomis
+        .put('/offender-sentences/booking/aaa/home-detention-curfews/latest/approval-status')
+        .reply(200, { result: 'answer' })
 
-      return expect(nomisClient.putApprovalStatus('aaa', 'Approved')).to.eventually.eql({})
+      return expect(
+        nomisClient.putApprovalStatus('aaa', { approvalStatus: 'status', refusedReason: 'reason' })
+      ).to.eventually.eql({ result: 'answer' })
     })
 
-    it('should pass in the status and date', () => {
+    it('should pass in the status and date but no reason if not specified', () => {
       fakeNomis
         .put('/offender-sentences/booking/aaa/home-detention-curfews/latest/approval-status', {
-          approvalStatus: 'Approved',
+          approvalStatus: 'status',
           date: '2018-05-31',
         })
-        .reply(200, {})
+        .reply(200, { result: 'answer' })
 
-      return expect(nomisClient.putApprovalStatus('aaa', 'Approved')).to.eventually.eql({})
+      return expect(nomisClient.putApprovalStatus('aaa', { approvalStatus: 'status' })).to.eventually.eql({
+        result: 'answer',
+      })
+    })
+
+    it('should pass in the status, reason, and date', () => {
+      fakeNomis
+        .put('/offender-sentences/booking/aaa/home-detention-curfews/latest/approval-status', {
+          approvalStatus: 'status',
+          refusedReason: 'reason',
+          date: '2018-05-31',
+        })
+        .reply(200, { result: 'answer' })
+
+      return expect(
+        nomisClient.putApprovalStatus('aaa', { approvalStatus: 'status', refusedReason: 'reason' })
+      ).to.eventually.eql({ result: 'answer' })
     })
   })
 })

--- a/test/routes/approvalTest.js
+++ b/test/routes/approvalTest.js
@@ -141,9 +141,8 @@ describe('/hdc/approval', () => {
     })
 
     it('should push the decision to nomis if config variable is true', () => {
-      signInServiceStub.getClientCredentialsTokens.resolves('new token')
-      licenceServiceStub.update.resolves({ approval: { release: { decision: 'UPDATED' } } })
-      app = createApp({ licenceServiceStub, nomisPushServiceStub, signInServiceStub }, 'dmUser', {
+      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
+      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
         pushToNomis: true,
       })
       return request(app)
@@ -151,16 +150,18 @@ describe('/hdc/approval', () => {
         .send({ decision: 'Yes' })
         .expect(302)
         .expect(() => {
-          expect(signInServiceStub.getClientCredentialsTokens).to.be.calledOnce()
           expect(nomisPushServiceStub.pushStatus).to.be.calledOnce()
-          expect(nomisPushServiceStub.pushStatus).to.be.calledWith('1', { approval: 'UPDATED' }, 'new token')
+          expect(nomisPushServiceStub.pushStatus).to.be.calledWith(
+            '1',
+            { type: 'release', status: 'ABC', reason: undefined },
+            'DM_USER'
+          )
         })
     })
 
     it('should not push the decision to nomis if config variable is false', () => {
-      signInServiceStub.getClientCredentialsTokens.resolves('new token')
-      licenceServiceStub.update.resolves({ approval: { release: { decision: 'UPDATED' } } })
-      app = createApp({ licenceServiceStub, nomisPushServiceStub, signInServiceStub }, 'dmUser', {
+      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
+      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
         pushToNomis: false,
       })
       return request(app)
@@ -168,7 +169,6 @@ describe('/hdc/approval', () => {
         .send({ decision: 'Yes' })
         .expect(302)
         .expect(() => {
-          expect(signInServiceStub.getClientCredentialsTokens).to.not.be.called()
           expect(nomisPushServiceStub.pushStatus).to.not.be.called()
         })
     })
@@ -181,9 +181,6 @@ describe('/hdc/approval', () => {
         .send({})
         .expect(302)
         .expect('Location', '/hdc/approval/release/1')
-        .expect(() => {
-          expect(licenceServiceStub.update).to.not.be.called()
-        })
     })
 
     it('should throw if submitted by non-DM user', () => {

--- a/test/routes/routeWorkers/standardTest.js
+++ b/test/routes/routeWorkers/standardTest.js
@@ -1,0 +1,164 @@
+const standard = require('../../../server/routes/routeWorkers/standard')
+const { createLicenceServiceStub, createNomisPushServiceStub } = require('../../supertestSetup')
+
+describe('formPost', () => {
+  describe('push to nomis', () => {
+    const testLicence = {
+      sectionName: { testForm: {} },
+      statusProperty: 'testStatus',
+      reasonProperty: 'testReason',
+      nestedStatusProperty: { subStatus: 'subStatus' },
+      nestedReasonProperty: { subReason: { subSubReason: 'subSubReason' } },
+    }
+
+    const req = {
+      body: {},
+      user: {
+        username: 'testUser',
+      },
+      flash: () => {},
+    }
+
+    const res = {
+      locals: {
+        licence: testLicence,
+        licenceStatus: { decisions: {} },
+      },
+      redirect: () => {},
+    }
+
+    let licenceService
+    let nomisPushService
+
+    beforeEach(() => {
+      licenceService = createLicenceServiceStub()
+      nomisPushService = createNomisPushServiceStub()
+      licenceService.update.resolves(testLicence)
+    })
+
+    function createRoute({ nomisPush, config = { pushToNomis: true }, validate = false }) {
+      const formConfig = {
+        testForm: {
+          nextPath: {},
+          validate,
+          nomisPush,
+        },
+      }
+
+      return standard({
+        formConfig,
+        licenceService,
+        sectionName: 'sectionName',
+        nomisPushService,
+        config,
+      })
+    }
+
+    it('should not send to nomisPushService if main config off', async () => {
+      const nomisPush = {
+        status: ['statusProperty'],
+        reason: ['reasonProperty'],
+      }
+
+      const standardRoute = createRoute({ nomisPush, config: { pushToNomis: false } })
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).not.to.be.calledOnce()
+    })
+
+    it('should not send to nomisPushService when validation errors', async () => {
+      const nomisPush = {
+        status: ['statusProperty'],
+        reason: ['reasonProperty'],
+      }
+
+      licenceService.validateForm.returns(['some errors'])
+      const standardRoute = createRoute({ nomisPush, validate: true })
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).not.to.be.calledOnce()
+    })
+
+    it('should not send to nomisPushService if no form config', async () => {
+      const standardRoute = createRoute({})
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).not.to.be.calledOnce()
+    })
+
+    it('should send the specified licence fields to nomisPushService', async () => {
+      const nomisPush = {
+        status: ['statusProperty'],
+        reason: ['reasonProperty'],
+      }
+
+      const standardRoute = createRoute({ nomisPush })
+
+      const expectedData = {
+        type: 'testForm',
+        status: 'testStatus',
+        reason: 'testReason',
+      }
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).to.be.calledOnce()
+      expect(nomisPushService.pushStatus).to.be.calledWith('123', expectedData, 'testUser')
+    })
+
+    it('should send the specified licence fields to nomisPushService when fields are nested', async () => {
+      const nomisPush = {
+        status: ['nestedStatusProperty', 'subStatus'],
+        reason: ['nestedReasonProperty', 'subReason', 'subSubReason'],
+      }
+
+      const standardRoute = createRoute({ nomisPush })
+
+      const expectedData = {
+        type: 'testForm',
+        status: 'subStatus',
+        reason: 'subSubReason',
+      }
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).to.be.calledOnce()
+      expect(nomisPushService.pushStatus).to.be.calledWith('123', expectedData, 'testUser')
+    })
+
+    it('should send to nomisPushService even if fields are not found', async () => {
+      const nomisPush = {
+        status: ['noSuchProperty'],
+        reason: [''],
+      }
+
+      const standardRoute = createRoute({ nomisPush })
+
+      const expectedData = {
+        type: 'testForm',
+        status: undefined,
+        reason: undefined,
+      }
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).to.be.calledOnce()
+      expect(nomisPushService.pushStatus).to.be.calledWith('123', expectedData, 'testUser')
+    })
+
+    it('should not try to access licence data if not specified', async () => {
+      const nomisPush = {
+        reason: ['reasonProperty'],
+      }
+
+      const standardRoute = createRoute({ nomisPush })
+
+      const expectedData = {
+        type: 'testForm',
+        status: undefined,
+        reason: 'testReason',
+      }
+
+      await standardRoute.formPost(req, res, 'testForm', '123', '')
+      expect(nomisPushService.pushStatus).to.be.calledOnce()
+      expect(nomisPushService.pushStatus).to.be.calledWith('123', expectedData, 'testUser')
+    })
+  })
+})

--- a/test/services/nomisPushServiceTest.js
+++ b/test/services/nomisPushServiceTest.js
@@ -124,6 +124,16 @@ describe('nomisPushService', () => {
           data: { type: 'postpone', status: 'Yes', reason: 'outstandingRisk' },
           approvalStatus: { approvalStatus: 'PP OUT RISK', refusedReason: 'OUTSTANDING' },
         },
+        {
+          example: 'Refused - addressUnsuitable',
+          data: { type: 'refusal', status: 'Yes', reason: 'addressUnsuitable' },
+          approvalStatus: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        },
+        {
+          example: 'Refused - addressUnsuitable',
+          data: { type: 'refusal', status: 'Yes', reason: 'insufficientTime' },
+          approvalStatus: { approvalStatus: 'REJECTED', refusedReason: 'LIMITS' },
+        },
       ]
 
       specs.forEach(spec => {

--- a/test/services/nomisPushServiceTest.js
+++ b/test/services/nomisPushServiceTest.js
@@ -3,53 +3,201 @@ const createNomisPushService = require('../../server/services/nomisPushService')
 describe('nomisPushService', () => {
   let service
   let nomisClientMock
+  let signInService
 
   beforeEach(() => {
     nomisClientMock = {
       putApprovalStatus: sinon.stub().resolves(),
     }
     const nomisClientBuilder = sinon.stub().returns(nomisClientMock)
-    service = createNomisPushService(nomisClientBuilder)
+    signInService = {
+      getClientCredentialsTokens: sinon.stub().returns('token'),
+    }
+    service = createNomisPushService(nomisClientBuilder, signInService)
   })
 
   describe('pushStatus', () => {
-    it('should call nomisClient.putApprovalStatus with bookingId, status and systemToken', async () => {
-      await service.pushStatus('1', { approval: 'Yes' }, 'token')
+    describe('required pushes', () => {
+      const specs = [
+        {
+          example: 'Release approved',
+          data: { type: 'release', status: 'Yes' },
+          approvalStatus: { approvalStatus: 'APPROVED' },
+        },
+        {
+          example: 'Release refused - addressUnsuitable',
+          data: { type: 'release', status: 'No', reason: 'addressUnsuitable' },
+          approvalStatus: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        },
+        {
+          example: 'Release refused - insufficientTime',
+          data: { type: 'release', status: 'No', reason: 'insufficientTime' },
+          approvalStatus: { approvalStatus: 'REJECTED', refusedReason: 'LIMITS' },
+        },
+        {
+          example: 'Release refused - outOfTime',
+          data: { type: 'release', status: 'No', reason: 'outOfTime' },
+          approvalStatus: { approvalStatus: 'REJECTED', refusedReason: 'UNDER_14DAYS' },
+        },
+        {
+          example: 'Release refused - noAvailableAddress',
+          data: { type: 'release', status: 'No', reason: 'noAvailableAddress' },
+          approvalStatus: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        },
+        {
+          example: 'Opted out',
+          data: { type: 'optOut', status: 'Yes' },
+          approvalStatus: { approvalStatus: 'OPT_OUT', refusedReason: 'INM_REQUEST' },
+        },
+        {
+          example: 'Excluded - sexOffenderRegister',
+          data: { type: 'excluded', status: 'Yes', reason: 'sexOffenderRegister' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'SEX_OFFENCE' },
+        },
+        {
+          example: 'Excluded - convictedSexOffences',
+          data: { type: 'excluded', status: 'Yes', reason: 'convictedSexOffences' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'EXT_SENT' },
+        },
+        {
+          example: 'Excluded - rotlFail',
+          data: { type: 'excluded', status: 'Yes', reason: 'rotlFail' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'FAIL_RTN' },
+        },
+        {
+          example: 'Excluded - communityCurfew',
+          data: { type: 'excluded', status: 'Yes', reason: 'communityCurfew' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'CURFEW' },
+        },
+        {
+          example: 'Excluded - returnedAtRisk',
+          data: { type: 'excluded', status: 'Yes', reason: 'returnedAtRisk' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'S116' },
+        },
+        {
+          example: 'Excluded - hdcCurfewConditions',
+          data: { type: 'excluded', status: 'Yes', reason: 'hdcCurfewConditions' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'HDC_RECALL' },
+        },
+        {
+          example: 'Excluded - servingRecall',
+          data: { type: 'excluded', status: 'Yes', reason: 'servingRecall' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE' },
+        },
+        {
+          example: 'Excluded - deportation',
+          data: { type: 'excluded', status: 'Yes', reason: 'deportation' },
+          approvalStatus: { approvalStatus: 'INELIGIBLE', refusedReason: 'FNP' },
+        },
+        {
+          example: 'Unsuitable - sexOffender',
+          data: { type: 'exceptionalCircumstances', status: 'No', reason: 'sexOffender' },
+          approvalStatus: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'UNSUIT_SEX' },
+        },
+        {
+          example: 'Unsuitable - deportationLiable',
+          data: { type: 'exceptionalCircumstances', status: 'No', reason: 'deportationLiable' },
+          approvalStatus: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'DEPORT' },
+        },
+        {
+          example: 'Unsuitable - immigrationStatusUnclear',
+          data: { type: 'exceptionalCircumstances', status: 'No', reason: 'immigrationStatusUnclear' },
+          approvalStatus: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'DEPORT' },
+        },
+        {
+          example: 'Unsuitable - recalled',
+          data: { type: 'exceptionalCircumstances', status: 'No', reason: 'recalled' },
+          approvalStatus: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'CUR' },
+        },
+        {
+          example: 'Unsuitable - sentenceCategory',
+          data: { type: 'exceptionalCircumstances', status: 'No', reason: 'sentenceCategory' },
+          approvalStatus: { approvalStatus: 'PRES_UNSUIT', refusedReason: 'UNSUIT_OFF' },
+        },
+        {
+          example: 'Postponed - investigation',
+          data: { type: 'postpone', status: 'Yes', reason: 'investigation' },
+          approvalStatus: { approvalStatus: 'PP INVEST', refusedReason: 'OUTSTANDING' },
+        },
+        {
+          example: 'Postponed - outstandingRisk',
+          data: { type: 'postpone', status: 'Yes', reason: 'outstandingRisk' },
+          approvalStatus: { approvalStatus: 'PP OUT RISK', refusedReason: 'OUTSTANDING' },
+        },
+      ]
+
+      specs.forEach(spec => {
+        it(`should call nomisClient.putApprovalStatus for ${spec.example} with the correct values`, async () => {
+          await service.pushStatus('1', spec.data, 'user')
+          expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
+          expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
+          expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', spec.approvalStatus)
+        })
+      })
+    })
+
+    it('should not call nomisClient.putApprovalStatus if no type', async () => {
+      await service.pushStatus('1', { type: undefined, status: 'Yes', reason: 'something' }, 'user')
+      expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
+      expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
+    })
+
+    it('should not call nomisClient.putApprovalStatus if no status', async () => {
+      await service.pushStatus('1', { type: 'release', status: undefined, reason: 'something' }, 'user')
+      expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
+      expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
+    })
+
+    it('should not call nomisClient.putApprovalStatus if no matching update', async () => {
+      await service.pushStatus('1', { type: 'release', status: 'No', reason: 'unmatched-reason' }, 'user')
+      expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
+      expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
+    })
+
+    it('should not call nomisClient.putApprovalStatus if no matching update when array of reasons', async () => {
+      await service.pushStatus('1', { type: 'release', status: 'No', reason: ['unmatched-reason'] }, 'user')
+      expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
+      expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
+    })
+
+    it('should not call nomisClient.putApprovalStatus if no matching update when empty array of reasons', async () => {
+      await service.pushStatus('1', { type: 'release', status: 'No', reason: [] }, 'user')
+      expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
+      expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
+    })
+
+    it('should also accept reason in an array', async () => {
+      await service.pushStatus('1', { type: 'release', status: 'No', reason: ['insufficientTime'] }, 'user')
+      expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
-      expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', 'APPROVED', 'token')
+      expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', {
+        approvalStatus: 'REJECTED',
+        refusedReason: 'LIMITS',
+      })
     })
 
-    it('should call nomisClient.putApprovalStatus with Rejected if approvalDecision is No', async () => {
-      await service.pushStatus('1', { approval: 'No' }, 'token')
+    it('should use the first reason when there are many', async () => {
+      await service.pushStatus(
+        '1',
+        { type: 'release', status: 'No', reason: ['insufficientTime', 'addressUnsuitable', 'unmatched-reason'] },
+        'user'
+      )
+      expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
-      expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', 'REJECTED', 'token')
+      expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', {
+        approvalStatus: 'REJECTED',
+        refusedReason: 'LIMITS',
+      })
     })
 
-    it('should not nomisClient.putApprovalStatus if no decision', async () => {
-      await service.pushStatus('1', { approval: undefined }, 'token')
-      expect(nomisClientMock.putApprovalStatus).to.not.be.called()
-    })
-
-    it('should call nomisClient.putApprovalStatus if postpone investigation', async () => {
-      await service.pushStatus('1', { postpone: 'Yes', postponeReason: 'investigation' }, 'token')
-      expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
-      expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', 'PP INVEST', 'token')
-    })
-
-    it('should call nomisClient.putApprovalStatus if postpone outstanding risk', async () => {
-      await service.pushStatus('1', { postpone: 'Yes', postponeReason: 'outstandingRisk' }, 'token')
-      expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
-      expect(nomisClientMock.putApprovalStatus).to.be.calledWith('1', 'PP OUT RISK', 'token')
-    })
-
-    it('should not call nomisClient.putApprovalStatus if postpone No', async () => {
-      await service.pushStatus('1', { postpone: 'No', postponeReason: 'outstandingRisk' }, 'token')
-      expect(nomisClientMock.putApprovalStatus).to.not.be.calledOnce()
-    })
-
-    it('should not call nomisClient.putApprovalStatus if no recognised reason', async () => {
-      await service.pushStatus('1', { postpone: 'Yes', postponeReason: '' }, 'token')
-      expect(nomisClientMock.putApprovalStatus).to.not.be.calledOnce()
+    it('should not call nomisClient.putApprovalStatus if no matching update when first reason unmatched', async () => {
+      await service.pushStatus(
+        '1',
+        { type: 'release', status: 'No', reason: ['unmatched-reason', 'insufficientTime', 'addressUnsuitable'] },
+        'user'
+      )
+      expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
+      expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
   })
 })


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/wiki/spaces/LIC/pages/1428783438/NOMIS+Push for details


- added nomisPushService to routes that need to push to nomis
- added refusedReason to the data pushed to nomis
- when matt first added nomis pushing he copied standard route processing into approval and finalChecks routes and added nomis push, but I've reverted it back out into standard and added the nomis push into the standard router
- added formconfig used by standard router to control when to push to nomis and which licence data fields to push to nomis
- exception is optout which is handled in a non-standard way and so is done manually in the address route
- simplified nomisPushService to do a generalized lookup of approvalStatus based on type, status, and (optional) reason
- tests