### PR TITLE
Allow sending checks passed TRUE via standard route config

### DIFF
--- a/server/routes/config/eligibility.js
+++ b/server/routes/config/eligibility.js
@@ -21,7 +21,7 @@ module.exports = {
     nomisPush: {
       status: ['eligibility', 'excluded', 'decision'],
       reason: ['eligibility', 'excluded', 'reason'],
-      checksFailedStatusValue: 'Yes',
+      checksPassed: { failState: 'Yes' },
     },
     nextPath: {
       decisions: [
@@ -82,7 +82,7 @@ module.exports = {
     nomisPush: {
       status: ['eligibility', 'exceptionalCircumstances', 'decision'],
       reason: ['eligibility', 'suitability', 'reason'],
-      checksFailedStatusValue: 'No',
+      checksPassed: { passState: 'Yes', failState: 'No' },
     },
     nextPath: {
       decisions: [


### PR DESCRIPTION
Allow pushing "checks passed" to nomis when licence data exactly matches a specified value for passing or a specified value for failing, otherwise don't send.