### PR TITLE
Add nginx proxy buffer config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
             git push origin ${VERSION}
             ~/.local/bin/eb deploy --label ${VERSION}
       - store_artifacts:
-          path: Dockerrun.aws.json
+          path: deploy.zip
 
   accept_stage:
     working_directory: ~/noms-digital-studio/licences

--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -1,0 +1,10 @@
+files:
+  /etc/nginx/conf.d/proxy.conf:
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      client_max_body_size 20M;
+      proxy_buffer_size 128k;
+      proxy_buffers 4 256k;
+      proxy_busy_buffers_size 256k;

--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -2,7 +2,7 @@ branch-defaults:
   master:
     environment: licences-stage
 deploy:
-  artifact: Dockerrun.aws.json
+  artifact: deploy.zip
 global:
   application_name: licences
   default_region: eu-west-2

--- a/bin/plant-beanstalk.js
+++ b/bin/plant-beanstalk.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const AdmZip = require('adm-zip')
 
 const version = process.argv[2]
 
@@ -19,3 +20,8 @@ const dockerrun = {
 const output = JSON.stringify(dockerrun, null, 2)
 
 fs.writeFileSync(path.resolve(__dirname, '../Dockerrun.aws.json'), output)
+
+const zip = new AdmZip()
+zip.addLocalFile(`${__dirname}/../Dockerrun.aws.json`)
+zip.addLocalFile(`${__dirname}/../.ebextensions/nginx.config', '.ebextensions`)
+zip.writeZip(`${__dirname}/../deploy.zip`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,6 +331,11 @@
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
       "dev": true
     },
+    "adm-zip": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+    },
     "ajv": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "homepage": "https://github.com/noms-digital-studio/licences#readme",
   "dependencies": {
+    "adm-zip": "^0.4.13",
     "applicationinsights": "^1.1.0",
     "body-parser": "^1.18.3",
     "case": "^1.6.1",


### PR DESCRIPTION
We get a 502 Gateway error in some circumstances. https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=156&modal=detail&selectedIssue=LIC-960

The nginx proxy in EB gives "upstream sent too big header while reading response header from upstream".

This may actually be a red herring and there's a different error going on behind it, but I need to try this first because nothing is wrong locally, only wrong when behind nginx in AWS. If there is another error behind, fixing this part should reveal it.

The only way to configure nginx in AWS is via .ebextensions, which requires deploying a zip. We do the same thing for the batchloader where we have to configure a bigger file upload size limit.

It means we won't be able to use the Jenkins deployment for licences and have to revert to deploying via AWS console like we used to. It may be possible to adapt the Jenkins workflow to deploy zips from S3 but I don't want to spend time on that until I know this fix works.

See eg https://stackoverflow.com/questions/23844761/upstream-sent-too-big-header-while-reading-response-header-from-upstream