### PR TITLE
Push checks passed on failure

### DIFF
--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -3,7 +3,7 @@ const superagent = require('superagent')
 const logger = require('../../log')
 const config = require('../config')
 const { merge, pipe, getIn } = require('../utils/functionalHelpers')
-const { NoTokenError } = require('../utils/errors')
+const { unauthorisedError } = require('../utils/errors')
 
 const timeoutSpec = {
   response: config.nomis.timeout.response,
@@ -142,6 +142,10 @@ module.exports = token => {
     },
 
     async putChecksPassed({ bookingId, passed }) {
+      if (typeof passed !== 'boolean') {
+        throw new Error(`Missing required input parameter 'passed'`)
+      }
+
       const path = `${apiUrl}/offender-sentences/booking/${bookingId}/home-detention-curfews/latest/checks-passed`
       const body = { passed, date: moment().format('YYYY-MM-DD') }
 
@@ -159,7 +163,7 @@ module.exports = token => {
 function nomisGetBuilder(token) {
   return async ({ path, query = '', headers = {}, responseType = '' } = {}) => {
     if (!token) {
-      throw new NoTokenError()
+      throw unauthorisedError()
     }
 
     try {
@@ -187,7 +191,7 @@ function nomisPushBuilder(verb, token) {
 
   return async ({ path, body = '', headers = {}, responseType = '' } = {}) => {
     if (!token) {
-      throw new NoTokenError()
+      throw unauthorisedError()
     }
 
     try {

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -141,9 +141,9 @@ module.exports = token => {
       return nomisPut({ path, body })
     },
 
-    async putChecksPassed(bookingId) {
+    async putChecksPassed({ bookingId, passed }) {
       const path = `${apiUrl}/offender-sentences/booking/${bookingId}/home-detention-curfews/latest/checks-passed`
-      const body = { passed: 'true', date: moment().format('YYYY-MM-DD') }
+      const body = { passed, date: moment().format('YYYY-MM-DD') }
 
       return nomisPut({ path, body })
     },

--- a/server/routes/address.js
+++ b/server/routes/address.js
@@ -37,7 +37,11 @@ module.exports = ({ licenceService, nomisPushService }) => (router, audited, { p
       ])
 
       if (pushToNomis && decision === 'OptOut') {
-        await nomisPushService.pushStatus(bookingId, { type: 'optOut', status: 'Yes' }, req.user.username)
+        await nomisPushService.pushStatus({
+          bookingId,
+          data: { type: 'optOut', status: 'Yes' },
+          username: req.user.username,
+        })
       }
 
       const nextPath = formConfig.curfewAddressChoice.nextPath[decision] || `/hdc/taskList/`

--- a/server/routes/config/eligibility.js
+++ b/server/routes/config/eligibility.js
@@ -21,6 +21,7 @@ module.exports = {
     nomisPush: {
       status: ['eligibility', 'excluded', 'decision'],
       reason: ['eligibility', 'excluded', 'reason'],
+      checksFailedStatusValue: 'Yes',
     },
     nextPath: {
       decisions: [
@@ -81,6 +82,7 @@ module.exports = {
     nomisPush: {
       status: ['eligibility', 'exceptionalCircumstances', 'decision'],
       reason: ['eligibility', 'suitability', 'reason'],
+      checksFailedStatusValue: 'No',
     },
     nextPath: {
       decisions: [

--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -18,7 +18,7 @@ module.exports = ({ licenceService, signInService, nomisPushService }) => (route
       const notExcluded = getIn(updatedLicence, ['eligibility', 'excluded', 'decision']) === 'No'
       const notUnsuitable = getIn(updatedLicence, ['eligibility', 'suitability', 'decision']) === 'No'
       if (notExcluded && notUnsuitable) {
-        await nomisPushService.pushChecksPassed(bookingId, req.user.username)
+        await nomisPushService.pushChecksPassed({ bookingId, passed: true, username: req.user.username })
       }
     }
   }

--- a/server/routes/routeWorkers/standard.js
+++ b/server/routes/routeWorkers/standard.js
@@ -106,15 +106,15 @@ module.exports = ({ formConfig, licenceService, sectionName, nomisPushService, c
     const pushConfig = getIn(formConfig, [formName, 'nomisPush'])
 
     if (getIn(config, ['pushToNomis']) && pushConfig) {
-      await nomisPushService.pushStatus(
-        bookingId,
-        {
-          type: formName,
-          status: !isEmpty(pushConfig.status) ? getIn(updatedLicence, pushConfig.status) : undefined,
-          reason: !isEmpty(pushConfig.reason) ? getIn(updatedLicence, pushConfig.reason) : undefined,
-        },
-        username
-      )
+      const status = !isEmpty(pushConfig.status) ? getIn(updatedLicence, pushConfig.status) : undefined
+      const reason = !isEmpty(pushConfig.reason) ? getIn(updatedLicence, pushConfig.reason) : undefined
+      const statusForFailure = pushConfig.checksFailedStatusValue
+
+      if (statusForFailure && status === statusForFailure) {
+        await nomisPushService.pushChecksPassed({ bookingId, passed: false, username })
+      }
+
+      await nomisPushService.pushStatus({ bookingId, data: { type: formName, status, reason }, username })
     }
   }
 

--- a/server/services/nomisPushService.js
+++ b/server/services/nomisPushService.js
@@ -3,27 +3,27 @@ const { getIn } = require('../utils/functionalHelpers')
 const { statusValues, statusReasonValues } = require('./config/approvalStatuses')
 
 module.exports = (nomisClientBuilder, signInService) => {
-  async function pushStatus(bookingId, dataObject, userName) {
-    const approvalStatus = getApprovalStatus(dataObject)
+  async function pushStatus({ bookingId, data, username }) {
+    const approvalStatus = getApprovalStatus(data)
 
     if (!approvalStatus) {
       logger.info('No approval status to push to nomis')
       return null
     }
 
-    const systemTokens = await signInService.getClientCredentialsTokens(userName)
+    const systemTokens = await signInService.getClientCredentialsTokens(username)
     const nomisClient = nomisClientBuilder(systemTokens.token)
 
     logger.info('Pushing approval status to nomis', approvalStatus)
     return nomisClient.putApprovalStatus(bookingId, approvalStatus)
   }
 
-  async function pushChecksPassed(bookingId, userName) {
-    const systemTokens = await signInService.getClientCredentialsTokens(userName)
+  async function pushChecksPassed({ bookingId, passed, username }) {
+    const systemTokens = await signInService.getClientCredentialsTokens(username)
     const nomisClient = nomisClientBuilder(systemTokens.token)
 
-    logger.info('Pushing checks passed to nomis')
-    return nomisClient.putChecksPassed(bookingId)
+    logger.info(`Pushing checks passed=${passed} to nomis for bookingId: ${bookingId}`)
+    return nomisClient.putChecksPassed({ bookingId, passed })
   }
 
   return {

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -18,6 +18,23 @@ describe('nomisClient', () => {
     nock.cleanAll()
   })
 
+  describe('nomisClient', () => {
+    it('should throw error on GET when no token', () => {
+      const badClient = nomisClientBuilder()
+      return expect(badClient.getBooking('1')).to.be.rejectedWith('Unauthorised access')
+    })
+
+    it('should throw error on POST when no token', () => {
+      const badClient = nomisClientBuilder()
+      return expect(badClient.getOffenderSentencesByBookingId(['1'])).to.be.rejectedWith('Unauthorised access')
+    })
+
+    it('should throw error on PUT when no token', () => {
+      const badClient = nomisClientBuilder()
+      return expect(badClient.putActiveCaseLoad('1')).to.be.rejectedWith('Unauthorised access')
+    })
+  })
+
   describe('getBooking', () => {
     it('should return data from api', () => {
       fakeNomis.get(`/bookings/1`).reply(200, { key: 'value' })
@@ -551,6 +568,24 @@ describe('nomisClient', () => {
       return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: true })).to.eventually.eql({
         result: 'answer',
       })
+    })
+
+    it('should throw error if passed is undefined', () => {
+      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa' })).to.be.rejectedWith(
+        `Missing required input parameter 'passed'`
+      )
+    })
+
+    it('should throw error if passed is null', () => {
+      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: null })).to.be.rejectedWith(
+        `Missing required input parameter 'passed'`
+      )
+    })
+
+    it('should throw error if passed is not boolean', () => {
+      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: 0 })).to.be.rejectedWith(
+        `Missing required input parameter 'passed'`
+      )
     })
   })
 })

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -570,18 +570,6 @@ describe('nomisClient', () => {
       })
     })
 
-    it('should throw error if passed is undefined', () => {
-      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa' })).to.be.rejectedWith(
-        `Missing required input parameter 'passed'`
-      )
-    })
-
-    it('should throw error if passed is null', () => {
-      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: null })).to.be.rejectedWith(
-        `Missing required input parameter 'passed'`
-      )
-    })
-
     it('should throw error if passed is not boolean', () => {
       return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: 0 })).to.be.rejectedWith(
         `Missing required input parameter 'passed'`

--- a/test/data/nomisClientTest.js
+++ b/test/data/nomisClientTest.js
@@ -535,18 +535,20 @@ describe('nomisClient', () => {
         .put('/offender-sentences/booking/aaa/home-detention-curfews/latest/checks-passed')
         .reply(200, { result: 'answer' })
 
-      return expect(nomisClient.putChecksPassed('aaa')).to.eventually.eql({ result: 'answer' })
+      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: true })).to.eventually.eql({
+        result: 'answer',
+      })
     })
 
-    it('should pass in passed=true  and date', () => {
+    it('should pass in passed value and date', () => {
       fakeNomis
         .put('/offender-sentences/booking/aaa/home-detention-curfews/latest/checks-passed', {
-          passed: 'true',
+          passed: true,
           date: '2018-05-31',
         })
         .reply(200, { result: 'answer' })
 
-      return expect(nomisClient.putChecksPassed('aaa', { approvalStatus: 'status' })).to.eventually.eql({
+      return expect(nomisClient.putChecksPassed({ bookingId: 'aaa', passed: true })).to.eventually.eql({
         result: 'answer',
       })
     })

--- a/test/routes/approvalTest.js
+++ b/test/routes/approvalTest.js
@@ -177,11 +177,11 @@ describe('/hdc/approval', () => {
           .expect(302)
           .expect(() => {
             expect(nomisPushServiceStub.pushStatus).to.be.calledOnce()
-            expect(nomisPushServiceStub.pushStatus).to.be.calledWith(
-              '1',
-              { type: route.formName, status: 'ABC', reason: undefined },
-              'DM_USER'
-            )
+            expect(nomisPushServiceStub.pushStatus).to.be.calledWith({
+              bookingId: '1',
+              data: { type: route.formName, status: 'ABC', reason: undefined },
+              username: 'DM_USER',
+            })
           })
       })
 

--- a/test/routes/eligibilityTest.js
+++ b/test/routes/eligibilityTest.js
@@ -261,11 +261,11 @@ describe('/hdc/eligibility', () => {
           .expect(302)
           .expect(() => {
             expect(nomisPushService.pushStatus).to.be.calledOnce()
-            expect(nomisPushService.pushStatus).to.be.calledWith(
-              '1',
-              { type: spec.type, status: 'ABC', reason: 'XYZ' },
-              'CA_USER_TEST'
-            )
+            expect(nomisPushService.pushStatus).to.be.calledWith({
+              bookingId: '1',
+              data: { type: spec.type, status: 'ABC', reason: 'XYZ' },
+              username: 'CA_USER_TEST',
+            })
           })
       })
     })
@@ -418,7 +418,11 @@ describe('/hdc/eligibility', () => {
         .expect(302)
         .expect(() => {
           expect(nomisPushService.pushChecksPassed).to.be.calledOnce()
-          expect(nomisPushService.pushChecksPassed).to.be.calledWith('1', 'CA_USER_TEST')
+          expect(nomisPushService.pushChecksPassed).to.be.calledWith({
+            bookingId: '1',
+            passed: true,
+            username: 'CA_USER_TEST',
+          })
         })
     })
   })

--- a/test/routes/finalChecksTest.js
+++ b/test/routes/finalChecksTest.js
@@ -204,11 +204,11 @@ describe('/hdc/finalChecks', () => {
             .expect(302)
             .expect(() => {
               expect(nomisPushService.pushStatus).to.be.calledOnce()
-              expect(nomisPushService.pushStatus).to.be.calledWith(
-                '1',
-                { type: spec.type, status: 'ABC', reason: 'XYZ' },
-                'CA_USER_TEST'
-              )
+              expect(nomisPushService.pushStatus).to.be.calledWith({
+                bookingId: '1',
+                data: { type: spec.type, status: 'ABC', reason: 'XYZ' },
+                username: 'CA_USER_TEST',
+              })
             })
         })
       })

--- a/test/routes/proposedAddressTest.js
+++ b/test/routes/proposedAddressTest.js
@@ -259,7 +259,11 @@ describe('/hdc/proposedAddress', () => {
         .expect(302)
         .expect(() => {
           expect(nomisPushService.pushStatus).to.be.calledOnce()
-          expect(nomisPushService.pushStatus).to.be.calledWith('1', { type: 'optOut', status: 'Yes' }, 'CA_USER_TEST')
+          expect(nomisPushService.pushStatus).to.be.calledWith({
+            bookingId: '1',
+            data: { type: 'optOut', status: 'Yes' },
+            username: 'CA_USER_TEST',
+          })
         })
     })
 

--- a/test/services/nomisPushServiceTest.js
+++ b/test/services/nomisPushServiceTest.js
@@ -6,6 +6,9 @@ describe('nomisPushService', () => {
   let nomisClientMock
   let signInService
 
+  const bookingId = '1'
+  const username = 'user'
+
   beforeEach(() => {
     nomisClientMock = {
       putApprovalStatus: sinon.stub().resolves(),
@@ -140,7 +143,7 @@ describe('nomisPushService', () => {
 
       specs.forEach(spec => {
         it(`should call nomisClient.putApprovalStatus for ${spec.example} with the correct values`, async () => {
-          await service.pushStatus('1', spec.data, 'user')
+          await service.pushStatus({ bookingId, data: spec.data, username })
           expect(nomisClientBuilder).to.be.calledOnce()
           expect(nomisClientBuilder).to.be.calledWith('valid-token')
           expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
@@ -151,37 +154,57 @@ describe('nomisPushService', () => {
     })
 
     it('should not call nomisClient.putApprovalStatus if no type', async () => {
-      await service.pushStatus('1', { type: undefined, status: 'Yes', reason: 'something' }, 'user')
+      await service.pushStatus({
+        bookingId,
+        data: { type: undefined, status: 'Yes', reason: 'something' },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
 
     it('should not call nomisClient.putApprovalStatus if no status', async () => {
-      await service.pushStatus('1', { type: 'release', status: undefined, reason: 'something' }, 'user')
+      await service.pushStatus({
+        bookingId,
+        data: { type: 'release', status: undefined, reason: 'something' },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
 
     it('should not call nomisClient.putApprovalStatus if no matching update', async () => {
-      await service.pushStatus('1', { type: 'release', status: 'No', reason: 'unmatched-reason' }, 'user')
+      await service.pushStatus({
+        bookingId,
+        data: { type: 'release', status: 'No', reason: 'unmatched-reason' },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
 
     it('should not call nomisClient.putApprovalStatus if no matching update when array of reasons', async () => {
-      await service.pushStatus('1', { type: 'release', status: 'No', reason: ['unmatched-reason'] }, 'user')
+      await service.pushStatus({
+        bookingId,
+        data: { type: 'release', status: 'No', reason: ['unmatched-reason'] },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
 
     it('should not call nomisClient.putApprovalStatus if no matching update when empty array of reasons', async () => {
-      await service.pushStatus('1', { type: 'release', status: 'No', reason: [] }, 'user')
+      await service.pushStatus({ bookingId, data: { type: 'release', status: 'No', reason: [] }, username })
       expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
 
     it('should also accept reason in an array', async () => {
-      await service.pushStatus('1', { type: 'release', status: 'No', reason: ['insufficientTime'] }, 'user')
+      await service.pushStatus({
+        bookingId,
+        data: { type: 'release', status: 'No', reason: ['insufficientTime'] },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
       expect(nomisClientBuilder).to.be.calledWith('valid-token')
       expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
@@ -192,11 +215,11 @@ describe('nomisPushService', () => {
     })
 
     it('should use the first reason when there are many', async () => {
-      await service.pushStatus(
-        '1',
-        { type: 'release', status: 'No', reason: ['insufficientTime', 'addressUnsuitable', 'unmatched-reason'] },
-        'user'
-      )
+      await service.pushStatus({
+        bookingId,
+        data: { type: 'release', status: 'No', reason: ['insufficientTime', 'addressUnsuitable', 'unmatched-reason'] },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
       expect(nomisClientBuilder).to.be.calledWith('valid-token')
       expect(nomisClientMock.putApprovalStatus).to.be.calledOnce()
@@ -207,11 +230,11 @@ describe('nomisPushService', () => {
     })
 
     it('should not call nomisClient.putApprovalStatus if no matching update when first reason unmatched', async () => {
-      await service.pushStatus(
-        '1',
-        { type: 'release', status: 'No', reason: ['unmatched-reason', 'insufficientTime', 'addressUnsuitable'] },
-        'user'
-      )
+      await service.pushStatus({
+        bookingId,
+        data: { type: 'release', status: 'No', reason: ['unmatched-reason', 'insufficientTime', 'addressUnsuitable'] },
+        username,
+      })
       expect(signInService.getClientCredentialsTokens).not.to.be.calledOnce()
       expect(nomisClientMock.putApprovalStatus).not.to.be.calledOnce()
     })
@@ -219,11 +242,11 @@ describe('nomisPushService', () => {
 
   describe('pushChecksPassed', () => {
     it('should call nomisClient.putChecksPassed', async () => {
-      await service.pushChecksPassed('1', 'user')
+      await service.pushChecksPassed({ bookingId, passed: true, username })
       expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
       expect(nomisClientBuilder).to.be.calledWith('valid-token')
       expect(nomisClientMock.putChecksPassed).to.be.calledOnce()
-      expect(nomisClientMock.putChecksPassed).to.be.calledWith('1')
+      expect(nomisClientMock.putChecksPassed).to.be.calledWith({ bookingId: '1', passed: true })
     })
   })
 })


### PR DESCRIPTION
Checks passed is also used for false, not just true
Add route config to trigger checks failed push where ever needed
Change input to objects for consistency and to avoid passing unlabelled boolean
Make username consistent with prevailing usage