### PR TITLE
Lic 818 notification scheduler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -336,6 +336,91 @@
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
     },
+    "advisory-lock": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/advisory-lock/-/advisory-lock-1.1.1.tgz",
+      "integrity": "sha1-8kM8RYpQah6aqnfCuB8dnHk6vko=",
+      "requires": {
+        "debug": "^2.2.0",
+        "minimist": "^1.2.0",
+        "pg": "^4.5.5"
+      },
+      "dependencies": {
+        "buffer-writer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+          "integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "packet-reader": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.2.0.tgz",
+          "integrity": "sha1-gZ300BC4LV6lZx+KGjrPA5vNdwA="
+        },
+        "pg": {
+          "version": "4.5.7",
+          "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.7.tgz",
+          "integrity": "sha1-Ra4WsjcGpjRaAyed7MaveVwW0ps=",
+          "requires": {
+            "buffer-writer": "1.0.1",
+            "generic-pool": "2.4.2",
+            "js-string-escape": "1.0.1",
+            "packet-reader": "0.2.0",
+            "pg-connection-string": "0.1.3",
+            "pg-types": "1.*",
+            "pgpass": "0.0.3",
+            "semver": "^4.1.0"
+          }
+        },
+        "pg-connection-string": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+          "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+        },
+        "pg-types": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.13.0.tgz",
+          "integrity": "sha512-lfKli0Gkl/+za/+b6lzENajczwZHc7D5kiUCZfgm914jipD2kIOIvEkAhZ8GrW3/TUoP9w8FHjwpPObBye5KQQ==",
+          "requires": {
+            "pg-int8": "1.0.1",
+            "postgres-array": "~1.0.0",
+            "postgres-bytea": "~1.0.0",
+            "postgres-date": "~1.0.0",
+            "postgres-interval": "^1.1.0"
+          }
+        },
+        "pgpass": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz",
+          "integrity": "sha1-EuZ+NDsxicLzEgbrycwL7//PkUA=",
+          "requires": {
+            "split": "~0.3"
+          }
+        },
+        "postgres-array": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
+          "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
+        },
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        },
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+          "requires": {
+            "through": "2"
+          }
+        }
+      }
+    },
     "ajv": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
@@ -1501,6 +1586,15 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cron-parser": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.9.0.tgz",
+      "integrity": "sha512-WkHhWssz4OxEdepOIt3dXYQiKZgPwgeF1yzBMlLwnUCwv0ziNeINNbMs5haoG10ikM/j0LMrrhEsuK2Blt638w==",
+      "requires": {
+        "is-nan": "^1.2.1",
+        "moment-timezone": "^0.5.23"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1649,7 +1743,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -3350,6 +3443,11 @@
         "globule": "^1.0.0"
       }
     },
+    "generic-pool": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz",
+      "integrity": "sha1-iGvFvwvrfblugby7oHiBjeWmJoM="
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -4144,6 +4242,14 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-nan": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.2.1.tgz",
+      "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+      "requires": {
+        "define-properties": "^1.1.1"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -4479,6 +4585,11 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
       "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
     },
     "js-stringify": {
       "version": "1.0.2",
@@ -5096,6 +5207,11 @@
       "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
+    "long-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
+      "integrity": "sha1-lyHXiLR+C8taJMLivuGg2lXatRQ="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -5422,6 +5538,14 @@
       "resolved": "https://registry.npmjs.org/moment-business-days/-/moment-business-days-1.1.3.tgz",
       "integrity": "sha512-VfpcLQxVWJ9ymq4ljaqPdzoco01kOJblX9sbfOCYguBvqCvVPYDJQTdez49a2gtSoSK8AjL8JfvLvmoQlrBMiQ=="
     },
+    "moment-timezone": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5732,6 +5856,16 @@
       "requires": {
         "mkdirp": "^0.5.1",
         "node-sass": "^4.3.0"
+      }
+    },
+    "node-schedule": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.3.2.tgz",
+      "integrity": "sha512-GIND2pHMHiReSZSvS6dpZcDH7pGPGFfWBIEud6S00Q8zEIzAs9ommdyRK1ZbQt8y1LyZsJYZgPnyi7gpU2lcdw==",
+      "requires": {
+        "cron-parser": "^2.7.3",
+        "long-timeout": "0.1.1",
+        "sorted-array-functions": "^1.0.0"
       }
     },
     "nodemon": {
@@ -6956,8 +7090,7 @@
     "object-keys": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
-      "dev": true
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -8420,6 +8553,11 @@
       "requires": {
         "kind-of": "^3.2.0"
       }
+    },
+    "sorted-array-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
+      "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg=="
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "homepage": "https://github.com/noms-digital-studio/licences#readme",
   "dependencies": {
     "adm-zip": "^0.4.13",
+    "advisory-lock": "^1.1.1",
     "applicationinsights": "^1.1.0",
     "body-parser": "^1.18.3",
     "case": "^1.6.1",
@@ -85,6 +86,7 @@
     "moment-business-days": "^1.1.3",
     "node-sass": "^4.11.0",
     "node-sass-middleware": "^0.11.0",
+    "node-schedule": "^1.3.2",
     "nodemon": "^1.18.10",
     "notifications-node-client": "^4.6.0",
     "passport": "^0.4.0",

--- a/server/app.js
+++ b/server/app.js
@@ -28,6 +28,7 @@ const defaultRouter = require('../server/routes/default')
 const adminRouter = require('../server/routes/admin/admin')
 const userAdminRouter = require('../server/routes/admin/users')
 const mailboxesAdminRouter = require('../server/routes/admin/mailboxes')
+const jobsAdminRouter = require('../server/routes/admin/jobs')
 const apiRouter = require('../server/routes/api')
 const caseListRouter = require('../server/routes/caseList')
 const contactRouter = require('../server/routes/contact')
@@ -68,6 +69,7 @@ module.exports = function createApp({
   userService,
   nomisPushService,
   configClient,
+  jobSchedulerService,
   audit,
 }) {
   const app = express()
@@ -348,6 +350,7 @@ module.exports = function createApp({
   app.use('/admin/', secureRoute(adminRouter()))
   app.use('/admin/roUsers/', secureRoute(userAdminRouter({ userAdminService }), { auditKey: 'USER_MANAGEMENT' }))
   app.use('/admin/mailboxes/', secureRoute(mailboxesAdminRouter({ configClient })))
+  app.use('/admin/jobs/', secureRoute(jobsAdminRouter({ jobSchedulerService })))
   app.use('/hdc/contact/', secureRoute(contactRouter({ userAdminService })))
   app.use('/hdc/pdf/', secureRoute(pdfRouter({ pdfService, prisonerService }), { auditKey: 'CREATE_PDF' }))
   app.use('/hdc/send/', secureRoute(sendRouter({ licenceService, prisonerService, notificationService, audit })))

--- a/server/config.js
+++ b/server/config.js
@@ -24,6 +24,7 @@ module.exports = {
     server: get('DB_SERVER', 'localhost'),
     database: get('DB_NAME', 'licences'),
     sslEnabled: get('DB_SSL_ENABLED', 'true'),
+    port: 5432,
   },
 
   nomis: {

--- a/server/config.js
+++ b/server/config.js
@@ -72,9 +72,9 @@ module.exports = {
   use2019Conditions: get('NEW_CONDITIONS', 'no') === 'yes',
 
   jobs: {
-    systemUser: get('SYSTEM_USER', ''),
-    roReminders: get('RO_REMINDER_SCHEDULE', '0 1 * * 1-5'),
-    active: get('SCHEDULED_REMINDERS', 'no') === 'yes',
+    systemUser: get('REMINDERS_SYSTEM_USER', ''),
+    roReminders: get('REMINDERS_SCHEDULE_RO', '0 1 * * 1-5'),
+    autostart: get('SCHEDULED_REMINDERS_AUTOSTART', 'no') === 'yes',
     overlapTimeout: 5000,
   },
 }

--- a/server/config.js
+++ b/server/config.js
@@ -69,4 +69,11 @@ module.exports = {
 
   pushToNomis: get('PUSH_TO_NOMIS', 'no') === 'yes',
   use2019Conditions: get('NEW_CONDITIONS', 'no') === 'yes',
+
+  jobs: {
+    systemUser: get('SYSTEM_USER', ''),
+    roReminders: get('RO_REMINDER_SCHEDULE', '0 1 * * 1-5'),
+    active: get('SCHEDULED_REMINDERS', 'no') === 'yes',
+    overlapTimeout: 5000,
+  },
 }

--- a/server/data/dataAccess/db.js
+++ b/server/data/dataAccess/db.js
@@ -9,7 +9,7 @@ const pool = new Pool({
   host: config.db.server,
   database: config.db.database,
   password: config.db.password,
-  port: 5432,
+  port: config.db.port,
   ssl:
     config.db.sslEnabled === 'true'
       ? {

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,8 @@ const createUserService = require('./services/userService')
 const createNotificationService = require('./services/notificationService')
 const createNomisPushService = require('./services/nomisPushService')
 const createDeadlineService = require('./services/deadlineService')
+const createJobSchedulerService = require('./services/jobSchedulerService')
+const createNotificationJobs = require('./services/jobs/notificationJobs')
 
 const signInService = createSignInService(audit)
 const licenceService = createLicenceService(licenceClient)
@@ -45,6 +47,8 @@ const notificationService = createNotificationService(
   audit
 )
 const nomisPushService = createNomisPushService(nomisClientBuilder, signInService)
+const notificationJobs = createNotificationJobs(notificationService, signInService)
+const jobSchedulerService = createJobSchedulerService(notificationJobs)
 
 const app = createApp({
   signInService,
@@ -60,6 +64,7 @@ const app = createApp({
   nomisPushService,
   deadlineService,
   configClient,
+  jobSchedulerService,
   audit,
 })
 

--- a/server/routes/admin/jobs.js
+++ b/server/routes/admin/jobs.js
@@ -21,7 +21,7 @@ module.exports = ({ jobSchedulerService }) => router => {
   router.post(
     '/reschedule',
     asyncMiddleware(async (req, res) => {
-      jobSchedulerService.restartJob(req.body.jobName)
+      jobSchedulerService.startJob(req.body.jobName)
       res.redirect('/admin/jobs')
     })
   )

--- a/server/routes/admin/jobs.js
+++ b/server/routes/admin/jobs.js
@@ -1,0 +1,30 @@
+const { asyncMiddleware, authorisationMiddleware } = require('../../utils/middleware')
+
+module.exports = ({ jobSchedulerService }) => router => {
+  router.use(authorisationMiddleware)
+
+  router.get(
+    '/',
+    asyncMiddleware(async (req, res) => {
+      return res.render('admin/jobs/list', { jobs: jobSchedulerService.listJobs() })
+    })
+  )
+
+  router.post(
+    '/cancel',
+    asyncMiddleware(async (req, res) => {
+      jobSchedulerService.cancelJob(req.body.jobName)
+      res.redirect('/admin/jobs')
+    })
+  )
+
+  router.post(
+    '/reschedule',
+    asyncMiddleware(async (req, res) => {
+      jobSchedulerService.restartJob(req.body.jobName)
+      res.redirect('/admin/jobs')
+    })
+  )
+
+  return router
+}

--- a/server/services/jobSchedulerService.js
+++ b/server/services/jobSchedulerService.js
@@ -1,0 +1,87 @@
+const schedule = require('node-schedule')
+const advisoryLock = require('advisory-lock').default
+const moment = require('moment')
+const config = require('../config')
+const logger = require('../../log.js')
+const { onceOnly } = require('./jobs/jobUtils')
+
+module.exports = function createJobSchedulerService(notificationJobs) {
+  const connectionString = `postgres://${config.db.username}:${config.db.password}@${config.db.server}:5432/${
+    config.db.database
+  }`
+
+  const { active, overlapTimeout } = config.jobs
+
+  const roLock = advisoryLock(connectionString)('roReminders')
+
+  const jobs = [
+    {
+      name: 'roReminders',
+      spec: config.jobs.roReminders,
+      lock: roLock,
+      function: onceOnly(notificationJobs.roReminders, roLock, 'roReminders', overlapTimeout),
+    },
+  ]
+
+  const executions = {}
+
+  function createScheduledJobs() {
+    if (active) {
+      jobs.forEach(job => {
+        logger.info(`Scheduling job: ${job.name}`)
+        const execution = schedule.scheduleJob(job.name, job.spec, job.function)
+        executions[job.name] = execution
+      })
+    }
+  }
+
+  function nextExecution(job) {
+    if (!job) {
+      return null
+    }
+    const next = job.nextInvocation()
+    return next ? moment(next.toDate()).format('dddd Do MMMM HH:mm:ss') : null
+  }
+
+  function listJobs() {
+    return jobs.map(job => {
+      return {
+        name: job.name,
+        schedule: job.spec,
+        next: nextExecution(executions[job.name]),
+      }
+    })
+  }
+
+  function cancelJob(jobName) {
+    const job = jobs.find(j => j.name === jobName)
+    if (job) {
+      logger.info(`Cancelling job: ${job.name}`)
+      executions[job.name].cancel()
+    }
+  }
+
+  function cancelAllJobs() {
+    jobs.forEach(job => {
+      logger.info(`Cancelling job: ${job.name}`)
+      executions[job.name].cancel()
+    })
+  }
+
+  function restartJob(jobName) {
+    const job = jobs.find(j => j.name === jobName)
+    if (job) {
+      logger.info(`Scheduling job: ${job.name}`)
+      executions[job.name].reschedule(job.spec)
+    }
+  }
+
+  createScheduledJobs()
+
+  return {
+    listJobs,
+    cancelJob,
+    cancelAllJobs,
+    restartJob,
+  }
+}

--- a/server/services/jobSchedulerService.js
+++ b/server/services/jobSchedulerService.js
@@ -26,7 +26,7 @@ module.exports = function createJobSchedulerService(notificationJobs) {
   const executions = {}
 
   function createScheduledJobs() {
-    if (active) {
+    if (process.env.NODE_ENV === 'test' || active) {
       jobs.forEach(job => {
         logger.info(`Scheduling job: ${job.name}`)
         const execution = schedule.scheduleJob(job.name, job.spec, job.function)

--- a/server/services/jobSchedulerService.js
+++ b/server/services/jobSchedulerService.js
@@ -6,9 +6,9 @@ const logger = require('../../log.js')
 const { onceOnly } = require('./jobs/jobUtils')
 
 module.exports = function createJobSchedulerService(notificationJobs) {
-  const connectionString = `postgres://${config.db.username}:${config.db.password}@${config.db.server}:5432/${
-    config.db.database
-  }`
+  const connectionString = `postgres://${config.db.username}:${config.db.password}@${config.db.server}:${
+    config.db.port
+  }/${config.db.database}`
 
   const { active, overlapTimeout } = config.jobs
 

--- a/server/services/jobs/jobUtils.js
+++ b/server/services/jobs/jobUtils.js
@@ -1,0 +1,33 @@
+const logger = require('../../../log.js')
+
+module.exports = {
+  onceOnly,
+}
+
+function onceOnly(jobFunction, jobLock, jobName, overlapTimeout) {
+  return async () => {
+    const lock = jobLock.tryLock()
+    if (lock) {
+      logger.info(`${jobName}: Obtained lock`)
+      return runJob(jobFunction, jobLock, jobName, overlapTimeout)
+    }
+
+    logger.info(`${jobName}: Could not obtain lock`)
+  }
+}
+
+async function runJob(jobFunction, jobLock, jobName, overlapTimeout) {
+  try {
+    await jobFunction()
+    await delay(overlapTimeout)
+  } catch (error) {
+    logger.error(`${jobName}: Error:`, error.stack)
+  }
+  jobLock.unlock()
+}
+
+async function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+}

--- a/server/services/jobs/notificationJobs.js
+++ b/server/services/jobs/notificationJobs.js
@@ -1,0 +1,20 @@
+const config = require('../../config')
+const logger = require('../../../log.js')
+
+module.exports = function createNotificationJobs(notificationService, signInService) {
+  const { systemUser } = config.jobs
+
+  async function roReminders() {
+    logger.info('Running RO reminders')
+    try {
+      const systemToken = await signInService.getClientCredentialsTokens(systemUser)
+      await notificationService.notifyRoReminders(systemToken.token)
+    } catch (error) {
+      logger.error('Error running RO reminders', error.stack)
+    }
+  }
+
+  return {
+    roReminders,
+  }
+}

--- a/server/services/prisonerService.js
+++ b/server/services/prisonerService.js
@@ -15,9 +15,14 @@ function createPrisonerService(nomisClientBuilder) {
 
       const prisoners = await nomisClient.getOffenderSentencesByBookingId(bookingId)
 
-      return formatObjectForView(prisoners[0])
+      const prisoner = prisoners[0]
+      if (!prisoner) {
+        return null
+      }
+
+      return formatObjectForView(prisoner)
     } catch (error) {
-      logger.error('Error getting prisoner personal details')
+      logger.error('Error getting prisoner personal details', error.stack)
       return null
     }
   }

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -11,4 +11,6 @@ block content
         a(href='/admin/roUsers/incomplete') Incomplete RO users
       div
         a(href='/admin/mailboxes') Notification mailboxes
+      div
+        a(href='/admin/jobs') Batch jobs
 

--- a/server/views/admin/jobs/list.pug
+++ b/server/views/admin/jobs/list.pug
@@ -1,0 +1,41 @@
+extends ../../layout
+
+block content
+
+  div.back-link-container.smallPaddingTop
+    a#back.link-back(href="/admin/") Back
+
+  div.pure-g
+
+    div.pure-u-1.largeMarginTop
+      h2.heading-medium #{heading}
+
+      table.largeMarginBottom
+        thead
+          tr
+            th Job
+            th Schedule
+            th Next run
+            th
+            th
+        tbody
+
+        each job in jobs
+          tr
+            td #{job.name}
+            td #{job.schedule}
+            td #{job.next}
+            td
+              if (job.next)
+                form(method='POST' action='/admin/jobs/cancel')
+                  input(type="hidden" name="_csrf" value=csrfToken)
+                  input(type="hidden" name="jobName" value=job.name)
+                  input.requiredButton.button(type="submit" value="Turn off")
+
+              else
+                form(method='POST' action='/admin/jobs/reschedule')
+                  input(type="hidden" name="_csrf" value=csrfToken)
+                  input(type="hidden" name="jobName" value=job.name)
+                  input.requiredButton.button(type="submit" value="Turn on")
+
+

--- a/test/services/jobSchedulerServiceTest.js
+++ b/test/services/jobSchedulerServiceTest.js
@@ -1,0 +1,69 @@
+const proxyquire = require('proxyquire')
+const createJobSchedulerService = require('../../server/services/jobSchedulerService')
+const createNotificationJobs = require('../../server/services/jobs/notificationJobs')
+const config = require('../../server/config')
+
+describe('jobSchedulerService', () => {
+  let service
+  let jobs
+  let signInService
+  let notificationService
+
+  beforeEach(() => {
+    signInService = {
+      getClientCredentialsTokens: sinon.stub().resolves({ token: 'system-user-token' }),
+    }
+
+    notificationService = {
+      notifyRoReminders: sinon.stub().resolves({}),
+    }
+
+    jobs = createNotificationJobs(notificationService, signInService)
+    service = createJobSchedulerService(jobs)
+  })
+
+  afterEach(() => {
+    service.cancelAllJobs()
+  })
+
+  it('should create RO reminders job', async () => {
+    expect(service.listJobs().length).to.eql(1)
+    expect(service.listJobs()[0].name).to.eql('roReminders')
+  })
+
+  it('should cancel job and remove next execution', async () => {
+    const jobName = service.listJobs()[0].name
+    expect(service.listJobs()[0].next).to.not.eql(null)
+    service.cancelJob(jobName)
+    expect(service.listJobs()[0].next).to.eql(null)
+  })
+
+  it('should restart job and set next execution', async () => {
+    const jobName = service.listJobs()[0].name
+    service.cancelJob(jobName)
+    expect(service.listJobs()[0].next).to.eql(null)
+    service.restartJob(jobName)
+    expect(service.listJobs()[0].next).to.not.eql(null)
+  })
+
+  it('should cancel all jobs', async () => {
+    expect(service.listJobs()[0].next).to.not.eql(null)
+    service.cancelAllJobs()
+    expect(service.listJobs()[0].next).to.eql(null)
+  })
+
+  it('should schedule jobs using the scheduler library', async () => {
+    const scheduleStub = {
+      scheduleJob: sinon.stub().returns({}),
+    }
+
+    const stubbedService = proxyquire('../../server/services/jobSchedulerService', {
+      'node-schedule': scheduleStub,
+    })
+
+    await stubbedService(jobs)
+
+    expect(scheduleStub.scheduleJob).to.be.calledOnce()
+    expect(scheduleStub.scheduleJob).to.be.calledWith('roReminders', config.jobs.roReminders, sinon.match.func)
+  })
+})

--- a/test/services/jobSchedulerServiceTest.js
+++ b/test/services/jobSchedulerServiceTest.js
@@ -4,66 +4,86 @@ const createNotificationJobs = require('../../server/services/jobs/notificationJ
 const config = require('../../server/config')
 
 describe('jobSchedulerService', () => {
-  let service
-  let jobs
-  let signInService
-  let notificationService
+  describe('createScheduledJobs', () => {
+    let service
+    let jobs
+    let signInService
+    let notificationService
 
-  beforeEach(() => {
-    signInService = {
-      getClientCredentialsTokens: sinon.stub().resolves({ token: 'system-user-token' }),
-    }
+    beforeEach(() => {
+      signInService = {
+        getClientCredentialsTokens: sinon.stub().resolves({ token: 'system-user-token' }),
+      }
 
-    notificationService = {
-      notifyRoReminders: sinon.stub().resolves({}),
-    }
+      notificationService = {
+        notifyRoReminders: sinon.stub().resolves({}),
+      }
 
-    jobs = createNotificationJobs(notificationService, signInService)
-    service = createJobSchedulerService(jobs)
-  })
-
-  afterEach(() => {
-    service.cancelAllJobs()
-  })
-
-  it('should create RO reminders job', async () => {
-    expect(service.listJobs().length).to.eql(1)
-    expect(service.listJobs()[0].name).to.eql('roReminders')
-  })
-
-  it('should cancel job and remove next execution', async () => {
-    const jobName = service.listJobs()[0].name
-    expect(service.listJobs()[0].next).to.not.eql(null)
-    service.cancelJob(jobName)
-    expect(service.listJobs()[0].next).to.eql(null)
-  })
-
-  it('should restart job and set next execution', async () => {
-    const jobName = service.listJobs()[0].name
-    service.cancelJob(jobName)
-    expect(service.listJobs()[0].next).to.eql(null)
-    service.restartJob(jobName)
-    expect(service.listJobs()[0].next).to.not.eql(null)
-  })
-
-  it('should cancel all jobs', async () => {
-    expect(service.listJobs()[0].next).to.not.eql(null)
-    service.cancelAllJobs()
-    expect(service.listJobs()[0].next).to.eql(null)
-  })
-
-  it('should schedule jobs using the scheduler library', async () => {
-    const scheduleStub = {
-      scheduleJob: sinon.stub().returns({}),
-    }
-
-    const stubbedService = proxyquire('../../server/services/jobSchedulerService', {
-      'node-schedule': scheduleStub,
+      jobs = createNotificationJobs(notificationService, signInService)
+      service = createJobSchedulerService(jobs)
     })
 
-    await stubbedService(jobs)
+    afterEach(() => {
+      service.cancelAllJobs()
+    })
 
-    expect(scheduleStub.scheduleJob).to.be.calledOnce()
-    expect(scheduleStub.scheduleJob).to.be.calledWith('roReminders', config.jobs.roReminders, sinon.match.func)
+    it('should create RO reminders job', async () => {
+      expect(service.listJobs().length).to.eql(1)
+      expect(service.listJobs()[0].name).to.eql('roReminders')
+    })
+
+    it('should cancel job and remove next execution', async () => {
+      const jobName = service.listJobs()[0].name
+      expect(service.listJobs()[0].next).to.not.eql(null)
+      service.cancelJob(jobName)
+      expect(service.listJobs()[0].next).to.eql(null)
+    })
+
+    it('should restart job and set next execution', async () => {
+      const jobName = service.listJobs()[0].name
+      service.cancelJob(jobName)
+      expect(service.listJobs()[0].next).to.eql(null)
+      service.restartJob(jobName)
+      expect(service.listJobs()[0].next).to.not.eql(null)
+    })
+
+    it('should cancel all jobs', async () => {
+      expect(service.listJobs()[0].next).to.not.eql(null)
+      service.cancelAllJobs()
+      expect(service.listJobs()[0].next).to.eql(null)
+    })
+  })
+
+  describe('scheduler', () => {
+    let jobs
+    let signInService
+    let notificationService
+
+    beforeEach(() => {
+      signInService = {
+        getClientCredentialsTokens: sinon.stub().resolves({ token: 'system-user-token' }),
+      }
+
+      notificationService = {
+        notifyRoReminders: sinon.stub().resolves({}),
+      }
+
+      jobs = createNotificationJobs(notificationService, signInService)
+    })
+
+    it('should schedule jobs using the scheduler library', async () => {
+      const scheduleStub = {
+        scheduleJob: sinon.stub().returns({}),
+      }
+
+      const stubbedService = proxyquire('../../server/services/jobSchedulerService', {
+        'node-schedule': scheduleStub,
+      })
+
+      await stubbedService(jobs)
+
+      expect(scheduleStub.scheduleJob).to.be.calledOnce()
+      expect(scheduleStub.scheduleJob).to.be.calledWith('roReminders', config.jobs.roReminders, sinon.match.func)
+    })
   })
 })

--- a/test/services/jobs/jobUtilsTest.js
+++ b/test/services/jobs/jobUtilsTest.js
@@ -1,0 +1,48 @@
+const { onceOnly } = require('../../../server/services/jobs/jobUtils')
+
+describe('jobUtils', () => {
+  let jobFunction
+  let jobLock
+
+  beforeEach(() => {
+    jobFunction = sinon.stub().returns(true)
+    jobLock = {
+      tryLock: sinon.stub().returns(true),
+      unlock: sinon.stub().returns(),
+    }
+  })
+
+  it('should lock, execute, unlock', async () => {
+    const runner = onceOnly(jobFunction, jobLock, 'name', 0)
+    await runner()
+
+    expect(jobLock.tryLock).to.be.calledOnce()
+    expect(jobFunction).to.be.calledOnce()
+    expect(jobLock.unlock).to.be.calledOnce()
+  })
+
+  it('should not execute without lock', async () => {
+    jobLock = {
+      tryLock: sinon.stub().returns(false),
+      unlock: sinon.stub().returns(),
+    }
+
+    const runner = onceOnly(jobFunction, jobLock, 'name', 0)
+    await runner()
+
+    expect(jobLock.tryLock).to.be.calledOnce()
+    expect(jobFunction).not.to.be.calledOnce()
+    expect(jobLock.unlock).not.to.be.calledOnce()
+  })
+
+  it('should unlock if function throws', async () => {
+    jobFunction = sinon.stub().throws()
+
+    const runner = onceOnly(jobFunction, jobLock, 'name', 0)
+    await runner()
+
+    expect(jobLock.tryLock).to.be.calledOnce()
+    expect(jobFunction).to.be.calledOnce()
+    expect(jobLock.unlock).to.be.calledOnce()
+  })
+})

--- a/test/services/jobs/notificationJobsTest.js
+++ b/test/services/jobs/notificationJobsTest.js
@@ -1,0 +1,22 @@
+const createNotificationJobs = require('../../../server/services/jobs/notificationJobs')
+
+describe('notificationJobs', () => {
+  let signInService
+  let notificationService
+  let jobs
+
+  beforeEach(() => {
+    signInService = { getClientCredentialsTokens: sinon.stub().resolves({ token: 'test-token' }) }
+    notificationService = { notifyRoReminders: sinon.stub().resolves() }
+
+    jobs = createNotificationJobs(notificationService, signInService)
+  })
+
+  it('should sign in and trigger notifications', async () => {
+    await jobs.roReminders()
+
+    expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
+    expect(notificationService.notifyRoReminders).to.be.calledOnce()
+    expect(notificationService.notifyRoReminders).to.be.calledWith('test-token')
+  })
+})

--- a/test/services/notificationServiceTest.js
+++ b/test/services/notificationServiceTest.js
@@ -489,4 +489,63 @@ describe('notificationService', () => {
       expect(prisonerService.getPrisonerPersonalDetails).to.have.callCount(4)
     })
   })
+
+  describe('notifyReminders', () => {
+    it('should get notifiable booking IDs from deadline service', async () => {
+      await service.notifyRoReminders('token')
+      expect(deadlineService.getDueInDays).to.be.calledTwice()
+      expect(deadlineService.getDueInDays).to.be.calledWith('RO', 0)
+      expect(deadlineService.getDueInDays).to.be.calledWith('RO', 2)
+      expect(deadlineService.getOverdue).to.be.calledOnce()
+    })
+
+    it('should get submissionTarget and prisonerDetails for each notifiable case', async () => {
+      await service.notifyRoReminders('token')
+      expect(prisonerService.getOrganisationContactDetails).to.have.callCount(4)
+      expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('RO', 1, 'token')
+      expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('RO', 2, 'token')
+      expect(prisonerService.getOrganisationContactDetails).to.be.calledWith('RO', 3, 'token')
+
+      expect(prisonerService.getPrisonerPersonalDetails).to.have.callCount(4)
+      expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith(1, 'token')
+      expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith(2, 'token')
+      expect(prisonerService.getPrisonerPersonalDetails).to.be.calledWith(3, 'token')
+    })
+
+    it('should call notify client for each notification', async () => {
+      const expectedCommonData = {
+        offender_dob: '1/1/1',
+        offender_name: 'First Last',
+        offender_noms: 'AB1234A',
+        domain: 'http://localhost:3000',
+      }
+
+      const firstNotification = {
+        ...expectedCommonData,
+        booking_id: 2,
+        date: 'Tuesday 15th January',
+        prison: 'HMP Blah',
+        ro_name: undefined,
+      }
+      const secondNotification = {
+        ...expectedCommonData,
+        booking_id: 3,
+        date: 'Tuesday 15th January',
+        prison: 'HMP Blah',
+        ro_name: undefined,
+      }
+      const overdueTemplate = templates.RO_OVERDUE.templateId
+      const expectedEmail = 'expected@ro.email'
+
+      await service.notifyRoReminders('token')
+
+      expect(notifyClient.sendEmail).to.have.callCount(4)
+      expect(notifyClient.sendEmail).to.be.calledWith(overdueTemplate, expectedEmail, {
+        personalisation: firstNotification,
+      })
+      expect(notifyClient.sendEmail).to.be.calledWith(overdueTemplate, expectedEmail, {
+        personalisation: secondNotification,
+      })
+    })
+  })
 })


### PR DESCRIPTION
See https://dsdmoj.atlassian.net/wiki/spaces/LIC/pages/1393918299/Notifications

This service runs some function (in this case sending reminder notifications to ROs) on a cron schedule.
The npm library node-schedule is used for cron-based scheduling.

The jobs are created at application startup. An admin screen is presented for internal admin users to enable/disable scheduled jobs. Cron schedules are set in config via an envvar (no requirement for user config at this stage)

To avoid multiple application instances in AWS all running the same scheduled job, a Postgres "advisory lock" database lock is used to ensure that only one instance gets to run the job.

To avoid scenarios where the job runs so quickly that it finishes before a second instance attempts to acquire the lock, a delay is introduced before releasing the lock.