### PR TITLE
DCS-183 Adding the ability to override delius client id and secret

### DIFF
--- a/server/authentication/oauth.js
+++ b/server/authentication/oauth.js
@@ -1,9 +1,7 @@
-const querystring = require('querystring')
 const config = require('../config')
 
 const generate = (clientId, clientSecret) => {
-  const token = Buffer.from(`${querystring.escape(clientId)}:${querystring.escape(clientSecret)}`).toString('base64')
-
+  const token = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
   return `Basic ${token}`
 }
 

--- a/server/config.js
+++ b/server/config.js
@@ -46,10 +46,10 @@ module.exports = {
 
   delius: {
     apiUrl: get('DELIUS_API_URL', 'http://localhost:9090/communityapi/api'),
-    authUrl: get('NOMIS_AUTH_URL', 'http://localhost:9090/elite2api'),
+    authUrl: get('DELIUS_AUTH_URL', get('NOMIS_AUTH_URL', 'http://localhost:9090/elite2api')),
     admin: {
-      apiClientId: get('ADMIN_API_CLIENT_ID', 'licencesadmin'),
-      apiClientSecret: get('ADMIN_API_CLIENT_SECRET', 'clientsecret'),
+      apiClientId: get('DELIUS_API_CLIENT_ID', get('ADMIN_API_CLIENT_ID', 'licencesadmin')),
+      apiClientSecret: get('DELIUS_API_CLIENT_SECRET', get('ADMIN_API_CLIENT_SECRET', 'clientsecret')),
     },
   },
 

--- a/server/data/deliusClient.js
+++ b/server/data/deliusClient.js
@@ -39,7 +39,7 @@ module.exports = signInService => {
 
       return result.body
     } catch (error) {
-      logger.warn('Error calling delius', path, error.stack)
+      logger.warn('Error calling delius', path, error.response, error.stack)
       throw error
     }
   }


### PR DESCRIPTION
Licences staging points to T3 oauth server and T2 communities-api.

We're currently getting 401s from communities api and I think it is because of this mismatch. Communities api is unable to read the token created by T3. 

`'{"error":"invalid_token","error_description":"Cannot convert access token to JSON"}'`

This should allow us to configure delius and nomis to use different oauth servers.
Also adding more logging and fixing issue where secrets with specific characters aren't accepted