### PR TITLE
Required RO user management

### DIFF
--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -78,12 +78,17 @@ module.exports = token => {
       return prisoners.map(addReleaseDatesToPrisoner)
     },
 
-    async getOffenderSentencesByBookingId(bookingIds) {
+    async getOffenderSentencesByBookingId(bookingIds, addReleaseDates = true) {
       const path = `${apiUrl}/offender-sentences/bookings`
       const headers = { 'Page-Limit': 10000 }
       const body = [].concat(bookingIds)
 
       const prisoners = await nomisPost({ path, body, headers })
+
+      if (!addReleaseDates) {
+        return prisoners
+      }
+
       return prisoners.map(addReleaseDatesToPrisoner)
     },
 

--- a/server/data/userClient.js
+++ b/server/data/userClient.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const db = require('./dataAccess/db')
 
 module.exports = {
@@ -24,6 +25,40 @@ module.exports = {
     const { rows } = await db.query(query)
 
     return rows.map(convertPropertyNames)
+  },
+
+  async getIncompleteRoUsers() {
+    const query = {
+      text: `select
+               timestamp as sent_timestamp,
+               details -> 'bookingId' as booking_id,
+               details -> 'submissionTarget' -> 'com' -> 'deliusId' as sent_staffcode,
+               details -> 'submissionTarget' -> 'com' -> 'name' as sent_name,
+               (s.staff_id is not null) as mapped,
+               s.auth_onboarded,
+               s.first_name, s.last_name, s.nomis_id
+             from (
+                    select *,
+                           row_number() over (
+                             partition by (a.details -> 'submissionTarget' -> 'com' -> 'deliusId')
+                             order by a.timestamp ASC
+                             ) as rownbr
+                    from audit a
+                           left join staff_ids s
+                                     on s.staff_id = (a.details-> 'submissionTarget' -> 'com' ->> 'deliusId')
+                    where a.action = 'SEND'
+                      and a.details @> '{ "transitionType": "caToRo" }'
+                  ) s
+             where rownbr = 1`,
+    }
+
+    const { rows } = await db.query(query)
+
+    if (rows) {
+      return rows.map(convertIncompleteUserPropertyNames)
+    }
+
+    return []
   },
 
   async getRoUser(nomisId) {
@@ -140,6 +175,22 @@ function convertPropertyNames(user) {
         orgEmail: user.org_email,
         telephone: user.telephone,
         onboarded: user.auth_onboarded,
+      }
+    : null
+}
+
+function convertIncompleteUserPropertyNames(user) {
+  return user
+    ? {
+        first: user.first_name,
+        last: user.last_name,
+        mapped: user.mapped,
+        onboarded: user.auth_onboarded,
+        nomisId: user.nomis_id,
+        sent: moment(user.sent_timestamp).format('DD/MM/YYYY'),
+        bookingId: user.booking_id,
+        sentStaffCode: user.sent_staffcode,
+        sentName: user.sent_name,
       }
     : null
 }

--- a/server/routes/admin/users.js
+++ b/server/routes/admin/users.js
@@ -8,7 +8,7 @@ module.exports = ({ userAdminService }) => (router, audited) => {
     '/',
     asyncMiddleware(async (req, res) => {
       const roUsers = await userAdminService.getRoUsers()
-      return res.render('admin/users/list', { roUsers, heading: 'All RO users' })
+      return res.render('admin/users/list', { roUsers, heading: 'RO users' })
     })
   )
 
@@ -126,6 +126,26 @@ module.exports = ({ userAdminService }) => (router, audited) => {
       return { deliusId: 'Delius staff id is required' }
     }
   }
+
+  router.get(
+    '/incomplete',
+    asyncMiddleware(async (req, res) => {
+      const incompleteUsers = await userAdminService.getIncompleteRoUsers(res.locals.token)
+      return res.render('admin/users/incompleteList', { incompleteUsers })
+    })
+  )
+
+  router.post('/incomplete/add', async (req, res) => {
+    try {
+      const input = req.body.incompleteUser
+      const userInput = JSON.parse(input)
+      req.flash('userInput', userInput)
+
+      return res.redirect('/admin/roUsers/add')
+    } catch (error) {
+      return res.redirect('/admin/roUsers/incomplete')
+    }
+  })
 
   return router
 }

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -8,5 +8,7 @@ block content
       div
         a(href='/admin/roUsers') RO users
       div
+        a(href='/admin/roUsers/incomplete') Incomplete RO users
+      div
         a(href='/admin/mailboxes') Notification mailboxes
 

--- a/server/views/admin/users/incompleteList.pug
+++ b/server/views/admin/users/incompleteList.pug
@@ -1,0 +1,15 @@
+extends ../../layout
+
+block content
+
+  div.back-link-container.smallPaddingTop
+    a#back.link-back(href="/admin/") Back
+
+  div.pure-g
+    div.pure-u-1.searchLink.alignRight.smallPaddingTop
+      a#incompleteUserLink(href='/admin/roUsers') View complete users
+
+    div.pure-u-1
+      h2.heading-medium Incomplete RO users
+      include incompleteUsersTable
+

--- a/server/views/admin/users/incompleteUsersTable.pug
+++ b/server/views/admin/users/incompleteUsersTable.pug
@@ -1,0 +1,54 @@
+table.largeMarginBottom
+  thead
+    tr
+      th Delius staff code
+      th Name
+      th First seen
+      th Offender
+      th Mapped
+      th In SSO
+      th Mapped user nomis ID
+      th Mapped user name
+      th
+  tbody
+    if incompleteUsers && incompleteUsers.length > 0
+      each incompleteUser, index in incompleteUsers
+        if !(incompleteUser.mapped && incompleteUser.onboarded)
+          tr.hdcEligible
+            td
+              if incompleteUser.sentStaffCode
+                | #{incompleteUser.sentStaffCode}
+            td
+              if incompleteUser.sentName
+                | #{incompleteUser.sentName}
+            td
+              if incompleteUser.sent
+                | #{incompleteUser.sent}
+            td
+              if incompleteUser.offenderNomis
+                | #{incompleteUser.offenderNomis}
+            td.center
+              if incompleteUser.mapped
+                img(src="/public/images/large_tick.svg" alt="white tick" height="30px")
+            td.center
+              if incompleteUser.onboarded
+                img(src="/public/images/large_tick.svg" alt="white tick" height="30px")
+            td
+              if incompleteUser.nomisId
+                | #{incompleteUser.nomisId}
+            td
+              if incompleteUser.first
+                | #{incompleteUser.first}
+              if incompleteUser.last
+                |  #{incompleteUser.last}
+
+            td.edit
+              if incompleteUser.mapped
+                a.button.button-primary.fullWidth.center(href="/admin/roUsers/edit/" + incompleteUser.nomisId role="button")
+                  | Edit
+              else
+                form(method='POST' action='/admin/roUsers/incomplete/add')
+                  input(type="hidden" name="_csrf" value=csrfToken)
+                  input(type="hidden" name="incompleteUser" value=incompleteUser.mapping)
+                  input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Add user")
+

--- a/server/views/admin/users/list.pug
+++ b/server/views/admin/users/list.pug
@@ -6,14 +6,14 @@ block content
     a#back.link-back(href="/admin/") Back
 
   div.pure-g
-    div.pure-u-1.searchLink.alignRight.sm-padTop55.u-paddingTop
+    div.pure-u-1.searchLink.alignRight.smallPaddingTop
       a#addUserLink(href='/admin/roUsers/add') Add user
+    div.pure-u-1.searchLink.alignRight
+      a#incompleteUserLink(href='/admin/roUsers/incomplete') View incomplete users
 
     include userSearchForm
 
-    div.pure-u-1.largeMarginTop
+    div.pure-u-1
       h2.heading-medium #{heading}
-        include usersTable
+      include usersTable
 
-block append scripts
-  script(src="/public/javascripts/pagination.js?" + version)

--- a/server/views/admin/users/roUserDetails.pug
+++ b/server/views/admin/users/roUserDetails.pug
@@ -6,7 +6,7 @@ block content
   -var inputs = userInput ? userInput : roUser ? roUser : {}
 
   div.back-link-container.smallPaddingTop
-    a#back.link-back(href="/admin/") Back
+    a#back.link-back(href="javascript: window.history.back();") Back
   +errorBannerWithDetail(errors, [
     { field: 'nomisId' },
     { field: 'deliusId' }
@@ -102,7 +102,7 @@ block content
     div.paddingBottom.smallPaddingTop
       div.pure-u-1.inlineButtons
         input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Save")
-        a#backBtn.requiredButton.button.button-secondary.smallMarginTop(href="/admin/roUsers" role="button") Cancel
+        a#backBtn.requiredButton.button.button-secondary.smallMarginTop(href="javascript: window.history.back();" role="button") Cancel
 
   hr
   include verifyNomis

--- a/server/views/admin/users/usersTable.pug
+++ b/server/views/admin/users/usersTable.pug
@@ -1,10 +1,10 @@
 table#hdcEligiblePrisoners.largeMarginBottom
   thead
     tr
-      th Nomis Username
-      th Delius Staff ID
-      th First Name
-      th Last Name
+      th Nomis user
+      th Delius staff code
+      th First name
+      th Last name
       th In SSO
       th
       th

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -379,6 +379,20 @@ describe('nomisClient', () => {
       ])
     })
 
+    it('should return data from api without release dates if disabled', () => {
+      fakeNomis
+        .post(`/offender-sentences/bookings`, ['1'])
+        .reply(200, [{ sentenceDetail: { conditionalReleaseDate: 'a' } }])
+
+      return expect(nomisClient.getOffenderSentencesByBookingId(['1'], false)).to.eventually.eql([
+        {
+          sentenceDetail: {
+            conditionalReleaseDate: 'a',
+          },
+        },
+      ])
+    })
+
     it('should reject if api fails', () => {
       fakeNomis.post(`/offender-sentences`, ['1']).reply(500)
 

--- a/test/data/userClientTest.js
+++ b/test/data/userClientTest.js
@@ -39,6 +39,52 @@ describe('userClient', () => {
     })
   })
 
+  describe('getIncompleteRoUsers', () => {
+    const incompleteUsers = {
+      rows: [
+        {
+          first_name: 1,
+          last_name: 2,
+          mapped: 3,
+          auth_onboarded: 4,
+          nomis_id: 5,
+          sent_timestamp: '2019-01-01',
+          booking_id: 7,
+          sent_staffcode: 8,
+          sent_name: 9,
+        },
+      ],
+    }
+
+    beforeEach(() => {
+      queryStub = sinon.stub().resolves(incompleteUsers)
+    })
+
+    it('should call query', () => {
+      userProxy().getIncompleteRoUsers()
+      expect(queryStub).to.have.callCount(1)
+    })
+
+    it('should convert results', async () => {
+      const converted = [
+        {
+          first: 1,
+          last: 2,
+          mapped: 3,
+          onboarded: 4,
+          nomisId: 5,
+          sent: '01/01/2019',
+          bookingId: 7,
+          sentStaffCode: 8,
+          sentName: 9,
+        },
+      ]
+      const results = await userProxy().getIncompleteRoUsers()
+      expect(queryStub).to.have.callCount(1)
+      expect(results).to.eql(converted)
+    })
+  })
+
   describe('getRoUser', () => {
     it('should call query', () => {
       userProxy().getRoUser('id')

--- a/test/supertestSetup.js
+++ b/test/supertestSetup.js
@@ -70,6 +70,7 @@ const createPdfServiceStub = () => ({
 
 const createUserAdminServiceStub = () => ({
   getRoUsers: sinon.stub().resolves(),
+  getIncompleteRoUsers: sinon.stub().resolves(),
   getRoUser: sinon.stub().resolves(),
   getRoUserByDeliusId: sinon.stub().resolves({}),
   updateRoUser: sinon.stub().resolves(),


### PR DESCRIPTION
Adds a service to lookup incomplete users out of the audit data so that internal admins (Jim) can onboard new users.

Lots of this is just pug view files for the admin screens. Lots of it is tests.

Only used by internal admins, not user facing.

PS finding "incomplete" users means looking in the audit for users that have been sent cases (action: SEND, transitionType:caToRo), comparing those to the staff_ids table which holds all onboarded users, and if the user is missing, take the first time they appeared in the audit. Also have to call nomis to lookup the offender nomis ID matching that case.

After that, just show the list of incomplete users in a table.