### PR TITLE
LIC-1027 DM name missing off the DM notification: 

### DIFF
--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -1,4 +1,5 @@
 const { asyncMiddleware } = require('../utils/middleware')
+const { sendingUserName } = require('../utils/userProfile')
 
 module.exports = ({ licenceService, prisonerService, notificationService, audit }) => router => {
   router.get('/:destination/:bookingId', async (req, res) => {
@@ -38,7 +39,7 @@ module.exports = ({ licenceService, prisonerService, notificationService, audit 
         prisoner: res.locals.prisoner,
         notificationType: transition.notificationType,
         submissionTarget,
-        sendingUserName: req.user.username,
+        sendingUserName: sendingUserName(req.user),
         token: res.locals.token,
       })
 

--- a/server/utils/userProfile.js
+++ b/server/utils/userProfile.js
@@ -1,0 +1,9 @@
+module.exports = {
+  /*
+   * Extract the given name for a user. Expects a 'user' object - the object returned in the
+   * passport.authenticate callback.  This has name and username properties.
+   * The name property appears to be a single string like '<firstname> <lastName>'.
+   * So, if 'name' is a string use that, otherwise fall back to using username.
+   */
+  sendingUserName: user => (typeof user.name === 'string' && user.name) || user.username,
+}

--- a/test/routes/sendTest.js
+++ b/test/routes/sendTest.js
@@ -326,7 +326,7 @@ describe('send', () => {
               prisoner,
               bookingId: '123',
               notificationType: 'RO_NEW',
-              sendingUserName: sinon.match.any,
+              sendingUserName: 'ca last',
               submissionTarget,
               token: 'token',
             })
@@ -354,7 +354,7 @@ describe('send', () => {
               notificationType: 'CA_RETURN',
               submissionTarget,
               bookingId: '123',
-              sendingUserName: sinon.match.any,
+              sendingUserName: 'ro last',
             })
           })
       })
@@ -380,7 +380,7 @@ describe('send', () => {
               notificationType: 'DM_NEW',
               submissionTarget,
               bookingId: '123',
-              sendingUserName: sinon.match.any,
+              sendingUserName: 'ca last',
             })
           })
       })
@@ -406,7 +406,7 @@ describe('send', () => {
               notificationType: 'CA_DECISION',
               submissionTarget,
               bookingId: '123',
-              sendingUserName: sinon.match.any,
+              sendingUserName: 'dm last',
             })
           })
       })

--- a/test/utils/userProfileTest.js
+++ b/test/utils/userProfileTest.js
@@ -1,0 +1,23 @@
+const { sendingUserName } = require('../../server/utils/userProfile')
+
+describe('sendingUserName', () => {
+  it('should extract username from user', () => {
+    expect(sendingUserName({ username: 'A' })).to.eql('A')
+  })
+
+  it('should extract name from user', () => {
+    expect(sendingUserName({ username: 'A', name: 'B' })).to.eql('B')
+  })
+
+  it('should fall back to username when name is not a string', () => {
+    expect(
+      sendingUserName({
+        username: 'A',
+        name: {
+          familyName: 'C',
+          givenName: 'D',
+        },
+      })
+    ).to.eql('A')
+  })
+})


### PR DESCRIPTION
Favour the 'req.user.name' field over 'req.user.username' for sendingUserName