### PR TITLE
Use newer PDF lib and configure it to work in Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/noms-digital-studio/licences
   docker:
-    - image: circleci/node:10
+    - image: circleci/node:latest-browsers
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/noms-digital-studio/licences
   docker:
-    - image: circleci/node:latest-browsers
+    - image: circleci/node:10-browsers
 
 version: 2
 jobs:
@@ -73,9 +73,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/noms-digital-studio/licences
-      - run:
-          name: update node-sass.
-          command: npm rebuild node-sass
       - run:
           name: Run the node app.
           command: npm start

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,9 @@ jobs:
       - attach_workspace:
           at: ~/noms-digital-studio/licences
       - run:
+          name: update node-sass.
+          command: npm rebuild node-sass
+      - run:
           name: Run the node app.
           command: npm start
           background: true

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 .port.tmp
 public
 assets/stylesheets/application.css
-assets/stylesheets/pdf.css
+assets/stylesheets/forms-pdf.css
 lib/govuk_template.html
 govuk_modules
 node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,15 @@ ADD . .
 # Install AWS RDS Root cert
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem > /app/root.cert
 
+# Install latest chrome dev package libs so that the bundled version of Chromium installed by Puppeteer will work
+# https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-unstable ttf-freefont \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN npm install && \
     npm run build && \
     export BUILD_NUMBER=${BUILD_NUMBER} && \

--- a/assets/sass/forms-pdf.scss
+++ b/assets/sass/forms-pdf.scss
@@ -2,8 +2,8 @@ body {
   padding-left: 1cm;
   padding-right: 0.5cm;
   font-family: "nta", Arial, helvetica, sans-serif;
-  font-size: 11px;
-  line-height: 16px;
+  font-size: 14px;
+  line-height: 20px;
   text-align: left;
   font-weight: normal
 }
@@ -99,21 +99,21 @@ p {
 h1 {
   margin-top: 0.6cm;
   margin-bottom: 0.4cm;
-  font-size: 15pt;
+  font-size: 18pt;
   font-weight: normal
 }
 
 h2 {
   margin-top: 0.5cm;
   margin-bottom: 0.3cm;
-  font-size: 13pt;
+  font-size: 16pt;
   font-weight: normal
 }
 
 h3 {
   margin-top: 0.3cm;
   margin-bottom: 0;
-  font-size: 11pt;
+  font-size: 14pt;
   font-weight: normal
 }
 

--- a/bin/build-css
+++ b/bin/build-css
@@ -6,3 +6,6 @@
     --include-path node_modules/govuk-elements-sass/public/sass \
     assets/sass/application.scss \
     assets/stylesheets/application.css
+./node_modules/node-sass/bin/node-sass $@ \
+    assets/sass/forms-pdf.scss \
+    assets/stylesheets/forms-pdf.css

--- a/licences-specs/src/test/resources/GebConfig.groovy
+++ b/licences-specs/src/test/resources/GebConfig.groovy
@@ -23,8 +23,8 @@ environments {
 
 // Default if geb.env is not set to one of 'chrome', or 'chromeHeadless'
 driver = {
-  System.setProperty('webdriver.chrome.driver', '/Applications/chromedriver')
-//  System.setProperty('webdriver.chrome.driver', '/usr/local/bin/chromedriver')
+  // System.setProperty('webdriver.chrome.driver', '/Applications/chromedriver')
+  // System.setProperty('webdriver.chrome.driver', '/usr/local/bin/chromedriver')
   ChromeOptions options = new ChromeOptions()
   options.addArguments('headless')
   new ChromeDriver(options)

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,246 +245,11 @@
       }
     },
     "@ministryofjustice/express-template-to-pdf": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/express-template-to-pdf/-/express-template-to-pdf-1.0.4.tgz",
-      "integrity": "sha512-HwG+ZBU1tcSfGbqGzwlB+TKEn16TKvb1lWAh9DuKnG47ZAGFJdGMQIbIOinDTRf+iZp6AD/VNVq8mtA5ZxUQyQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/express-template-to-pdf/-/express-template-to-pdf-2.1.0.tgz",
+      "integrity": "sha512-mv7XVsW9MVcYO4mPk30mmZbl2MpQ47wTufln3b+4D+Y3PB6Jr0FLzl8QfI2fL9Vg8qYmJKGnhc6eOC/M5zXitA==",
       "requires": {
-        "html-pdf": "^2.2.0"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-          "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-          "requires": {
-            "mime-types": "~2.1.24",
-            "negotiator": "0.6.2"
-          }
-        },
-        "body-parser": {
-          "version": "1.19.0",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-          "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-          "requires": {
-            "bytes": "3.1.0",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "http-errors": "1.7.2",
-            "iconv-lite": "0.4.24",
-            "on-finished": "~2.3.0",
-            "qs": "6.7.0",
-            "raw-body": "2.4.0",
-            "type-is": "~1.6.17"
-          }
-        },
-        "bytes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-          "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-        },
-        "content-disposition": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-          "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-          "requires": {
-            "safe-buffer": "5.1.2"
-          }
-        },
-        "cookie": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-        },
-        "express": {
-          "version": "4.17.1",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-          "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-          "requires": {
-            "accepts": "~1.3.7",
-            "array-flatten": "1.1.1",
-            "body-parser": "1.19.0",
-            "content-disposition": "0.5.3",
-            "content-type": "~1.0.4",
-            "cookie": "0.4.0",
-            "cookie-signature": "1.0.6",
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
-            "finalhandler": "~1.1.2",
-            "fresh": "0.5.2",
-            "merge-descriptors": "1.0.1",
-            "methods": "~1.1.2",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.3",
-            "path-to-regexp": "0.1.7",
-            "proxy-addr": "~2.0.5",
-            "qs": "6.7.0",
-            "range-parser": "~1.2.1",
-            "safe-buffer": "5.1.2",
-            "send": "0.17.1",
-            "serve-static": "1.14.1",
-            "setprototypeof": "1.1.1",
-            "statuses": "~1.5.0",
-            "type-is": "~1.6.18",
-            "utils-merge": "1.0.1",
-            "vary": "~1.1.2"
-          }
-        },
-        "finalhandler": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-          "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-          "requires": {
-            "debug": "2.6.9",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.3",
-            "statuses": "~1.5.0",
-            "unpipe": "~1.0.0"
-          }
-        },
-        "http-errors": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ipaddr.js": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
-        },
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        },
-        "mime-db": {
-          "version": "1.40.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-        },
-        "mime-types": {
-          "version": "2.1.24",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-          "requires": {
-            "mime-db": "1.40.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "negotiator": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-          "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-        },
-        "parseurl": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-        },
-        "proxy-addr": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-          "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-          "requires": {
-            "forwarded": "~0.1.2",
-            "ipaddr.js": "1.9.0"
-          }
-        },
-        "qs": {
-          "version": "6.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-        },
-        "range-parser": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-        },
-        "raw-body": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-          "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-          "requires": {
-            "bytes": "3.1.0",
-            "http-errors": "1.7.2",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "send": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-          "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "~1.7.2",
-            "mime": "1.6.0",
-            "ms": "2.1.1",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.1",
-            "statuses": "~1.5.0"
-          }
-        },
-        "serve-static": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-          "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-          "requires": {
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "parseurl": "~1.3.3",
-            "send": "0.17.1"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-        },
-        "type-is": {
-          "version": "1.6.18",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-          "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-          "requires": {
-            "media-typer": "0.3.0",
-            "mime-types": "~2.1.24"
-          }
-        }
+        "puppeteer": "^1.18.1"
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -578,6 +343,14 @@
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
       "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "6.9.1",
@@ -841,6 +614,11 @@
       "requires": {
         "stack-chain": "^1.3.7"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "async-listener": {
       "version": "0.6.10",
@@ -1112,8 +890,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "optional": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-writer": {
       "version": "2.0.0",
@@ -1642,7 +1419,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "optional": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -2324,8 +2100,15 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "optional": true
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3006,7 +2789,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
       "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
-      "optional": true,
       "requires": {
         "concat-stream": "1.6.2",
         "debug": "2.6.9",
@@ -3050,7 +2832,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "optional": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -3304,17 +3085,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "fs-extra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0"
-      }
     },
     "fs-minipass": {
       "version": "1.2.6",
@@ -4290,14 +4060,6 @@
       "resolved": "https://registry.npmjs.org/hsts/-/hsts-2.1.0.tgz",
       "integrity": "sha512-zXhh/DqgrTXJ7erTN6Fh5k/xjMhDGXCqdYN3wvxUvGUQvnxcFfUd8E+6vLg/nk3ss1TYMb+DhRl25fYABioTvA=="
     },
-    "html-pdf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/html-pdf/-/html-pdf-2.2.0.tgz",
-      "integrity": "sha1-S8+Rwky1YOR6o/rP0DPg4b8kG5E=",
-      "requires": {
-        "phantomjs-prebuilt": "^2.1.4"
-      }
-    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -4317,6 +4079,30 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "husky": {
@@ -5281,15 +5067,6 @@
         }
       }
     },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsonwebtoken": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
@@ -5358,12 +5135,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "optional": true
-    },
     "keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
@@ -5375,15 +5146,6 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
         "is-buffer": "^1.1.5"
-      }
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.9"
       }
     },
     "knex": {
@@ -7551,8 +7313,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-      "optional": true
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -7618,41 +7379,6 @@
       "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
       "requires": {
         "split": "^1.0.0"
-      }
-    },
-    "phantomjs-prebuilt": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
-      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
-      "optional": true,
-      "requires": {
-        "es6-promise": "^4.0.3",
-        "extract-zip": "^1.6.5",
-        "fs-extra": "^1.0.0",
-        "hasha": "^2.2.0",
-        "kew": "^0.7.0",
-        "progress": "^1.1.8",
-        "request": "^2.81.0",
-        "request-progress": "^2.0.1",
-        "which": "^1.2.10"
-      },
-      "dependencies": {
-        "hasha": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-          "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-          "optional": true,
-          "requires": {
-            "is-stream": "^1.0.1",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-          "optional": true
-        }
       }
     },
     "pify": {
@@ -7805,8 +7531,7 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise": {
       "version": "7.3.1",
@@ -7836,6 +7561,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "proxyquire": {
       "version": "2.1.0",
@@ -7991,6 +7721,41 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "puppeteer": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.18.1.tgz",
+      "integrity": "sha512-luUy0HPSuWPsPZ1wAp6NinE0zgetWtudf5zwZ6dHjMWfYpTQcmKveFRox7VBNhQ98OjNA9PQ9PzQyX8k/KrxTg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "qs": {
       "version": "6.5.2",
@@ -8236,15 +8001,6 @@
         "tough-cookie": "~2.3.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.1.0"
-      }
-    },
-    "request-progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "optional": true,
-      "requires": {
-        "throttleit": "^1.0.0"
       }
     },
     "request-promise": {
@@ -9204,12 +8960,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "throttleit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-      "optional": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -9269,11 +9019,6 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
-    },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "token-stream": {
       "version": "0.0.1",
@@ -9410,8 +9155,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "optional": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -9862,6 +9606,14 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "x-xss-protection": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
@@ -9970,7 +9722,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "optional": true,
       "requires": {
         "fd-slicer": "~1.0.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -401,8 +401,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1270,11 +1269,6 @@
         "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5515,16 +5509,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5566,11 +5550,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -6042,7 +6021,8 @@
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6277,9 +6257,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -6288,12 +6268,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.11",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -6302,11 +6280,6 @@
         "true-case-path": "^1.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -6314,7 +6287,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -6348,17 +6321,22 @@
           }
         },
         "mime-db": {
-          "version": "1.38.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-          "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
         },
         "mime-types": {
-          "version": "2.1.22",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-          "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+          "version": "2.1.24",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+          "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
           "requires": {
-            "mime-db": "~1.38.0"
+            "mime-db": "1.40.0"
           }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
         "oauth-sign": {
           "version": "0.9.0",
@@ -7584,9 +7562,9 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA=="
     },
     "pstree.remy": {
       "version": "1.1.6",
@@ -9549,11 +9527,6 @@
         "strip-ansi": "^3.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -9665,11 +9638,6 @@
         "yargs-parser": "^5.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6287,7 +6287,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/noms-digital-studio/licences#readme",
   "dependencies": {
-    "@ministryofjustice/express-template-to-pdf": "^1.0.4",
+    "@ministryofjustice/express-template-to-pdf": "^2.1.0",
     "adm-zip": "^0.4.13",
     "applicationinsights": "^1.4.0",
     "applicationinsights-native-metrics": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "knex-migrate": "^1.7.0",
     "moment": "^2.24.0",
     "moment-business-days": "^1.1.3",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.11.0",
     "node-sass-middleware": "^0.11.0",
     "node-schedule": "^1.3.2",
     "nodemon": "^1.18.10",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "knex-migrate": "^1.7.0",
     "moment": "^2.24.0",
     "moment-business-days": "^1.1.3",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.12.0",
     "node-sass-middleware": "^0.11.0",
     "node-schedule": "^1.3.2",
     "nodemon": "^1.18.10",

--- a/server/config.js
+++ b/server/config.js
@@ -82,11 +82,11 @@ module.exports = {
 
   pdfOptions: {
     format: 'A4',
-    border: {
-      top: '30px',
-      bottom: '20px',
-      left: '30px',
-      right: '20px',
+    margin: {
+      top: '80px',
+      bottom: '70px',
+      left: '50px',
+      right: '30px',
     },
   },
 

--- a/server/routes/forms.js
+++ b/server/routes/forms.js
@@ -48,12 +48,8 @@ module.exports = ({ formService }) => router => {
       }
 
       const pageData = await formService.getTemplateData(templateName, licence, prisoner)
-
-      res.renderPDF(
-        `forms/${templateName}`,
-        { ...pageData, domain },
-        { filename: `${prisoner.offenderNo}.pdf`, pdfOptions }
-      )
+      const filename = `${prisoner.offenderNo}.pdf`
+      return res.renderPDF(`forms/${templateName}`, { ...pageData, domain }, { filename, pdfOptions })
     })
   )
 

--- a/server/views/forms/address.pug
+++ b/server/views/forms/address.pug
@@ -1,60 +1,52 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('address form')
 
-    block content
+  p During your first week in prison we said you're eligible for home detention curfew (tagging).
 
-      div
+  p Under home detention curfew you would have to:
 
-        +header('address form')
+  ul.disc
+    li stay at home during certain hours (your curfew)
+    li wear an electronic tag - to make sure you follow your curfew
 
-        p During your first week in prison we said you’re eligible for home detention curfew (tagging).
+  p It would mean you could be released on #{SENT_HDCED}.
 
-        p Under home detention curfew you would have to:
+  h2 What you need to do now
 
-        ul.disc
-          li stay at home during certain hours (your curfew)
-          li wear an electronic tag - to make sure you follow your curfew        
+  p You now need to fill in this address form and return it by
 
-        p It would mean you could be released on #{SENT_HDCED}.
+  p Try to provide details of at least one address where you could live. If you can, think of a second address in case your first choice is not suitable.
 
-        h2 What you need to do now
+  p If you don't have a place to stay, Bail and Accommodation Support Services (BASS) will try to help you find somewhere to stay.
 
-        p You now need to fill in this address form and return it by
+  h2 I do not have an address
 
-        p Try to provide details of at least one address where you could live. If you can, think of a second address in case your first choice is not suitable.
+  p Where would you like to live?
+  ul.byHand
+    li Town:
+    li County:
+    li Signed:
+    li Date:
 
-        p If you don’t have a place to stay, Bail and Accommodation Support Services (BASS) will try to help you find somewhere to stay.
+  h2 I can provide an address
 
-        h2 I do not have an address
+  p What address would you prefer to live at?
+  include includes/addressEntry
 
-        p Where would you like to live?
-        ul.byHand
-          li Town:
-          li County:
-          li Signed:
-          li Date:              
+  div.no-break
+    h2 Is there another address you could live at?
+    p Provide a second address if you can, in case your first address is not suitable.
+    include includes/addressEntry
 
-        div.pagebreak
-        h2 I can provide an address
-        
-        p What address would you prefer to live at?
-        include includes/addressEntry
-        
-        h2 Is there another address you could live at?
-        p Provide a second address if you can, in case your first address is not suitable.
-        include includes/addressEntry
-        
-        p As far as I know the information I provided is correct. I am happy for the main person living at the address or the landlord to be contacted.
-        
-        ul.byHand
-          li Signed:
-          li Date:
+  div.no-break
+    p As far as I know the information I provided is correct. I am happy for the main person living at the address or the landlord to be contacted.
+
+    ul.byHand
+      li Signed:
+      li Date:
         
 
 

--- a/server/views/forms/address_checks.pug
+++ b/server/views/forms/address_checks.pug
@@ -1,43 +1,34 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('information about address checks')
 
-    block content
+  p During your first week in prison we said you're eligible for home detention curfew (tagging).
 
-      div
+  p Under home detention curfew you would have to:
 
-        +header('information about address checks')
+  ul.disc
+    li stay at home during certain hours (your curfew)
+    li wear an electronic tag - to make sure you follow your curfew
 
-        p During your first week in prison we said you’re eligible for home detention curfew (tagging).
+  p It would mean you could be released on #{SENT_HDCED}
 
-        p Under home detention curfew you would have to:
+  h2 What you need to do now
 
-        ul.disc 
-          li stay at home during certain hours (your curfew)
-          li wear an electronic tag - to make sure you follow your curfew
+  p You now need to fill in the address form and return it by
 
-        p It would mean you could be released on #{SENT_HDCED}
+  h2 What we will do
 
-        h2 What you need to do now
+  p We will:
 
-        p You now need to fill in the address form and return it by
+  ol
+    li Check that the address you provided is suitable - this includes talking to anyone else who lives there.
+    li Assess any risks of releasing you on home detention curfew.
+    li Let you know our final decision (in writing).
 
-        h2 What we will do
+  h2 Not interested?
 
-        p We will:
-
-        ol
-          li Check that the address you provided is suitable - this includes talking to anyone else who lives there.
-          li Assess any risks of releasing you on home detention curfew.
-          li Let you know our final decision (in writing).
-
-        h2 Not interested?
-
-        p Not interested in being released early with home detention curfew (tagging)? Just fill in the ‘opt out’ form.
+  p Not interested in being released early with home detention curfew (tagging)? Just fill in the 'opt out' form.
 
 

--- a/server/views/forms/address_unsuitable.pug
+++ b/server/views/forms/address_unsuitable.pug
@@ -1,46 +1,38 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('address unsuitable')
 
-    block content
+  p We have checked the address you gave us and decided it is not a suitable place for you to live while under home detention curfew (tagging).
 
-      div
+  p You need to provide details of another address where you could live if you still want to be considered for tagging.
 
-        +header('address unsuitable')
+  p If you cannot provide an address, Bail and Accommodation Support Services (BASS) could help you find somewhere to stay.
 
-        p We have checked the address you gave us and decided it is not a suitable place for you to live while under home detention curfew (tagging).
+  h2 I no longer want to be considered for tagging
 
-        p You need to provide details of another address where you could live if you still want to be considered for tagging.
+  h2 I still want to be considered but do not have another address
 
-        p If you cannot provide an address, Bail and Accommodation Support Services (BASS) could help you find somewhere to stay.
+  div.no-break
+    p What address would you prefer to live at?
+    ul.byHand
+      li Town:
+      li County:
+      li Signed:
+      li Date:
 
-        h2 I no longer want to be considered for tagging
+  h2 I can provide another address
 
-        h2 I still want to be considered but do not have another address 
-        
-        p What address would you prefer to live at?
-        ul.byHand
-          li Town:
-          li County:
-          li Signed:
-          li Date:
+  p What address would you prefer to live at?
+  include includes/addressEntry
 
-        div.pagebreak
-        h2 I can provide another address
+  div.no-break
+    p As far as I know the information I provided is correct. I am happy for the main person living at the address or the landlord to be contacted.
 
-        p What address would you prefer to live at?
-        include includes/addressEntry
-        
-        p As far as I know the information I provided is correct. I am happy for the main person living at the address or the landlord to be contacted.
-        
-        ul.byHand
-          li Signed:
-          li Date:
+    ul.byHand
+      li Signed:
+      li Date:
         
 
 

--- a/server/views/forms/approved.pug
+++ b/server/views/forms/approved.pug
@@ -1,56 +1,47 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('approved')
 
-    block content
+  p We have checked your case and agreed that you can leave prison early with a tag.
 
-      div
+  h3 Your release date
+  p You will be released on #{SENT_HDCED} (or as soon as possible after this date).
 
-        +header('approved')
+  h3 Your approved address
+  p You must live at:
+  pre #{CURFEW_ADDRESS}
 
-        p We have checked your case and agreed that you can leave prison early with a tag.
 
-        h3 Your release date
-        p You will be released on #{SENT_HDCED} (or as soon as possible after this date).
+  h3 When you leave prison
+  p You must wear an electronic tag and stay at home during certain hours until #{SENT_CRD}. We will explain:
 
-        h3 Your approved address
-        p You must live at:
-        pre #{CURFEW_ADDRESS}
-        
+  ul.disc
+    li the times you must stay at home (your curfew)
+    li the rules you must follow (conditions)
+    li who your probation officer is and when you first need to report to them
 
-        h3 When you leave prison
-        p You must wear an electronic tag and stay at home during certain hours until #{SENT_CRD}. We will explain:
 
-        ul.disc 
-          li the times you must stay at home (your curfew)
-          li the rules you must follow (conditions)
-          li who your probation officer is and when you first need to report to them
-        
+  h3 Your electronic tag
 
-        h3 Your electronic tag
+  p The person fitting the electronic tag will meet you at your address on the day you're released. They will:
 
-        p The person fitting the electronic tag will meet you at your address on the day you're released. They will:
+  ul.disc
+    li fit you with the tag
+    li set up the monitoring equipment
 
-        ul.disc 
-          li fit you with the tag
-          li set up the monitoring equipment
-        
 
-        p You will have to go back to prison if you:
+  p You will have to go back to prison if you:
 
-        ul.disc 
-          li damage the tagging and monitoring equipment
-          li are not at home during your curfew
+  ul.disc
+    li damage the tagging and monitoring equipment
+    li are not at home during your curfew
 
-        ul.byHand
-          li Signed:
-          li Name:
-          li Grade:
-          li Date:
+  ul.byHand
+    li Signed:
+    li Name:
+    li Grade:
+    li Date:
 
 

--- a/server/views/forms/curfewAddress.pug
+++ b/server/views/forms/curfewAddress.pug
@@ -1,37 +1,31 @@
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+extends forms-layout
 
-  body
+block content
 
-    block content
+  h1 Home detention curfew - Address checks
+  span.alert (This form may be disclosed to the offender on request)
 
-      div
-        h1 Home detention curfew - Address checks
-        span.alert (This form may be disclosed to the offender on request)
+  include includes/offender
 
-      include includes/offender
+  if isBass
+    include includes/bassArea
+  else if isAP
+    include includes/approvedPremises
+  else
+    include includes/proposedAddress
 
-      if isBass
-        include includes/bassArea
-      else if isAP
-        include includes/approvedPremises
-      else
-        include includes/proposedAddress
+  include includes/prisonCompleted
 
-      include includes/prisonCompleted
+  if !isBass && !isAP
+    include includes/curfewAddressReview
 
-      if !isBass && !isAP
-        include includes/curfewAddressReview
-        
-      include includes/reporting
-        
-      include includes/conditions
-        
-      include includes/risk
-        
-      include includes/victim
+  include includes/reporting
 
-      include includes/probationCompleted
+  include includes/conditions
+
+  include includes/risk
+
+  include includes/victim
+
+  include includes/probationCompleted
         

--- a/server/views/forms/eligible.pug
+++ b/server/views/forms/eligible.pug
@@ -1,39 +1,30 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('eligible')
 
-    block content
+  p You are eligible for early release from prison on home detention curfew (tagging).
 
-      div
+  h2 What this means for you
+  p This means you could be released from prison on #{SENT_HDCED} if you:
 
-        +header('eligible')
+  ul.disc
+    li behave well in prison
+    li have somewhere to live after you leave prison
 
-        p You are eligible for early release from prison on home detention curfew (tagging).
+  p If you are released early you would have to:
 
-        h2 What this means for you
-        p This means you could be released from prison on #{SENT_HDCED} if you:
-
-        ul.disc
-          li behave well in prison
-          li have somewhere to live after you leave prison
-
-        p If you are released early you would have to:
-
-        ul.disc
-          li stay at home during certain hours (your curfew)
-          li wear an electronic tag - to make sure you follow your curfew
+  ul.disc
+    li stay at home during certain hours (your curfew)
+    li wear an electronic tag - to make sure you follow your curfew
 
 
-        p You would have a curfew and electronic tag until #{SENT_CRD}.
+  p You would have a curfew and electronic tag until #{SENT_CRD}.
 
-        h2 What happens next
-        p Think about where you could live if you were released on #{SENT_HDCED}. We will give you a form to fill in with the address details closer to the date you can be released on home detention curfew.
+  h2 What happens next
+  p Think about where you could live if you were released on #{SENT_HDCED}. We will give you a form to fill in with the address details closer to the date you can be released on home detention curfew.
 
-        p If you can, think of a second address in case your first choice is not suitable.
+  p If you can, think of a second address in case your first choice is not suitable.
 
-        p If you don’t have a place to stay, Bail and Accommodation Support Services (BASS) could help you find somewhere. We will pass your details on to BASS if you need it
+  p If you don't have a place to stay, Bail and Accommodation Support Services (BASS) could help you find somewhere. We will pass your details on to BASS if you need it

--- a/server/views/forms/forms-layout.pug
+++ b/server/views/forms/forms-layout.pug
@@ -1,0 +1,10 @@
+include includes/formsHeader
+
+doctype html
+html(lang="en")
+  head
+    link(href= domain + "/public/stylesheets/forms-pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+
+  body
+
+    block content

--- a/server/views/forms/includes/addressEntry.pug
+++ b/server/views/forms/includes/addressEntry.pug
@@ -1,4 +1,4 @@
-ul.byHand
+ul.byHand.no-break
   li Address line 1
   li Address line 2
   li Town or city
@@ -6,23 +6,26 @@ ul.byHand
   li Postcode
   li Telephone
 
-h2 Who is the main person living at this address?
-p We will contact them to make sure the address is suitable for you to live there. Provide the landlord’s details if no one else lives there.
+div.no-break
+  h2 Who is the main person living at this address?
+  p We will contact them to make sure the address is suitable for you to live there. Provide the landlord's details if no one else lives there.
 
-include mainOccupier
+  include mainOccupier
 
-h2 Does anyone else live at this address?
+div.no-break
+  h2 Does anyone else live at this address?
 
-p Yes &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;No
+  p Yes &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;No
 
-include otherResident
-include otherResident
-include otherResident
+  include otherResident
+  include otherResident
+  include otherResident
 
-h2 Have you ever been in trouble with the people living here or with the neighbours?
+div.no-break
+  h2 Have you ever been in trouble with the people living here or with the neighbours?
 
-p Yes &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;No
+  p Yes &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;No
 
-p If you answered yes, provide details:
+  p If you answered yes, provide details:
 
-div.box(style={height: '3cm'})
+  div.box(style={height: '3cm'})

--- a/server/views/forms/ineligible.pug
+++ b/server/views/forms/ineligible.pug
@@ -1,20 +1,11 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('not eligible')
 
-    block content
+  p We checked to see if you're eligible for release from prison on home detention curfew (tagging).
 
-      div
+  p By law you are not eligible because #{INELIGIBLE_REASON}.
 
-        +header('not eligible')
-
-        p We checked to see if you’re eligible for release from prison on home detention curfew (tagging).
-
-        p By law you are not eligible because #{INELIGIBLE_REASON}.
-
-        p You cannot challenge this because it is based on the law, not on a decision by prison staff.
+  p You cannot challenge this because it is based on the law, not on a decision by prison staff.

--- a/server/views/forms/no_time.pug
+++ b/server/views/forms/no_time.pug
@@ -1,19 +1,10 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('not enough time')
 
-    block content
-
-      div
-
-        +header('not enough time')
-
-        p We checked to see if you can be released from prison on home detention curfew (tagging).
-        p We cannot release you on home detention curfew as there is not enough time to carry out our checks before your release date.
-        p You will be released on #{SENT_CRD}.
+  p We checked to see if you can be released from prison on home detention curfew (tagging).
+  p We cannot release you on home detention curfew as there is not enough time to carry out our checks before your release date.
+  p You will be released on #{SENT_CRD}.
 

--- a/server/views/forms/optout.pug
+++ b/server/views/forms/optout.pug
@@ -1,32 +1,23 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('opt out')
 
-    block content
+  p I do not want to be considered for home detention curfew (tagging) because:
 
-      div
+  p
+    input#tick(type='checkbox')
+    label(for="tick") I have nowhere to stay
 
-        +header('opt out')
+  p Other reason:
+  div.box(style={height: '3cm'})
 
-        p I do not want to be considered for home detention curfew (tagging) because:
+  p If you don't have an address, Bail and Accommodation Support Services (BASS) will try to help you find somewhere to stay. Ask prison staff for more information.
 
-        p
-          input#tick(type='checkbox')
-          label(for="tick") I have nowhere to stay
+  p I understand that I will not be released until #{SENT_CRD}.
 
-        p Other reason:
-        div.box(style={height: '3cm'})
-
-        p If you don't have an address, Bail and Accommodation Support Services (BASS) will try to help you find somewhere to stay. Ask prison staff for more information.
-
-        p I understand that I will not be released until #{SENT_CRD}.
-
-        ul.byHand
-          li Signed:
-          li Name:
+  ul.byHand
+    li Signed:
+    li Name:
 

--- a/server/views/forms/postponed.pug
+++ b/server/views/forms/postponed.pug
@@ -1,25 +1,16 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('postponed')
 
-    block content
+  p We are still reviewing your case for release on home detention curfew (tagging).
 
-      div
+  p We will let you know our decision when we have all the information we need.
 
-        +header('postponed')
-
-        p We are still reviewing your case for release on home detention curfew (tagging).
-
-        p We will let you know our decision when we have all the information we need.
-
-        ul.byHand
-          li Signed:
-          li Name:
-          li Grade:
-          li Date:
+  ul.byHand
+    li Signed:
+    li Name:
+    li Grade:
+    li Date:
 

--- a/server/views/forms/refused.pug
+++ b/server/views/forms/refused.pug
@@ -1,25 +1,16 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('refused')
 
-    block content
+  p We have checked your case and decided that you will not be released on home detention curfew (tagging). This is because #{REFUSAL_REASON}.
 
-      div
+  p You will be released from prison on #{SENT_CRD}.
 
-        +header('refused')
-
-        p We have checked your case and decided that you will not be released on home detention curfew (tagging). This is because #{REFUSAL_REASON}.
-
-        p You will be released from prison on #{SENT_CRD}.
-
-        ul.byHand
-          li Signed:
-          li Name:
-          li Grade:
-          li Date:
+  ul.byHand
+    li Signed:
+    li Name:
+    li Grade:
+    li Date:
 

--- a/server/views/forms/unsuitable.pug
+++ b/server/views/forms/unsuitable.pug
@@ -1,27 +1,18 @@
-include includes/formsHeader
+extends forms-layout
 
-doctype html
-html(lang="en")
-  head
-    link(href= domain + "/public/stylesheets/pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+block content
 
-  body
+  +header('not suitable')
 
-    block content
+  p We checked to see if you're eligible for release from prison on home detention curfew (tagging).
 
-      div
+  p Although you are eligible by law, you are presumed unsuitable for the scheme because #{UNSUITABLE_REASON}.
 
-        +header('not suitable')
-        
-        p We checked to see if you’re eligible for release from prison on home detention curfew (tagging). 
+  p This means you would only be considered for home detention curfew in exceptional circumstances.
 
-        p Although you are eligible by law, you are presumed unsuitable for the scheme because #{UNSUITABLE_REASON}.
+  h2 Don't agree with this decision?</h2>
 
-        p This means you would only be considered for home detention curfew in exceptional circumstances.
+  p If you want to challenge this decision you need to follow your prison complaints process, although we'll only change our decision in exceptional circumstances.
 
-        h2 Don’t agree with this decision?</h2>
-
-        p If you want to challenge this decision you need to follow your prison complaints process, although we’ll only change our decision in exceptional circumstances.
-
-        p Ask prison staff about how to do this.
+  p Ask prison staff about how to do this.
 


### PR DESCRIPTION
Whether using PhantomJS or Puppeteer to generate PDF, you have to do some extra set-up to get the required shared libs installed for Docker environments.

While working on that and while migrating the licence PDFs it became clear that using PhantomJS is a bad idea because it is now unsupported (and doesn't handle page headers). 

Therefore have migrated the PDF generator to work with Puppeteer, which seems to be the favoured tool for this sort of thing. Most of that work is in https://www.npmjs.com/package/@ministryofjustice/express-template-to-pdf

Dockerfile now loads the shared libs that are required for Puppeteer/Chrome to work in Docker.

Changing the PDF generator engine has required some tweaks to the CSS to keep the forms looking correct.

Also factored out the common layout for the forms PDFs

NB also have to use a circleci node image that includes the chrome browser libs