### PR TITLE
LIC-1080: validation of telephone in Proposed Curfew Address page is …

### DIFF
--- a/server/services/utils/bespokeAddressSchema.js
+++ b/server/services/utils/bespokeAddressSchema.js
@@ -15,10 +15,18 @@ module.exports = {
         .optional(),
       addressTown: joi.string().required(),
       postCode: joi.postcode().required(),
-      telephone: joi
-        .string()
-        .regex(/^[0-9+\s]+$/)
-        .required(),
+      telephone: joi.when('occupier.isOffender', {
+        is: joi.not('Yes'),
+        then: joi
+          .string()
+          .regex(/^[0-9+\s]+$/)
+          .required(),
+        otherwise: joi
+          .string()
+          .regex(/^[0-9+\s]+$/)
+          .allow('')
+          .optional(),
+      }),
       residents: joi.array().items(
         joi.object().keys({
           name: joi.string().required(),

--- a/test/services/formValidationTest.js
+++ b/test/services/formValidationTest.js
@@ -204,6 +204,44 @@ describe('validation', () => {
               },
               outcome: {},
             },
+            {
+              formResponse: {
+                addressLine1: 'a1',
+                addressTown: 't1',
+                postCode: 'S105NW',
+                cautionedAgainstResident: 'No',
+                telephone: '',
+                residents: [{ name: 'n', relationship: 'n' }],
+                occupier: { name: 'o', relationship: 'Enter a relationship', isOffender: 'Yes' },
+              },
+              outcome: {},
+            },
+            {
+              formResponse: {
+                addressLine1: 'a1',
+                addressTown: 't1',
+                postCode: 'S105NW',
+                cautionedAgainstResident: 'No',
+                telephone: '12345678900',
+                residents: [{ name: 'n', relationship: 'n' }],
+                occupier: { name: 'o', relationship: 'Enter a relationship', isOffender: 'Yes' },
+              },
+              outcome: {},
+            },
+            {
+              formResponse: {
+                addressLine1: 'a1',
+                addressTown: 't1',
+                postCode: 'S105NW',
+                cautionedAgainstResident: 'No',
+                telephone: '',
+                residents: [{ name: 'n', relationship: 'n' }],
+                occupier: { name: 'o', relationship: 'Enter a relationship', isOffender: 'No' },
+              },
+              outcome: {
+                telephone: 'Enter a telephone number',
+              },
+            },
           ]
 
           options.forEach(option => {


### PR DESCRIPTION
…now dependent on offender being main occupier

The telephone number was previously required in all cases. Have changed this to optional if the prisoner is the main occupier of the curfew address

3 new unit tests to verify error messages are/are not generated for telephone number dependent on selection of occupier.isOffender checkbox