### PR TITLE
Explicit function for anonymous client creds to avoid misuse

### DIFF
--- a/server/authentication/signInService.js
+++ b/server/authentication/signInService.js
@@ -35,6 +35,13 @@ const signInService = () => {
 
       return oauthTokenRequest(oauthAdminClientToken, oauthRequest)
     },
+
+    async getAnonymousClientCredentialsTokens() {
+      const oauthAdminClientToken = generateAdminOauthClientToken()
+      const oauthRequest = { grant_type: 'client_credentials' }
+
+      return oauthTokenRequest(oauthAdminClientToken, oauthRequest)
+    },
   }
 }
 

--- a/server/services/jobs/notificationJobs.js
+++ b/server/services/jobs/notificationJobs.js
@@ -1,13 +1,10 @@
-const config = require('../../config')
 const logger = require('../../../log.js')
 
 module.exports = function createNotificationJobs(notificationService, signInService) {
-  const { systemUser } = config.jobs
-
   async function roReminders() {
     logger.info('Running RO reminders')
     try {
-      const systemToken = await signInService.getClientCredentialsTokens(systemUser)
+      const systemToken = await signInService.getAnonymousClientCredentialsTokens()
       return await notificationService.notifyRoReminders(systemToken.token)
     } catch (error) {
       logger.error('Error running RO reminders', error.stack)

--- a/test/authentication/signInTest.js
+++ b/test/authentication/signInTest.js
@@ -34,4 +34,32 @@ describe('signInService', () => {
       expect(newToken).to.be.eql({ refreshToken: 'refreshed', refreshTime: in15Mins, token: 'token' })
     })
   })
+
+  describe('get client credentials tokens', () => {
+    it('should get anonymous client credentials without a username', async () => {
+      fakeOauth.post(`/oauth/token`, 'grant_type=client_credentials').reply(200, {
+        token_type: 'type',
+        access_token: 'token',
+        refresh_token: 'refreshed',
+        expires_in: '1200',
+      })
+
+      const newToken = await service.getAnonymousClientCredentialsTokens()
+
+      expect(newToken).to.be.eql({ refreshToken: 'refreshed', expiresIn: '1200', token: 'token' })
+    })
+
+    it('should pass username for regular client credentials token', async () => {
+      fakeOauth.post(`/oauth/token`, 'grant_type=client_credentials&username=testuser').reply(200, {
+        token_type: 'type',
+        access_token: 'token',
+        refresh_token: 'refreshed',
+        expires_in: '1200',
+      })
+
+      const newToken = await service.getClientCredentialsTokens('testuser')
+
+      expect(newToken).to.be.eql({ refreshToken: 'refreshed', expiresIn: '1200', token: 'token' })
+    })
+  })
 })

--- a/test/services/jobs/notificationJobsTest.js
+++ b/test/services/jobs/notificationJobsTest.js
@@ -8,7 +8,7 @@ describe('notificationJobs', () => {
   const notifyRoRemindersResult = { result: 'result' }
 
   beforeEach(() => {
-    signInService = { getClientCredentialsTokens: sinon.stub().resolves({ token: 'test-token' }) }
+    signInService = { getAnonymousClientCredentialsTokens: sinon.stub().resolves({ token: 'test-token' }) }
     notificationService = { notifyRoReminders: sinon.stub().resolves(notifyRoRemindersResult) }
 
     jobs = createNotificationJobs(notificationService, signInService)
@@ -17,7 +17,7 @@ describe('notificationJobs', () => {
   it('should sign in and trigger notifications', async () => {
     const result = await jobs.roReminders()
 
-    expect(signInService.getClientCredentialsTokens).to.be.calledOnce()
+    expect(signInService.getAnonymousClientCredentialsTokens).to.be.calledOnce()
     expect(notificationService.notifyRoReminders).to.be.calledOnce()
     expect(notificationService.notifyRoReminders).to.be.calledWith('test-token')
     expect(result).to.eql(notifyRoRemindersResult)


### PR DESCRIPTION
and don't set an empty username param for anonymous creds