### PR TITLE
Lic 946 nomis push on dm refusals

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/decision/ApprovalRefusePage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/decision/ApprovalRefusePage.groovy
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.licences.pages.decision
+
+import geb.Page
+import geb.module.Checkbox
+import geb.module.RadioButtons
+import uk.gov.justice.digital.hmpps.licences.modules.HeaderModule
+
+class ApprovalRefusePage extends Page {
+
+  static url = '/hdc/approval/refuseReason'
+
+  static at = {
+    browser.currentUrl.contains(url)
+  }
+
+  static content = {
+
+    header { module(HeaderModule) }
+
+    reasonsForm(required: false) { $("#releaseForm") }
+
+    reasonsItem { value ->
+      $("input", value: value, name: "reason").module(Checkbox)
+    }
+  }
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalSpec.groovy
@@ -5,6 +5,7 @@ import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Stepwise
 import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
+import uk.gov.justice.digital.hmpps.licences.pages.decision.ApprovalRefusePage
 import uk.gov.justice.digital.hmpps.licences.pages.decision.ApprovalReleasePage
 import uk.gov.justice.digital.hmpps.licences.pages.eligibility.EligibilityExclusionPage
 import uk.gov.justice.digital.hmpps.licences.pages.eligibility.EligibilitySuitabilityPage
@@ -73,5 +74,41 @@ class ApprovalSpec extends GebReportingSpec {
 
     then: 'I see the previous values'
     releaseRadios.checked == 'Yes'
+  }
+
+  def 'When sent for refusal, shows reason chosen by CA - insufficient time'() {
+
+    given: 'Sent for refusal due to insufficient time'
+    testData.loadLicence('decision/insufficientTime')
+
+    when: 'I view the refusal page'
+    to ApprovalRefusePage, testData.markAndrewsBookingId
+
+    then: 'I see the reason chosen by the CA'
+    reasonsForm.isDisplayed()
+
+    reasonsItem('insufficientTime').checked
+    
+    !reasonsItem('addressUnsuitable').checked
+    !reasonsItem('noAvailableAddress').checked
+    !reasonsItem('outOfTime').checked
+  }
+
+  def 'When sent for refusal, shows reason chosen by CA - address unsuitable'() {
+
+    given: 'Sent for refusal due to address rejected'
+    testData.loadLicence('decision/address-rejected')
+
+    when: 'I view the refusal page'
+    to ApprovalRefusePage, testData.markAndrewsBookingId
+
+    then: 'I see the reason chosen by the CA'
+    reasonsForm.isDisplayed()
+
+    reasonsItem('addressUnsuitable').checked
+
+    !reasonsItem('insufficientTime').checked
+    !reasonsItem('noAvailableAddress').checked
+    !reasonsItem('outOfTime').checked
   }
 }

--- a/server/routes/config/approval.js
+++ b/server/routes/config/approval.js
@@ -42,7 +42,21 @@ module.exports = {
   },
   refuseReason: {
     licenceSection: 'release',
-    fields: [{ decision: {} }],
+    validate: true,
+    fields: [
+      {
+        decision: {
+          responseType: 'requiredYesNo',
+          validationMessage: 'Select yes or no',
+        },
+      },
+      {
+        reason: {
+          responseType: 'selection',
+          validationMessage: 'Select a reason',
+        },
+      },
+    ],
     nextPath: {
       path: '/hdc/send/decided/',
     },

--- a/server/routes/config/approval.js
+++ b/server/routes/config/approval.js
@@ -57,6 +57,10 @@ module.exports = {
         },
       },
     ],
+    nomisPush: {
+      status: ['approval', 'release', 'decision'],
+      reason: ['approval', 'release', 'reason'],
+    },
     nextPath: {
       path: '/hdc/send/decided/',
     },

--- a/server/routes/routeWorkers/standard.js
+++ b/server/routes/routeWorkers/standard.js
@@ -48,7 +48,8 @@ module.exports = ({ formConfig, licenceService, sectionName, nomisPushService, c
     })
 
     if (formConfig[formName].validate) {
-      const errors = validationErrors(updatedLicence, formName, res)
+      const errors = validationErrors(updatedLicence[targetSection][targetForm], formName, res)
+
       if (!isEmpty(errors)) {
         req.flash('errors', errors)
         const actionPath = action ? `${action}/` : ''
@@ -81,10 +82,10 @@ module.exports = ({ formConfig, licenceService, sectionName, nomisPushService, c
     return { targetSection, targetForm }
   }
 
-  function validationErrors(updatedLicence, formName, res) {
-    const form = updatedLicence[sectionName][formName]
+  function validationErrors(form, formName, res) {
     // address is in array
     const formToValidate = form && form.addresses ? lastItem(form.addresses) : form
+
     return licenceService.validateForm({
       formResponse: formToValidate,
       pageConfig: formConfig[formName],

--- a/server/services/config/approvalStatuses.js
+++ b/server/services/config/approvalStatuses.js
@@ -17,6 +17,12 @@ module.exports = {
         outOfTime: { approvalStatus: 'REJECTED', refusedReason: 'UNDER_14DAYS' },
       },
     },
+    refuseReason: {
+      No: {
+        addressUnsuitable: { approvalStatus: 'REJECTED', refusedReason: 'ADDRESS' },
+        insufficientTime: { approvalStatus: 'REJECTED', refusedReason: 'LIMITS' },
+      },
+    },
     postpone: {
       Yes: {
         investigation: { approvalStatus: 'PP INVEST', refusedReason: 'OUTSTANDING' },

--- a/server/views/approval/includes/release.pug
+++ b/server/views/approval/includes/release.pug
@@ -1,6 +1,8 @@
 block excludedForm
 
-  - var vals = data.reason || ''
+  - var noAddress = licenceStatus.decisions.curfewAddressRejected ? 'addressUnsuitable' : ''
+  - var noTime = licenceStatus.decisions.insufficientTimeStop ? 'insufficientTime' : ''
+  - var vals = data.reason || noAddress + noTime
 
   div
     if errorObject.reason

--- a/server/views/approval/refuseReason.pug
+++ b/server/views/approval/refuseReason.pug
@@ -18,12 +18,10 @@ block content
         input#releaseYes(type="hidden"  name="decision" value="No")
 
         div.paddingBottom.largeMarginBottom
-          if licenceStatus.decisions.insufficientTimeStop
-            div HDC refused because there is not enough time. (Less than 4 weeks to conditional release date)
-          if licenceStatus.decisions.curfewAddressRejected
-            div HDC refused because there is no suitable curfew address
-          else
-            div HDC refused
+
+          div#releaseForm.panel.panel-border-narrow
+            include includes/release
+
           br
           div.paddingBottom.smallPaddingTop
             input#continueBtn.requiredButton.button(type="submit" value="Save and continue")

--- a/test/routes/approvalTest.js
+++ b/test/routes/approvalTest.js
@@ -100,7 +100,7 @@ describe('/hdc/approval', () => {
     })
   })
 
-  describe('POST /hdc/approval/{route}/:bookingId', () => {
+  describe('POST /hdc/approval/:form/:bookingId', () => {
     const routes = [
       {
         url: '/hdc/approval/release/1',
@@ -165,6 +165,39 @@ describe('/hdc/approval', () => {
           .send({ decision: 'Yes' })
           .expect(403)
       })
+    })
+
+    it('should push the decision to nomis if config variable is true', () => {
+      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
+      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
+        pushToNomis: true,
+      })
+      return request(app)
+        .post('/hdc/approval/release/1')
+        .send({ decision: 'Yes' })
+        .expect(302)
+        .expect(() => {
+          expect(nomisPushServiceStub.pushStatus).to.be.calledOnce()
+          expect(nomisPushServiceStub.pushStatus).to.be.calledWith(
+            '1',
+            { type: 'release', status: 'ABC', reason: undefined },
+            'DM_USER'
+          )
+        })
+    })
+
+    it('should not push the decision to nomis if config variable is false', () => {
+      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
+      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
+        pushToNomis: false,
+      })
+      return request(app)
+        .post('/hdc/approval/release/1')
+        .send({ decision: 'Yes' })
+        .expect(302)
+        .expect(() => {
+          expect(nomisPushServiceStub.pushStatus).to.not.be.called()
+        })
     })
 
     it('should throw if submitted by non-DM user case insensitively', () => {

--- a/test/routes/approvalTest.js
+++ b/test/routes/approvalTest.js
@@ -165,39 +165,39 @@ describe('/hdc/approval', () => {
           .send({ decision: 'Yes' })
           .expect(403)
       })
-    })
 
-    it('should push the decision to nomis if config variable is true', () => {
-      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
-      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
-        pushToNomis: true,
-      })
-      return request(app)
-        .post('/hdc/approval/release/1')
-        .send({ decision: 'Yes' })
-        .expect(302)
-        .expect(() => {
-          expect(nomisPushServiceStub.pushStatus).to.be.calledOnce()
-          expect(nomisPushServiceStub.pushStatus).to.be.calledWith(
-            '1',
-            { type: 'release', status: 'ABC', reason: undefined },
-            'DM_USER'
-          )
+      it('should push the decision to nomis if config variable is true', () => {
+        licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
+        app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
+          pushToNomis: true,
         })
-    })
+        return request(app)
+          .post(route.url)
+          .send({ decision: 'Yes' })
+          .expect(302)
+          .expect(() => {
+            expect(nomisPushServiceStub.pushStatus).to.be.calledOnce()
+            expect(nomisPushServiceStub.pushStatus).to.be.calledWith(
+              '1',
+              { type: route.formName, status: 'ABC', reason: undefined },
+              'DM_USER'
+            )
+          })
+      })
 
-    it('should not push the decision to nomis if config variable is false', () => {
-      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
-      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
-        pushToNomis: false,
-      })
-      return request(app)
-        .post('/hdc/approval/release/1')
-        .send({ decision: 'Yes' })
-        .expect(302)
-        .expect(() => {
-          expect(nomisPushServiceStub.pushStatus).to.not.be.called()
+      it('should not push the decision to nomis if config variable is false', () => {
+        licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
+        app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
+          pushToNomis: false,
         })
+        return request(app)
+          .post(route.url)
+          .send({ decision: 'Yes' })
+          .expect(302)
+          .expect(() => {
+            expect(nomisPushServiceStub.pushStatus).to.not.be.called()
+          })
+      })
     })
 
     it('should throw if submitted by non-DM user case insensitively', () => {

--- a/test/routes/approvalTest.js
+++ b/test/routes/approvalTest.js
@@ -56,8 +56,8 @@ describe('/hdc/approval', () => {
     })
     app = createApp({ licenceServiceStub: service }, 'dmUser')
     const routes = [
-      // {url: '/hdc/approval/release/1', content: 'Do you approve HDC release for this offender?'},
-      { url: '/hdc/approval/refuseReason/1', content: 'HDC refused because there is no suitable curfew address' },
+      { url: '/hdc/approval/release/1', content: 'Do you approve HDC release for this offender?' },
+      { url: '/hdc/approval/refuseReason/1', content: 'HDC refused' },
     ]
 
     testFormPageGets(app, routes, service)
@@ -83,16 +83,24 @@ describe('/hdc/approval', () => {
         })
     })
 
-    it('should throw if requested by non-DM user', () => {
+    it('release should throw if requested by non-DM user', () => {
       const caApp = createApp({ licenceServiceStub }, 'caUser')
 
       return request(caApp)
         .get('/hdc/approval/release/1')
         .expect(403)
     })
+
+    it('refuseReason should throw if requested by non-DM user', () => {
+      const caApp = createApp({ licenceServiceStub }, 'caUser')
+
+      return request(caApp)
+        .get('/hdc/approval/refuseReason/1')
+        .expect(403)
+    })
   })
 
-  describe('POST /hdc/approval/:form/:bookingId', () => {
+  describe('POST /hdc/approval/{route}/:bookingId', () => {
     const routes = [
       {
         url: '/hdc/approval/release/1',
@@ -138,65 +146,32 @@ describe('/hdc/approval', () => {
             expect(res.header.location).to.equal(route.nextPath)
           })
       })
-    })
 
-    it('should push the decision to nomis if config variable is true', () => {
-      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
-      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
-        pushToNomis: true,
+      it('should redirect to same page if errors on input', () => {
+        licenceServiceStub.validateForm.returns({ decision: 'Error 1' })
+
+        return request(app)
+          .post(route.url)
+          .send({})
+          .expect(302)
+          .expect('Location', route.url)
       })
-      return request(app)
-        .post('/hdc/approval/release/1')
-        .send({ decision: 'Yes' })
-        .expect(302)
-        .expect(() => {
-          expect(nomisPushServiceStub.pushStatus).to.be.calledOnce()
-          expect(nomisPushServiceStub.pushStatus).to.be.calledWith(
-            '1',
-            { type: 'release', status: 'ABC', reason: undefined },
-            'DM_USER'
-          )
-        })
-    })
 
-    it('should not push the decision to nomis if config variable is false', () => {
-      licenceServiceStub.update.resolves({ approval: { release: { decision: 'ABC' } } })
-      app = createApp({ licenceServiceStub, nomisPushServiceStub }, 'dmUser', {
-        pushToNomis: false,
+      it('should throw if submitted by non-DM user', () => {
+        const caApp = createApp({ licenceServiceStub }, 'caUser')
+
+        return request(caApp)
+          .post(route.url)
+          .send({ decision: 'Yes' })
+          .expect(403)
       })
-      return request(app)
-        .post('/hdc/approval/release/1')
-        .send({ decision: 'Yes' })
-        .expect(302)
-        .expect(() => {
-          expect(nomisPushServiceStub.pushStatus).to.not.be.called()
-        })
-    })
-
-    it('should redirect to same page if errors on input', () => {
-      licenceServiceStub.validateForm.returns({ decision: 'Error 1' })
-
-      return request(app)
-        .post('/hdc/approval/release/1')
-        .send({})
-        .expect(302)
-        .expect('Location', '/hdc/approval/release/1')
-    })
-
-    it('should throw if submitted by non-DM user', () => {
-      const caApp = createApp({ licenceServiceStub }, 'caUser')
-
-      return request(caApp)
-        .post('/hdc/approval/release/1')
-        .send({ decision: 'Yes' })
-        .expect(403)
     })
 
     it('should throw if submitted by non-DM user case insensitively', () => {
       const caApp = createApp({ licenceServiceStub }, 'caUser')
 
       return request(caApp)
-        .post('/hdc/Approval/release/1')
+        .post('/hdc/Approval/refuseReason/1')
         .send({ decision: 'Yes' })
         .expect(403)
     })


### PR DESCRIPTION
On the "send for refusal" paths, we now need to capture the refusal reason.
We re-use the same form as the regular refusals.
The difference is that the reason was chosen by the CA, so we pre-select that reason when showing the form.
(The DM can override by selecting other reasons)

This is the first example of requiring validation on a form that updates a different licence section, so we also need to select the target section as the source of data for validation

Having captured the refusal reason, we can configure the push to nomis for approval status just like other routes