### PR TITLE
LIC-1041 PDF documents not rendering in preprod environment

### DIFF
--- a/server/data/deliusClient.js
+++ b/server/data/deliusClient.js
@@ -30,10 +30,12 @@ module.exports = signInService => {
     }
 
     try {
+      logger.debug(`GET ${path}`)
       const result = await superagent
         .get(path)
         .set('Authorization', `Bearer ${token.token}`)
         .timeout(timeoutSpec)
+      logger.debug(`GET ${path} -> ${result.status}`)
 
       return result.body
     } catch (error) {

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -167,6 +167,7 @@ function nomisGetBuilder(token) {
     }
 
     try {
+      logger.debug(`GET ${path}`)
       const result = await superagent
         .get(path)
         .query(query)
@@ -175,6 +176,7 @@ function nomisGetBuilder(token) {
         .responseType(responseType)
         .timeout(timeoutSpec)
 
+      logger.debug(`GET ${path} -> ${result.status}`)
       return result.body
     } catch (error) {
       logger.warn('Error calling nomis', path, error.stack)
@@ -195,7 +197,9 @@ function nomisPushBuilder(verb, token) {
     }
 
     try {
+      logger.debug(`${verb} ${path}`)
       const result = await updateMethod[verb](token, path, body, headers, responseType)
+      logger.debug(`${verb} ${path} -> ${result.status}`)
       return result.body
     } catch (error) {
       logger.error('Error calling nomis', path, error.stack)

--- a/server/routes/forms.js
+++ b/server/routes/forms.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const logger = require('../../log.js')
 const { asyncMiddleware } = require('../utils/middleware')
 const {
   pdf: {
@@ -52,9 +53,17 @@ module.exports = ({ formService }) => router => {
         throw new Error(`unknown form template: ${templateName}`)
       }
 
-      const pageData = await formService.getTemplateData(templateName, licence, prisoner)
-      const filename = `${prisoner.offenderNo}.pdf`
-      return res.renderPDF(`forms/${templateName}`, { ...pageData, domain }, { filename, pdfOptions })
+      logger.info(`Render PDF for form '${templateName}'`)
+
+      try {
+        const pageData = await formService.getTemplateData(templateName, licence, prisoner)
+        const filename = `${prisoner.offenderNo}.pdf`
+        const pdf = res.renderPDF(`forms/${templateName}`, { ...pageData, domain }, { filename, pdfOptions })
+        logger.info(`Returning rendered PDF for form '${templateName}'`)
+        return pdf
+      } catch (e) {
+        logger.warn(`Caught an exception while rendering form ${templateName}: ${e}`)
+      }
     })
   )
 

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -15,6 +15,7 @@ const logger = require('../../log.js')
 
 module.exports = function createFormService(pdfFormatter, conditionsService, prisonerService, configClient) {
   async function getTemplateData(templateName, licence, prisoner) {
+    logger.info(`getTemplateData for '${templateName}'`)
     if (!requiredFields[templateName]) {
       logger.warn(`No such form template: ${templateName}`)
       return null
@@ -26,6 +27,7 @@ module.exports = function createFormService(pdfFormatter, conditionsService, pri
       return mergeWithRight(allValues, { [field]: fieldValue(licence, prisoner, field) })
     }, {})
 
+    logger.info(`getTemplateData for '${templateName}'. Extracted template data for ${Object.keys(values).join(', ')}`)
     return values
   }
 

--- a/server/views/forms/forms-layout.pug
+++ b/server/views/forms/forms-layout.pug
@@ -3,8 +3,7 @@ include includes/formsHeader
 doctype html
 html(lang="en")
   head
-    link(href= domain + "/public/stylesheets/forms-pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
-
+    link(href= "http://127.0.0.1:3000/public/stylesheets/forms-pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
   body
 
     block content

--- a/server/views/licences/hdc_ap.pug
+++ b/server/views/licences/hdc_ap.pug
@@ -3,7 +3,7 @@ include includes/licenceHeader
 doctype html
 html(lang="en")
   head
-    link(href= domain + "/public/stylesheets/licences-pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
+    link(href= "http://127.0.0.1:3000/public/stylesheets/forms-pdf.css?" + version, media="print", rel="stylesheet", type="text/css")
 
   body
 


### PR DESCRIPTION
Experimental tweaks that may fix the problem.  The only way to test this is to deploy to the pre-prod environment because the errors do not happen in any of the earlier environments (stage, local, local docker etc).

My current theory is that the pre-prod environment has a white-list of ip address for ingress:  The licences node application uses a headless Chrome browser to render PDF documents from HTML source.  This process is managed by a node module called puppet + a thin wrapper written by Alistair.  The HTML documents have links to a CSS file and font files that are served by the node app. Before this change the HTML documents prefixed the css and font file urls with the fully qualified public domain name of the licences instance.  eg https://licences-preprod.service.hmpps.dsd.io/public/forms-pdf.css etc.

This would work in the stage environment because there's no whitelist.  i think it fails in preprod because the whitelist does not include the licence application's public ip addresses.

This fix replaces the public domain prefix with http://127.0.0.1:3000 

The chrome browser should be able to read the css and font files without dns lookup and by making a local request that is unaffected by whitelists.