### PR TITLE
LIC-1087 - Optional phone number in curfew address caused bug in task…

### DIFF
--- a/server/utils/licenceStatus.js
+++ b/server/utils/licenceStatus.js
@@ -439,8 +439,15 @@ function getCurfewAddressState(licence, optedOut, bassReferralNeeded, curfewAddr
       return taskStates.STARTED
     }
 
-    const required = ['cautionedAgainstResident', 'addressLine1', 'addressTown', 'postCode', 'telephone']
+    const required = ['cautionedAgainstResident', 'addressLine1', 'addressTown', 'postCode']
+
     if (required.some(field => !address[field])) {
+      return taskStates.STARTED
+    }
+
+    const offenderIsMainOccupier = getIn(address, ['occupier', 'isOffender']) === 'Yes'
+
+    if (!offenderIsMainOccupier && !address.telephone) {
       return taskStates.STARTED
     }
 

--- a/test/utils/licenceStatusTest.js
+++ b/test/utils/licenceStatusTest.js
@@ -1473,6 +1473,51 @@ describe('getLicenceStatus', () => {
       const status = getLicenceStatus(licence)
       expect(status.tasks.curfewAddress).to.eql(taskStates.STARTED)
     })
+
+    it('should show curfew address as STARTED if telephone empty and Main Occupier NOT checked', () => {
+      const licence = {
+        stage: 'PROCESSING_CA',
+        licence: {
+          proposedAddress: {
+            curfewAddress: {
+              addressLine1: '123 ABC',
+              addressTown: 'b',
+              postCode: 'c',
+              telephone: '',
+              occupier: {
+                isOffender: 'No',
+              },
+            },
+          },
+        },
+      }
+
+      const status = getLicenceStatus(licence)
+      expect(status.tasks.curfewAddress).to.eql(taskStates.STARTED)
+    })
+
+    it('should show curfew address as DONE if telephone empty and Main Occupier IS checked', () => {
+      const licence = {
+        stage: 'PROCESSING_CA',
+        licence: {
+          proposedAddress: {
+            curfewAddress: {
+              addressLine1: '123 ABC',
+              addressTown: 'b',
+              postCode: 'c',
+              cautionedAgainstResident: 'e',
+              telephone: '',
+              occupier: {
+                isOffender: 'Yes',
+              },
+            },
+          },
+        },
+      }
+
+      const status = getLicenceStatus(licence)
+      expect(status.tasks.curfewAddress).to.eql(taskStates.DONE)
+    })
   })
 
   context('bass', () => {


### PR DESCRIPTION
…list page

The curfew address can optionally include a phone number. However in enabling this path,
the tasklist page became incorrect in that it still wanted the phone number to be included before it would let user continue.
Have removed this conditionality so that if user doesn't input a phone number (and has slected the checkbox for Main Occupier)
, the tasklist page's Curfew Address section  will show 'Completed' and a 'change' link.