### PR TITLE
Post-approval task list tweaks for approved premises

### DIFF
--- a/server/routes/viewModels/taskLists/roTasks.js
+++ b/server/routes/viewModels/taskLists/roTasks.js
@@ -76,27 +76,39 @@ module.exports = {
   },
 
   getRoTasksPostApproval: ({ decisions, tasks }) => {
+    const { approvedPremisesRequired } = decisions
+
     return [
+      {
+        title: 'Proposed curfew address',
+        label: curfewAddress.getLabel({ decisions, tasks }),
+        action: curfewAddress.getRoAction({ decisions, tasks }),
+        visible: approvedPremisesRequired,
+      },
       {
         title: 'Risk management',
         label: riskManagement.getLabel({ decisions, tasks }),
         action: riskManagement.getRoAction({ decisions, tasks }),
+        visible: !approvedPremisesRequired,
       },
       {
         title: 'Curfew hours',
         label: curfewHours.getLabel({ decisions, tasks }),
         action: curfewHours.getRoAction({ decisions, tasks }),
+        visible: true,
       },
       {
         title: 'Additional conditions',
         label: additionalConditions.getLabel({ decisions, tasks }),
         action: additionalConditions.getRoAction({ decisions, tasks }),
+        visible: true,
       },
       {
         title: 'Reporting instructions',
         label: reportingInstructions.getLabel({ decisions, tasks }),
         action: reportingInstructions.getRoAction({ decisions, tasks }),
+        visible: true,
       },
-    ]
+    ].filter(task => task.visible)
   },
 }

--- a/server/routes/viewModels/taskLists/tasks/curfewAddress.js
+++ b/server/routes/viewModels/taskLists/tasks/curfewAddress.js
@@ -39,7 +39,11 @@ module.exports = {
   },
 
   getCaPostApprovalAction: ({ decisions }) => {
-    const { addressWithdrawn, approvedPremisesRequired } = decisions
+    const { optedOut, addressWithdrawn, approvedPremisesRequired } = decisions
+
+    if (optedOut) {
+      return change('/hdc/proposedAddress/curfewAddressChoice/')
+    }
 
     if (approvedPremisesRequired) {
       return viewEdit('/hdc/curfew/approvedPremisesChoice/')

--- a/test/routes/viewModels/taskListModelsTest.js
+++ b/test/routes/viewModels/taskListModelsTest.js
@@ -1277,7 +1277,7 @@ describe('TaskList models', () => {
   })
 
   describe('roTasksPostApproval', () => {
-    it('should return four taskes', () => {
+    it('should return four tasks', () => {
       expect(
         taskListModel(
           'RO',
@@ -1295,21 +1295,66 @@ describe('TaskList models', () => {
           title: 'Risk management',
           label: 'Not completed',
           action: { type: 'btn', text: 'Continue', href: '/hdc/risk/riskManagement/' },
+          visible: true,
         },
         {
           title: 'Curfew hours',
           label: 'Not completed',
           action: { type: 'btn', text: 'Continue', href: '/hdc/curfew/curfewHours/' },
+          visible: true,
         },
         {
           title: 'Additional conditions',
           label: 'Not completed',
           action: { type: 'btn', text: 'Continue', href: '/hdc/licenceConditions/standard/' },
+          visible: true,
         },
         {
           title: 'Reporting instructions',
           label: 'Not completed',
           action: { type: 'btn', text: 'Continue', href: '/hdc/reporting/reportingInstructions/' },
+          visible: true,
+        },
+      ])
+    })
+
+    it('should hide risk and show address taks when approved premises', () => {
+      expect(
+        taskListModel(
+          'RO',
+          false,
+          {
+            decisions: { approvedPremisesRequired: true },
+            tasks: {},
+            stage: 'DECIDED',
+          },
+          { version: 1 },
+          null
+        )
+      ).to.eql([
+        {
+          title: 'Proposed curfew address',
+          label: 'Not completed',
+          action: { type: 'btn', text: 'Continue', href: '/hdc/curfew/approvedPremises/' },
+          visible: true,
+        },
+        {
+          title: 'Curfew hours',
+          label: 'Not completed',
+          action: { type: 'btn', text: 'Continue', href: '/hdc/curfew/curfewHours/' },
+          visible: true,
+        },
+        {
+          title: 'Additional conditions',
+          label: 'Not completed',
+          action: { type: 'btn', text: 'Continue', href: '/hdc/licenceConditions/standard/' },
+          visible: true,
+        },
+        {
+          title: 'Reporting instructions',
+          label: 'Not completed',
+          action: { type: 'btn', text: 'Continue', href: '/hdc/reporting/reportingInstructions/' },
+          visible: true,
         },
       ])
     })
@@ -2145,68 +2190,13 @@ describe('TaskList models', () => {
           label: 'Not completed',
           title: 'Proposed curfew address',
         },
-        {
-          action: {
-            href: '/hdc/review/victimLiaison/',
-            text: 'View',
-            type: 'btn-secondary',
-          },
-          label: 'Not completed',
-          title: 'Victim liaison',
-        },
-        {
-          action: {
-            href: '/hdc/review/curfewHours/',
-            text: 'View',
-            type: 'btn-secondary',
-          },
-          label: 'Not completed',
-          title: 'Curfew hours',
-        },
-        {
-          action: {
-            href: '/hdc/review/conditions/',
-            text: 'View',
-            type: 'btn-secondary',
-          },
-          label: 'Not completed',
-          title: 'Additional conditions',
-        },
-        {
-          action: {
-            href: '/hdc/review/reporting/',
-            text: 'View',
-            type: 'btn-secondary',
-          },
-          label: 'Not completed',
-          title: 'Reporting instructions',
-        },
-        {
-          action: {
-            href: '/hdc/review/finalChecks/',
-            text: 'View',
-            type: 'btn-secondary',
-          },
-          label: 'Not completed',
-          title: 'Review case',
-        },
-        {
-          action: {
-            href: '/hdc/send/return/',
-            text: 'Return to prison case admin',
-            type: 'btn-secondary',
-          },
-          title: 'Return to prison case admin',
-        },
-        {
-          action: {
-            href: '/hdc/approval/release/',
-            text: 'Continue',
-            type: 'btn',
-          },
-          label: 'Not started',
-          title: 'Final decision',
-        },
+        victim,
+        curfew,
+        conditions,
+        reporting,
+        review,
+        returnPCA,
+        release,
       ])
     })
 

--- a/test/routes/viewModels/taskLists/tasks/curfewAddressTest.js
+++ b/test/routes/viewModels/taskLists/tasks/curfewAddressTest.js
@@ -166,7 +166,7 @@ describe('curfew address task', () => {
       })
     })
 
-    it('should btn to 3 way choice if opted out', () => {
+    it('should link to 3 way choice if opted out', () => {
       expect(
         getCaPostApprovalAction({
           decisions: { optedOut: true },
@@ -181,7 +181,7 @@ describe('curfew address task', () => {
   })
 
   describe('getCaProcessingAction', () => {
-    it('should btn to 3 way choice if opted out', () => {
+    it('should link to 3 way choice if opted out', () => {
       expect(
         getCaProcessingAction({
           decisions: { optedOut: true },

--- a/test/routes/viewModels/taskLists/tasks/curfewAddressTest.js
+++ b/test/routes/viewModels/taskLists/tasks/curfewAddressTest.js
@@ -165,6 +165,19 @@ describe('curfew address task', () => {
         type: 'btn-secondary',
       })
     })
+
+    it('should btn to 3 way choice if opted out', () => {
+      expect(
+        getCaPostApprovalAction({
+          decisions: { optedOut: true },
+          tasks: { curfewAddress: 'UNSTARTED' },
+        })
+      ).to.eql({
+        text: 'Change',
+        href: '/hdc/proposedAddress/curfewAddressChoice/',
+        type: 'link',
+      })
+    })
   })
 
   describe('getCaProcessingAction', () => {


### PR DESCRIPTION
Shows the curfew/approved premises address task on the RO task list post-approval when approved premises is required, hides the risk task if approved premises required

For CA, the curfew adrress task links to curfew address choice when opted out