### PR TITLE
LIC-fix-docker-compose 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - HOST=licences.hmpps.dsd.test
       - PDF_SERVICE_HOST=http://hdc-pdfgenerator:8080
       - GLOBAL_SEARCH_URL=http://localhost:3002/global-search
+      - ENABLE_TEST_UTILS=true
 
   licences-nomis-mocks:
     image: mojdigitalstudio/licences-nomis-mocks:latest

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/pdf/PdfSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/pdf/PdfSpec.groovy
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.licences.specs.pdf
 
 import geb.spock.GebReportingSpec
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Stepwise
 import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/util/LicencesApi.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/util/LicencesApi.groovy
@@ -35,6 +35,10 @@ class LicencesApi {
     )
 
     println("Status: " + response.status)
+    if (response.status > 299) {
+      throw new Exception("Received an HTTP ${response.status} status code while attempting to create a licence. Licence creation failed.")
+    }
+
     if (response.data) {
       println("Content Type: " + response.contentType)
       println("Headers: " + response.getAllHeaders())

--- a/server/app.js
+++ b/server/app.js
@@ -127,7 +127,7 @@ module.exports = function createApp({
   app.use(bodyParser.json())
   app.use(bodyParser.urlencoded({ extended: true }))
 
-  if (config.enableTestUtils) {
+  if (config.enableTestUtils === 'true') {
     app.use('/utils/', utilsRouter())
   }
 


### PR DESCRIPTION
- docker-compose.yml   add - ENABLE_TEST_UTILS=true to the environment section of the licences
- service. app.js: test that enableTestUtils === 'true'. 
- LicencesApi.create: test response status code and fail if > 299.