### PR TITLE
Move HDC-AP licence out of PDF service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 public
 assets/stylesheets/application.css
 assets/stylesheets/forms-pdf.css
+assets/stylesheets/licences-pdf.css
 lib/govuk_template.html
 govuk_modules
 node_modules/*

--- a/assets/sass/licences-pdf.scss
+++ b/assets/sass/licences-pdf.scss
@@ -1,0 +1,189 @@
+body {
+  padding-left: 0.5cm;
+  font-family: "nta", Arial, helvetica, sans-serif;
+  font-size: 14px;
+  line-height: 16px;
+  counter-reset: maincounter;
+}
+
+h1 {
+  font-size: 16px;
+}
+
+h2 {
+  font-size: 14px;
+}
+
+h3 {
+  font-size: 14px;
+}
+
+.center {
+  text-align: center;
+}
+
+small {
+  font-size: 12px;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.pre {
+  white-space: pre-wrap;
+}
+
+.conditions {
+  margin-left: 20px;
+  text-align: justify-all;
+}
+
+.entry {
+  font-weight: bold;
+}
+
+.pagebreak {
+  page-break-before: always;
+}
+
+.no-break {
+  page-break-inside: avoid;
+}
+
+table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  empty-cells: show;
+}
+
+table.wide {
+  width: 100%;
+}
+
+tr {
+  line-height: 25px;
+}
+
+table.compact tr {
+  line-height: 15px;
+}
+
+table.signature {
+  border: 1px solid grey;
+}
+
+td {
+  padding-left: 15px;
+  padding-right: 15px;
+
+}
+
+td.nopad {
+  padding-left: 0;
+  padding-right: 0;
+
+}
+
+table.noLeftPad td {
+  padding-left: 0;
+}
+
+table.lined td {
+  border: 1px solid grey;
+}
+
+ol.start {
+  counter-reset: maincounter;
+}
+
+ol.roman.start {
+  counter-reset: romancounter;
+}
+
+ol.start li, ol.continue li {
+  list-style-type: none;
+}
+
+ol.start li:before, ol.continue li:before {
+  content: counter(maincounter) ". ";
+  counter-increment: maincounter;
+}
+
+ol {
+  padding-left: 5px;
+  width: 95%
+}
+
+li {
+  margin-top: 10px;
+  text-align: justify;
+}
+
+li:empty {
+  display: none;
+}
+
+ol.roman li {
+  padding-left: 20px;
+  list-style-type: none;
+}
+
+ol.roman li:before {
+  content: counter(romancounter, lower-roman) ". ";
+  counter-increment: romancounter;
+}
+
+ul.midCondition {
+  padding-bottom: 10px;
+}
+
+ul.disc li {
+  list-style-type: disc;
+}
+
+ul.disc li:before {
+  content: none;
+}
+
+img {
+  display: block;
+}
+
+.placeholder-image {
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOQAAAEdCAYAAAAcvcvoAAAAAXNSR0IArs4c6QAAGdFJREFUeAHtXWdzG7uShbKonGVLlhWd7ru1f+19vB9ebW1t7af9efuurWAly3JQjpRERW+fkWnTskjODGeGDeB01YgUJwGncYAG0Gg0/POvf30zFCJABFQg0IxU/O9//6eKxDARRMBnBP76r/8xjT4DwLwTAW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNAAnptfqZeW0IkJDaNML0eI0ACem1+pl5bQiQkNo0wvR4jQAJ6bX6mXltCJCQ2jTC9HiNQLPXubc483d3d+bbt2/BcSefDZKXhsZG04ijAf9RbESAhFSmNRDtolAwhYuCuby6MldyFAqX5vr62tze3prrmxtzI0c1aWpqMi3NzaZZjpaWZtPa2mra2tpM2/fPXEfONMs1FF0IkJB11AcIdprPm7Oz8+DzQkhYEDImIXg2DnN5WfZxIGculzOdnR2mu7vLdHV2BeQtewNPpI4ACZk6xD9fcCut3+nJqTk6PjbHxyfm/OLi58k6fEMLjAPpKUp7e7vp6ek2fb09prenJ2hhi+f4mT4CJGTKGMPkPDg4NAdHR+ZEyIh+n2ZBC41jZ2c3SGZXV6cZ6O83g4MDpl1MXkq6CJCQKeCLPt7e/oHZ29sPTNEUXpHZI/P5M4Pj4+Yn0yHm7dDQYHDA3KUkjwAJmSCmR0fHZmd31xwcHqlvCeNkGyY2iImjr6/XjAwNmYGBftPAUd04cD56Dwn5KCzhf0S/cFfMu63tnWB0NPyddl+JygdHa2uLGR0ZCQ6M5lJqQ4AIxsQPZunXrW2zJccNRjM9laura7P56bP5/PmLGR4ZNuNPnwTTK57CUXO2SciIEIKIn798NdvSIqJ1pNwjAOcEYILBoOHhoYCYGLGlREOAhAyJFwocWkO0BD63iNXgwigySLm7uxeYsRPPxjh1Ug20kvMkZAkY5b5ixPTj5qbMsV+Vu4S/P0AAxNza3paR5j0zPj5mnj4Z5eDPA4we+5eEfAyV77/BZW39wweZOD+pcBVPVUIA1sTGx81g9HlmaipwOqh0ve/nSMhHSgCm7mGafpJD+0T+I8lX+RPcAt8tLJoR6V9OPp+gGVtGSyTkA2BQcJZXVwP/0gen+G8CCOxI3xIWx8z0lOmXuUzKrwiQkCV4YBoD5hVbxRJQUvgKd8LFpfdmdHTETElriSVjlHsESEjBAf2c1dW1wMOGBSM7BDBNAmf7ly/nTI5TJAHw3ldNZ2dn5u+/35GM2fHwlzfBHQ/47+3v//K7r/943ULuHxyYldV1g0XBlPohAAeL5ZW1oN+OAR+fxVtCYgQVLl8UPQh8+bplLqTFfDE3axDxwEfxzmTFlMbq2jrJqLS0H4rD+tv5BQldcq00hekmyytCwv1taWlZJqn30kWVT68JgfPzC5mzXPBq9UwRMG8IiX7KwuKSOZSV+xT9CMBL6t38ojk/P9ef2ART6AUhMWiDeS+E0KDYgwAi7b1bWBJS1jf2UJaIOU/IezIuk4xZlqoE34XlbvPiclfvgGAJZqnio5wmJAZwlt6vmOMTOodXLAXKTyIWLUgJM9Z1cZqQazKaWhri0HVlupy/6+sbs7C0ZK7EjHVZnCUkAjFxNNWtoosWcnHx/X0AaLey9iM3ThISblgIs0FxD4EzGXV9v7zqXsa+58g5QiIs/+raB2cVxoyZoBuCVTkuilOEROd/aXmZvqkultQHeYKbnYsO6U4RckWWUDHuzYOS6/C/sISwU5hL4gwhsbgYgXsp/iCAOeb3yysGLpGuiBOEREff1T6FKwUtrXzAi2dj42Naj8/8udYTMli9IWsaGXYj87Kj5oXYxsEV68h6QiI6HFpIit8IrEm4zmCDWsthsJqQiBCHhcYUIoDBPBe6LVYTcn1jg6YqufgDgW3ZwuD0NP/jfxu/WEtI7EqMbcEpRKAUgfUPG6X/WvfdSkJimNsF88S60mJBgjGegEEeW8VKQmIXqsKl+0txbC1U9U73JwleZusAj3WEBNBf6Dhe7zKv+v1woYRrnY1iHSHhkQPAKUSgEgJfhZBYQ2mbWEXIoHW0tOazrWDYnl4ENbNxCZ5VhMSCY1v7BrYXcBvTv7OzYxCTxyaxhpBwkfu6ZWe/wKYC4VJa0UraNuJqDSH3JQoAl1a5RJds8oJt1W1aDWINIbe3d7PRIN/iFAIY2Nnfs2dnLSsIiUWoJ6cMcuwUUzLMDFzqbBErCImNPSlEIC4Cp/m8NVsSWEHIvf2DuLrgfUQgQMCWkKDqCQkHcuzxQCECtSBgS6WunpD7h4e16IH3EoEAAVTqNkSxV0/IA5qrpFRCCOxbUJZUExKdcfqtJlQa+RhzeKh/b1DVhHQlcBG5oAMBVO6o5DWLbkIeM86q5sJjY9q0V/JqCXkj6x7z+TMbdc40K0ZA+5b2agmZV25aKC5zTFoFBLAZk+YVQ2oJaXv0sAplgqfqjMCJ4sh0egnJFrLOxdbd158q9otWS0j2H90lRL1zlj/TOzahkpBY96jZzq93geL7a0MA/UitopKQF4ULrXgxXQ4ggLAel1dXKnOikpDYYoxCBNJE4EJpGVNJyIJju+KmWbD47HgInF/orPRVElKrORFP9bxLIwKXSiPfqyRkocBtAjQWYpfSpHUrCpWEvFLa4XapQPqel4LsLapR1BES0x13Ek+TQgTSROBKaRQKdYS0LdJ0moWGz04PAVT6Git+fYSUFpJCBLJAQGOsJn2EtHDHoiwKD9+RPAIarTF1hPwmuyNTiEAWCGDNrTZRR0ib9mHQpkymJxoCd3f6Kn91hGQLGa1Q8er4CGgsayRkfH3yTssR+KZwek0dIRsaLNcyk28NAvoMVmPUEbKxUV2SrClgTGg0BBoV1v7qSn+DYRMZrVjx6rgINDTqK2vqCNnYpC5JcfXN+5Qj0MAWsrqGmpqaql/EK4hAAgiQkCFAbCYhQ6DES5JAoLm5OYnHJPoMdfZhS0tLohnkw4hAOQQ0WmPqCIlRVo2jX+WUyt/tRaCFLWQ45bW0spUMhxSvqgUBtpAh0WttbQ15JS8jAvEQ0FrG1JmsgLeNhIxXynhXaARalVphKgmptfYKrW1eqB6B1hadVhgJqb7oMIFpINDWRkKGxjWXaw99LS8kAnEQ0GqFqWwh29tIyDiFjPeERyDXrrOM6SRkexvnIsOXLV4ZA4F2EjIaaloBi5YLXq0VgXap9DWKyhYSQOVyOY14MU0OINDe1mY0OpYDWrWE7OzscED1zIJGBDQPGpKQGksM05QqAh0deit7tYTUDFqqpYUPTx2BThIyOsatsgyLS7Gi48Y7qiPQobg7pLaFBKzsR1YvXLwiGgJY3qd1DhI5UU3Inu7uaGjzaiJQBYGurs4qV9T3tGpCagevvqrj2+Mg0NVJQsbBLbinu6sr9r28kQg8hoD2MqW6hYS9r3lE7DGF8zfdCHTSZK1NQd3sR9YGIO/+gUCbeOhoX/yuuoUEkn19PT8A5RciUAsCNgwSqiekDSDWUkh4b3YI9PToH7VXT0hEBtM+MpZdkeKbakHAhspdPSGhABtqtloKCu9NHwH0H7UuuSrNvRWE7OvrLU0zvxOByAj09tgxFmEFIXsETI1BbSOXCt5QNwRsGRy0gpDYxa+v144arm4lji+uiEBvrx1WlhWEBNJ9fX0VAedJIlAOge7uLmPLrmoWEdKOGq5coeDv9UOg36LK3BpCYn0kajoKEYiKQH+/PdaVNYSEEgYHBqLqgtd7jgCiF3ZYFDDNKkLaVNN5zgM12R+wqHUEaFYREuH7GEVATVm3IiED/f1WpLOYSKsIiUTTbC2qjp/VELBx3ME+Qg6yH1mtIPL8PQKDFpYV6wgJs5WjraRcGARIyDAoJXDN0OBgAk/hI1xGIKi4LQwBY10LiUKEmk/r3gwuF3Kb8mZj6wh8rSRkS3Oz+LbSc8cmgmSd1qEhO60oKwkJ5Y6ODGetY77PEgQwNWaTM0AprNYSsk8mfDGsTSECDxEYGba3sraWkFiSZatZ8rAA8f/kEGhsaLC6XFhLSKhwdGQkOU3ySU4gMDDQb81Sq8cAt5qQiJFiS2iGx8Dnb8kjYLO5CjSsJiQy8GSUrSRwoBgJYtVuei2PLGE9IfvFRNEejZpkyQaBp09Gs3lRim+xnpAY3BnhFEiKRcSOR2MfmGFL5x5LEbaekMgM5iTpuVOqVv++g4wuRCZ0gpDY+tyF2tE/GiWX4ycOmKtAwwlCIiNjT5/gg+IhAgikbatnzkN1OUPInMRNoX/rQ/X68b8LgzlFTTlDSGRobIytZFGxvnx2dHQ4VRE7RUg4CTDmji9UvM+na10VpwgJFT0bH/erRHqcW+xoNWRhmI5KKnOOkAj719GRq5RnnnMEAbSOrk13OUdIlDW2ko4wrkI24J3l4ppYJwk5KO50GHWluIvAUwdbR2jLSUIiYxPPxvBBcRCB1tYWM+roogJnCYmAyhxxdZCNkqXxsTGDhcguirOEhLKeP3vmos68zhPWwLrYdywq1WlCwqWKC5iLqnbjEwN2ro2slmrGaUIioxMTnJcsVbjN3+Gv6voiAucJ2S3Rq7lBj800/Jn2ycmJn/84+s15QkJvk8+fOTsI4Gi5/C1b6H74sHjAC0LCxQrzVhQ7EcB46tTz53YmPmKqvSAkMBkfHzOYv6LYh8CoLD7O5drtS3iMFHtDyCaJufJ8wv0+SIwyoPqW5uYmMyGVqS/iDSGhUIzQ9fR0+6JbJ/KJueRm2VzJF/GKkFDqzPSU0/NYLhVcjJC76iJXTk/eETInwXRdW9RaTrk2/46BnJnpSZuzECvt3hESKD2TPglcsCh6EUAUOYTn8E28JCSC6sJ0pehEAJXl8wk//ZC9JCSKIXxcuS+ITkKiskSl6aP4mevvmp58PkHTVVmph6nq84IArwlJ01UXG2GqTnpqqhY14TUhAQJqY5cC7RYVa+Pn7PS0t6ZqUV/eExJAwHTt9HBEr1gINHxi5JtOGw7H1IlSyLDg9eWLWe9r5yiYJXltd3eXxEDiulVgyhbye8nC7rvTk36sKEiSTLU+q7mpybyYnan1Mc7cT0KWqBIbv7q+Ir0kuyq+zs5MGyyPo9wjQEI+KAmYA/PRQ+QBDJn8CxfGAYmhS/mJAAn5E4vgG6ZCXkl/Est+KOkh0NvbEwympfcGO59MQj6iN/QnX8zNPnKGPyWBAExU4vs4kiTk47gE8VswHUJJFoF7C2TOtHi0xjEKgiRkBbTQx3E5KG+FrKd2CtNLjChfHl4Ssjw2wZnp6Skvop1VgSGR09NTk6a/ry+RZ7n6EBKyimaxUBa1OoL0UuIjgJU1XF1THT8SsjpGpkkmr9+8eWUQbYASHYGhwUGD1pFSHQESsjpGwRWtLS3m9euXBhuFUsIj0C87Ws/NzYS/wfMrScgIBaBdhuvRUra0+BMFLQI8v13aJ3ONr17MGZj9lHAIkJDhcPpxFczWP968FlIy6PIPUB75gmVtr16+YIS/R7Cp9BMJWQmdMucwwPPnH68lEjrN18cgwh4cMO99DcPxGCZhfyMhwyL14Dp48/xDzFc6Rv8KzKD4pr5+9YKbG/0KS+j/SMjQUP1+YUBKaSk5JXKPzcjwsEwRSZ/R0e3Gfy8Byf9CQtaIKUZd//zHG4Pt0nwWhG2cnZnyGYJE8k5CJgAj5ilfv3rppZsd+oloFcfHniaAJB/B8fuEysB96Psp2TYtZzY+bppv374l9GS9j2lrazUv5+ZMV1en3kRaljISMmGFIYIdNol5v7JqLi8vE366nsfBREfoDZ92psoCfZqsKaCMFuM//vzDSad0WAJYlvZGTHSSMfnCwxYyeUyDJ6KwvpG5uO2dHTFhP5nb29uU3pTdYzGaPDs7bbo6aaKmhToJmRay3587OjIStJRrHzbM0dFxym9L5/GYxkDcVAzccEojHYyLTyUhi0ik+AnnAZh4u3v7ZnPzk7m8ukrxbck+Gi5wU1PPOdeaLKxln0ZCloUm+RMIMQlPli9ft8znL1/N3d1d8i9J6Inw2Z2UOLX9ns+vJgRn6MeQkKGhSuZCzNvB/BsZHhJSbpmd3V1VxAQRnzJ0STLKjvEUpwmJgZTz8wtzUbgwhcJlMA1xdX2d2gALFuKG3S4djunTYgpOPBszW9s75uvWtrm5uYmhwmRuwVTN2JjESe2PFicVGK+tfxCMC8kkpOQpcLjAOlSY/NgZC3O8GFjC766KM4TERHz+7MycnuZNPp83Z+fnAQmzVNzZ2bk5kzQgGnfYlQ4YjUWLOSYDJoeHh9Ji7pljGfzJwq0AS8hgQg9Lax1n5BQkXFx6nznOICc2R+qSSgT7giDtrgw2WU3I84uLYOTy+OTEnJycqjD99vYPzMVFwbx8OWewoDmsNMpI5uDAQHBcSyu+f3Bojo+PzbHkK8kpEzjEY+Ewgk3V4n97cHhkVlbXEk1bWKxg7eAARhBUftg5CwNQyJPNzv7WERItIAr90dGRKSj1hEHr/PfbeTMzPRW0QEGpifAHLVdpUKhTafGRb7S+qIRQGMMMCMEsRp8wl2uXlqTb9MjR2lrbwmpYInANhImtRYAFppRwIG2oCPukwhkaHAhaUC3pDJMOKwhZENMIptyeTBvYMmWA/uD75RXZvGco6CvW0u9B/w5HqeD513Lc3tya27t7pwOYbXgPdpQCGZM241DRLK+siQVwUZoUdd9RUW9tbwcHVuMMyeg2BtFgHWgXtYRETQyTZFsGPE5OT7XjWDZ9u3t70rqdmhlZmgSTKilB3xNHFoL+7BeZptn89Nk6p3lU4JhiwgELYVTCUaLfnHRllZQestFohNTeyKgdSLglJhFGRF0Q1NjzC0tiQg2KH+gzq0J/HB+fmPWNj+pbxTDlBBU7jg10CWQRAMgJa0KTqCEkTDDUYts7u3UZKMhCKXv7++ZQ+r4YVcWqEK21NLDAShX0x4oDJ1ngk9U7UNF/FI8plDf01TFVlZW1US2PdSckOuTwXMGR5GhitYzX6zzyiIIOKwDzfgh7oYmYMPG+ii6QvjvH13RCFyAl5oFBShxhp6vSKj91JSR8O1FTXVnk25mUImDGrq1vBAVi7OnTYNChnoUBA2eoFDF45sPi6lI9gpjoH8M6m5RQJBgEqpfUhZCYUF5dWw+G8uuVcS3vvby8MuuyEmRTKqb70cDhzHaHAvGOZK4TLYStK1GS1CMahmWZW92SJXNw7sCUUdaSKSFtHq1LWzEYzAIxcMALZWhowPSLG1vShQJm6Ik4UmBif1/mc+vprpc2pnGfjznf//v3W3FrHA88qLAoOyvJjJAwiVD75PNnWeXN2vdgvu/s47n0NT+JH2ereKH0mG5xD+uUSATwQoli2qLWhzMBcMcIIwpbGKcCa8FLKOGwHtCdOhB3xhezs4EvbUKPrviYTAgJzxo4IPswaFMR7RgnYdLuSr8OR1Ew6Y8Jb+wxgtHBIkFRiIAxWtsruQ/9VJKviFq8T1Rk/377zsxOi9eVeP6kLakTEiOKGCygJIcAWj0fB8KSQzDak1DJIWjZmLgupr3NfWqEDDKxvBoMGkTLPq8mAjoRQMOC5XzYwLcWV8hKuUsl6tz19Y15N79IMlZCnuesRACj0ijbKONpSOKEhIfH2/n5YD1iGgnmM4lAvRHAoNvb+QXxZko+NlKihISXxzvx2cTyIAoRcBkBzBrMLywmvvooMUJiUS0cqF2O1u1yAWPeoiNQXDSQpPmaCCExgLOwiFAOycdViQ4T7yAC2SGAMr+wuJTYlF4ihMSiVdjVFCLgIwLFhdtJ5L1mQsKbAUuKKETAZwTAAXChVqmJkPCHxPIVChEgAibgAjhRi8QmJDxFsGKDQgSIwE8EwImrq/iRLmITcnXtA1cK/NQDvxGBAAGsnlldj99QxSIktliDxwKFCBCB3xHA2lIsdo4jkQmJ0IMfNz/HeRfvIQLeIIABnjhrTSMTMu6LvNEEM0oEBAGQMc6oayRCYr5lJ2ZTTC0RAd8QgNkadX4+EiE3aar6VqaY3xoRQPCsKBKakNhXgg4AUaDltUTAyI5mR7InS3gvttCE3Pz0hfgSASIQA4EorWQoQsKBlq1jDE3wFiIgCIA7YZckhiJk3DkVaoMIEIF7BDB3H0aqEhJxPBHNmkIEiEB8BBA1MExE+KqEPJQt4eJMcMZPOu8kAu4hAIcaxHitJlUJuX9wUO0ZPE8EiEAIBBApvppUJCSC7B6KXx6FCBCB2hEAl6oFrq5IyDAPqD2ZfAIR8AMBkLHapkYVCXnESAB+lBTmMjMEqlmcFQmJzVkoRIAIJIfAyelJxYeVJSSCwIadzKz4Bp4kAkTgBwLgFOIXl5OyhGTrWA4y/k4EakPg9KS85VmWkPl8vra38m4iQAQeReBUFmqUk4Z//vUvbGxMIQJEQAEC/w/mtrl2oMJMqgAAAABJRU5ErkJggg==');
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-origin: content-box;
+  vertical-align: bottom;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+
+.tinyPaddingBottom {
+  padding-bottom: 5px;
+}
+
+.smallPaddingBottom {
+  padding-bottom: 10px;
+}
+
+.midPaddingBottom {
+  padding-bottom: 20px;
+}
+
+
+.paddingBottom {
+  padding-bottom: 30px;
+}
+
+.largePaddingBottom {
+  padding-bottom: 50px;
+}
+
+.box {
+  border: 1px solid grey;
+  padding: 10px;
+}

--- a/bin/build-css
+++ b/bin/build-css
@@ -9,3 +9,6 @@
 ./node_modules/node-sass/bin/node-sass $@ \
     assets/sass/forms-pdf.scss \
     assets/stylesheets/forms-pdf.css
+./node_modules/node-sass/bin/node-sass $@ \
+    assets/sass/licences-pdf.scss \
+    assets/stylesheets/licences-pdf.css

--- a/server/config.js
+++ b/server/config.js
@@ -60,33 +60,46 @@ module.exports = {
   sessionSecret: get('SESSION_SECRET', 'licences-insecure-default-session', { requireInProduction: true }),
 
   pdf: {
-    pdfServiceHost: get('PDF_SERVICE_HOST', 'http://localhost:8081'),
-    taggingCompanyTelephone: get('TAGGING_CO_PHONE', '01234 567890'),
-  },
-
-  formsDateFormat: 'Do MMMM YYYY',
-  formsFileDateFormat: 'YYYYMMDD',
-  formTemplates: {
-    eligible: 'Eligible',
-    ineligible: 'Not eligible',
-    unsuitable: 'Not suitable',
-    address_checks: 'Information about address checks',
-    address: 'Address form',
-    address_unsuitable: 'Address unsuitable',
-    optout: 'Opt out',
-    postponed: 'Postponed',
-    no_time: 'Not enough time',
-    refused: 'Refused',
-    approved: 'Approved',
-  },
-
-  pdfOptions: {
-    format: 'A4',
-    margin: {
-      top: '80px',
-      bottom: '70px',
-      left: '50px',
-      right: '30px',
+    licences: {
+      pdfServiceHost: get('PDF_SERVICE_HOST', 'http://localhost:8081'),
+      taggingCompanyTelephone: get('TAGGING_CO_PHONE', '01234 567890'),
+      localTemplates: ['hdc_ap'],
+      pdfOptions: {
+        format: 'A4',
+        margin: {
+          top: '80px',
+          bottom: '70px',
+          left: '50px',
+          right: '30px',
+        },
+        displayHeaderFooter: true,
+      },
+    },
+    forms: {
+      formsDateFormat: 'Do MMMM YYYY',
+      formsFileDateFormat: 'YYYYMMDD',
+      formTemplates: {
+        eligible: 'Eligible',
+        ineligible: 'Not eligible',
+        unsuitable: 'Not suitable',
+        address_checks: 'Information about address checks',
+        address: 'Address form',
+        address_unsuitable: 'Address unsuitable',
+        optout: 'Opt out',
+        postponed: 'Postponed',
+        no_time: 'Not enough time',
+        refused: 'Refused',
+        approved: 'Approved',
+      },
+      pdfOptions: {
+        format: 'A4',
+        margin: {
+          top: '80px',
+          bottom: '70px',
+          left: '50px',
+          right: '30px',
+        },
+      },
     },
   },
 

--- a/server/data/healthcheck.js
+++ b/server/data/healthcheck.js
@@ -17,7 +17,7 @@ function dbCheck() {
 }
 
 function pdfApiCheck() {
-  return serviceApiCheck('pdf', `${config.pdf.pdfServiceHost}/health`)
+  return serviceApiCheck('pdf', `${config.pdf.licences.pdfServiceHost}/health`)
 }
 
 function nomisApiCheck() {

--- a/server/routes/config/pdf.js
+++ b/server/routes/config/pdf.js
@@ -3,22 +3,27 @@ module.exports = {
     {
       id: 'hdc_ap_pss',
       label: 'AP PSS HDC Licence',
+      version: '1.0',
     },
     {
       id: 'hdc_yn',
       label: "HDC Young Person's Licence",
+      version: '1.0',
     },
     {
       id: 'hdc_ap',
       label: 'AP HDC Licence',
+      version: '1.0',
     },
     {
       id: 'hdc_pss',
       label: 'HDC PSS Notice of Supervision',
+      version: '1.0',
     },
     {
       id: 'hdc_u12',
       label: 'HDC Under 12 month licence',
+      version: '1.0',
     },
   ],
 }

--- a/server/routes/forms.js
+++ b/server/routes/forms.js
@@ -1,6 +1,11 @@
 const moment = require('moment')
 const { asyncMiddleware } = require('../utils/middleware')
-const { formTemplates, formsDateFormat, pdfOptions, domain } = require('../config')
+const {
+  pdf: {
+    forms: { formTemplates, formsDateFormat, pdfOptions },
+  },
+  domain,
+} = require('../config')
 const { curfewAddressCheckFormFileName } = require('./utils/pdfUtils')
 const { isEmpty, getIn } = require('../utils/functionalHelpers')
 

--- a/server/routes/pdf.js
+++ b/server/routes/pdf.js
@@ -3,6 +3,12 @@ const { asyncMiddleware } = require('../utils/middleware')
 const { templates } = require('./config/pdf')
 const versionInfo = require('../utils/versionInfo')
 const { firstItem, getIn, isEmpty } = require('../utils/functionalHelpers')
+const {
+  domain,
+  pdf: {
+    licences: { pdfOptions, localTemplates },
+  },
+} = require('../config')
 
 module.exports = ({ pdfService, prisonerService }) => (router, audited) => {
   router.get(
@@ -72,11 +78,6 @@ module.exports = ({ pdfService, prisonerService }) => (router, audited) => {
     })
   )
 
-  function getTemplateLabel(templateName) {
-    const templateConfig = templates.find(template => template.id === templateName)
-    return getIn(templateConfig, ['label'])
-  }
-
   router.get(
     '/missing/:section/:templateName/:bookingId',
     asyncMiddleware(async (req, res) => {
@@ -107,14 +108,74 @@ module.exports = ({ pdfService, prisonerService }) => (router, audited) => {
     asyncMiddleware(async (req, res) => {
       const { bookingId, templateName } = req.params
       const { licence, postRelease } = res.locals
-      logger.debug(`GET pdf/create/${bookingId}/${templateName}`)
+      logger.debug(`GET pdf/create/${templateName}/${bookingId}`)
 
-      const pdf = await pdfService.generatePdf(templateName, bookingId, licence, res.locals.token, postRelease)
+      const qualifiedTemplateName = `${postRelease ? 'vary_' : ''}${templateName}`
 
-      res.type('application/pdf')
-      return res.end(pdf, 'binary')
+      if (localTemplates.includes(qualifiedTemplateName)) {
+        return createPdfLocal(res, qualifiedTemplateName, bookingId, licence, res.locals.token, postRelease)
+      }
+
+      return createPdfRemote(res, qualifiedTemplateName, bookingId, licence, res.locals.token, postRelease)
     })
   )
 
+  async function createPdfRemote(res, templateName, bookingId, licence, token, postRelease) {
+    const pdf = await pdfService.generatePdf(templateName, bookingId, licence, token, postRelease)
+
+    res.type('application/pdf')
+    return res.end(pdf, 'binary')
+  }
+
+  async function createPdfLocal(res, templateName, bookingId, licence, token, postRelease) {
+    const pdfData = await pdfService.getPdfLicenceData(templateName, bookingId, licence, token, postRelease)
+
+    const filename = `${pdfData.values.OFF_NOMS}.pdf`
+    const headerTemplate = getHeader(pdfData)
+    const footerTemplate = getFooter(pdfData, templateName)
+
+    return res.renderPDF(
+      `licences/${templateName}`,
+      { domain, ...pdfData.values },
+      { filename, pdfOptions: { ...pdfOptions, headerTemplate, footerTemplate } }
+    )
+  }
+
   return router
+}
+
+const licencePdfHeaderFooterStyle =
+  'font-family: Arial; font-size: 10px; font-weight: bold; width: 100%; height: 15px; text-align: center; padding: 10px;'
+
+function getHeader(pdfData) {
+  return `
+    <span style="${licencePdfHeaderFooterStyle}">
+      <table style="width: 100%; padding-left: 30px;">
+        <tr>
+          <td style="text-align: center;">Name: ${pdfData.values.OFF_NAME}</td>
+          <td style="text-align: center;">Prison no: ${pdfData.values.OFF_NOMS}</td>
+          <td style="text-align: center;">Date of Birth: ${pdfData.values.OFF_DOB}</td>
+        </tr>
+      </table>
+    </span>`
+}
+
+function getFooter(pdfData, templateName) {
+  const templateLabel = getTemplateVersionLabel(templateName)
+  return `
+      <span style="${licencePdfHeaderFooterStyle}">
+        Version: ${pdfData.values.VERSION_NUMBER}, ${pdfData.values.VERSION_DATE}
+        <br/>
+        Page <span class="pageNumber"></span> of <span class="totalPages"></span> - ${templateLabel}
+      </span>`
+}
+
+function getTemplateLabel(templateName) {
+  const templateConfig = templates.find(template => template.id === templateName)
+  return getIn(templateConfig, ['label'])
+}
+
+function getTemplateVersionLabel(templateName) {
+  const { label, version } = templates.find(template => template.id === templateName)
+  return [label, version].join(' v')
 }

--- a/server/routes/utils/pdfUtils.js
+++ b/server/routes/utils/pdfUtils.js
@@ -1,5 +1,9 @@
 const moment = require('moment')
-const { formsFileDateFormat } = require('../../config')
+const {
+  pdf: {
+    forms: { formsFileDateFormat },
+  },
+} = require('../../config')
 
 function curfewAddressCheckFormFileName(prisoner) {
   const fileDate = moment().format(formsFileDateFormat)

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -1,6 +1,10 @@
 const moment = require('moment')
 const { isEmpty, getIn, mergeWithRight } = require('../utils/functionalHelpers')
-const { formsDateFormat } = require('../config')
+const {
+  pdf: {
+    forms: { formsDateFormat },
+  },
+} = require('../config')
 const {
   requiredFields,
   refusalReasonlabels,

--- a/server/services/utils/pdfFormatter.js
+++ b/server/services/utils/pdfFormatter.js
@@ -18,7 +18,7 @@ function formatPdfData(
   const conditions = getConditionsForConfig(licence, templateName, 'CONDITIONS')
   const pssconditions = getConditionsForConfig(licence, templateName, 'PSSCONDITIONS')
   const photo = image ? image.toString('base64') : null
-  const taggingCompany = { telephone: config.pdf.taggingCompanyTelephone }
+  const taggingCompany = { telephone: config.pdf.licences.taggingCompanyTelephone }
   const curfewAddress = pickCurfewAddress(licence)
 
   const allData = {

--- a/server/views/licences/hdc_ap.pug
+++ b/server/views/licences/hdc_ap.pug
@@ -1,0 +1,277 @@
+include includes/licenceHeader
+
+doctype html
+html(lang="en")
+  head
+    link(href= domain + "/public/stylesheets/licences-pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+
+  body
+
+    block content
+
+      +heading('LICENCE')
+
+      include includes/offender
+
+
+      ol.start
+        li
+          | Under the provisions of Chapter 6 of the Criminal Justice Act 2003 you are being released on licence.
+          | You will be subject to a Home Detention Curfew. The objective of the Home Detention Curfew is to help you
+          | manage your return into the community. You will also be under the supervision of a nominated officer. The
+          | objectives of this supervision are to (a) protect the public, (b) prevent re-offending and (c) help you to
+          | resettle successfully into the community.
+
+        li
+          | Your Home Detention Curfew commences on
+          =" "
+          span.entry #{SENT_HDCAD}
+          |  and expires on
+          =" "
+          span.entry #{SENT_CRD}
+
+        li
+          | Your supervision commences on
+          =" "
+          span.entry #{SENT_HDCAD}
+          |  and expires on
+          =" "
+          span.entry #{SENT_LED}
+          |  unless this licence is previously revoked.
+
+        li
+            | On release from prison (including, if applicable, any release from detention under the Immigration Act 1971
+            | during the currency of your licence, whether or not leave has been granted for you to remain in the United
+            | Kingdom), unless otherwise directed by your supervising officer, you must report without delay to:
+            br
+            br
+            span.entry #{REPORTING_NAME}
+            br
+            span.pre.entry #{REPORTING_ADDRESS}
+            br
+            br
+            | At
+            =" "
+            span.entry #{REPORTING_AT}
+            |  on
+            =" "
+            span.entry #{REPORTING_ON}
+
+
+
+
+      div.smallPaddingBottom
+
+      h2 Home Detention Curfew
+
+      ol.continue
+        li The address(es) to which you are curfewed are:
+          br
+          br
+          span.pre.entry #{CURFEW_ADDRESS}
+          br
+          br
+          | Details of curfew times are shown below at paragraph 7.
+
+        li
+            | On the day of your release, you will be subject to curfew at your curfew address from
+            =" "
+            span.entry #{CURFEW_FIRST_FROM}
+            |  until
+            =" "
+            span.entry #{CURFEW_FIRST_UNTIL}.
+            |  The contractor will visit you at this address before
+            | midnight during this period in order to fit you with the tag. You must show the contractor this copy of the
+            | licence to confirm your identity. Your curfew will then run until the curfew finish time the following morning.  
+            | On your last day of curfew the contractor will visit you to remove the tag and monitoring equipment. This will
+            | take place in the last two hours of your last curfew period; i.e. between 10pm and midnight.
+
+        li.no-break After your day of release, you are required to remain at your place of curfew during the following hours:
+          br
+          br
+          table.compact
+            tr
+              td Monday
+              td from
+              td.entry #{CURFEW_MON_FROM}
+              td until
+              td.entry #{CURFEW_MON_UNTIL}
+
+            tr
+              td Tuesday
+              td from
+              td.entry #{CURFEW_TUE_FROM}
+              td until
+              td.entry #{CURFEW_TUE_UNTIL}
+
+            tr
+              td Wednesday
+              td from
+              td.entry #{CURFEW_WED_FROM}
+              td until
+              td.entry #{CURFEW_WED_UNTIL}
+
+            tr
+              td Thursday
+              td from
+              td.entry #{CURFEW_THU_FROM}
+              td until
+              td.entry #{CURFEW_THU_UNTIL}
+
+            tr
+              td Friday
+              td from
+              td.entry #{CURFEW_FRI_FROM}
+              td until
+              td.entry #{CURFEW_FRI_UNTIL}
+
+            tr
+              td Saturday
+              td from
+              td.entry #{CURFEW_SAT_FROM}
+              td until
+              td.entry #{CURFEW_SAT_UNTIL}
+
+            tr
+              td Sunday
+              td from
+              td.entry #{CURFEW_SUN_FROM}
+              td until
+              td.entry #{CURFEW_SUN_UNTIL}
+
+
+        li
+          | Your compliance with the conditions of the Home Detention Curfew will be monitored by the electronic
+          | monitoring contractor. You must provide the contractor with access to the curfew address to install and check
+          | the monitoring equipment and electronic tag. Such visits will be made during your curfew hours but not between
+          | midnight and 6.00am. However, the contractor may visit the curfew address between midnight and 6:00am in
+          | order to investigate a reported violation.
+
+        li
+          | The monitoring equipment will usually operate via the mobile cellular network and will only need a dedicated
+          | telephone line to be fitted if the mobile signal is poor at the curfew address. You will be responsible for
+          | meeting the cost of the small amount of electricity used by the monitoring equipment at your curfew address.
+          | It is your responsibility to ensure that there is an electricity supply available during your time on
+          | curfew.
+
+        li
+          | In the event of a dedicated telephone line needing to be installed you must agree to the installation at
+          | your curfew address for use by the supplier. The supplier will notify you of a time and a date and you must be
+          | present, and provide access to, the curfew address at the notified time to allow installation to take place.
+          | The installation will normally take place during standard working hours and is fully paid for by the
+          | supplier.
+
+        li.no-break
+          | While on Home Detention Curfew you may be liable to recall to prison if you breach the condition of this
+          | licence relating to the curfew.  You will be in breach of this condition if:
+          ol.roman.start
+            li You are absent from your curfew address during the specified curfew hours;
+            li You commit violence against or threaten the contractor or any of his staff with violence;
+            li You damage or tamper with the monitoring equipment;
+            li You withdraw your consent to the monitoring arrangements.
+
+        li
+          | In addition, you may be recalled to prison if your whereabouts can no longer be electronically monitored at
+          | the specified address.
+
+        li
+          | The contractor may authorise your absence from your place of curfew in clearly defined circumstances, which
+          | you will be informed about by the contractor in writing.  You must contact the contractor in advance of any such
+          | absence to seek authorisation where this is possible.  If it is not possible to contact the contractor in
+          | advance, you must contact them as soon as possible thereafter. Absence for any other reason other than these
+          | clearly defined circumstances will constitute a breach of your curfew condition.
+
+        li
+          | If you need to seek a permanent change to your curfew conditions (for instance because of the requirements of
+          | a new job), you must contact the Prison Service establishment from which you were released.  A contact number is
+          | attached at the bottom of this licence.
+
+      div.smallPaddingBottom
+      h3 Probation Supervision
+
+      ol.continue
+        li
+          | You must place yourself under the supervision of whichever supervising officer or social worker is nominated
+          | for this purpose from time to time.
+
+        li.no-break While under supervision you must:
+          ol.roman.start
+            li Be of good behaviour and not behave in a way which undermines the purpose of the licence period;
+            li Not commit any offence;
+            li Keep in touch with the supervising officer in accordance with instructions given by the supervising officer;
+            li Receive visits from the supervising officer in accordance with instructions given by the supervising officer;
+
+            li
+              | Reside permanently at an address approved by the supervising officer and obtain the prior permission
+              | of the supervising officer for any stay of one or more nights at a different address;
+
+            li
+              |  Not undertake work, or a particular type of work, unless it is approved by the supervising officer
+              | and notify the supervising officer in advance of any proposal to undertake work or a particular type of work;
+
+            li
+              | Not travel outside the United Kingdom, the Channel Islands or the Isle of Man, except with the
+              | prior permission of the supervising officer or for the purposes of immigration deportation or removal;
+
+            div.pre.conditions
+              br
+              | #{CONDITIONS}
+
+        li
+          | The Secretary of State may vary or cancel any of the above conditions, in accordance with Section 250(4) of
+          | the Criminal Justice Act 2003.
+
+        li
+          | If you fail to submit yourself to a recall to custody following either a notification of the revocation of
+          | your licence, or remain out of contact with Probation Services for a period of six months, you may be liable to
+          | face a further charge of being unlawfully at large following recall under section 255ZA of the Criminal Justice
+          | Act 2003. This could result in a fine, a sentence of up to two years’ imprisonment, or both.
+
+        li
+          | If you fail to comply with any requirement of your licence period (set out above) or
+          | if you otherwise pose a risk to the public, you will be liable to have this licence revoked and be recalled to
+          | custody until the date on which your licence would have otherwise ended. If you are sent back to prison and are
+          | re-released before the end of your licence, you will still be subject to licence conditions until the end of
+          | your sentence.
+
+        li Your licence expires on
+          =" "
+          span.entry #{SENT_LED}
+        li Your sentence expires on
+          =" "
+          span.entry #{SENT_SED}
+
+      div.no-break
+        h3 Contact Points
+
+        p Monitoring Supplier:
+          =" "
+          span.entry #{MONITOR}
+
+        p Releasing establishment:
+          =" "
+          span.entry #{EST_PHONE}
+
+        br
+
+        div.box
+          p Name:
+            =" "
+            span.entry #{APPROVER}
+
+          pr Date:
+            =" "
+            span.entry #{CREATION_DATE}
+
+          p for the Secretary of State for Justice.
+          br
+          p This licence has been given to me and its requirements have been explained.
+
+          p Name:
+            =" "
+            span.entry #{OFF_NAME}
+
+          p Signed:
+          br
+          p Date:
+

--- a/server/views/licences/includes/licenceHeader.pug
+++ b/server/views/licences/includes/licenceHeader.pug
@@ -1,0 +1,7 @@
+mixin heading(title)
+  div.center
+    p
+      h1 #{title}
+      h3 Criminal Justice Act 2003
+      h2 #{EST_PREMISE}
+      h2 #{EST_PHONE}

--- a/server/views/licences/includes/offender.pug
+++ b/server/views/licences/includes/offender.pug
@@ -1,0 +1,22 @@
+table.wide
+  tr
+    td.nopad
+      table
+        tr
+          td Name:
+          td.entry(colspan="3") #{OFF_NAME}
+        tr
+          td Date of Birth:
+          td.entry(colspan="3") #{OFF_DOB}
+        tr
+          td Prison no:
+          td.entry #{OFF_NOMS}
+          td CRO no:
+          td.entry #{OFF_CRO}
+        tr
+          td Booking no:
+          td.entry #{OFF_BOOKING}
+          td PNC Id:
+          td.entry #{OFF_PNC}
+    td.nopad
+      img(width="130px" src="data:image/jpeg;base64," + OFF_PHOTO)


### PR DESCRIPTION
1. Create a stylesheet for licences (mostly copied from the PDF service)
1. Re-organize the PDF config for forms and licences to make it cleaner
1. Modify the PDF route to check a config list of templates to make locally, sending others to the original PDF service. Now can migrate one by one (or revert back to the original in the PDF service if there's a problem)
1. Simplify some stuff to do with Vary licences because it wasn't needed - NB corresponding PR in licences PDF to match these changes for the vary templates
1. PDF page headers and footers are made a bit differently now with the new PDF module
1. Recreate the HDC_AP licence template - this is an attempt to keep it simple and ease the migration from the old template. In future it would be possible to include the Pure Grid CSS styles and make the template less dependent on tables