### PR TITLE
LIC-1067 Fixing refusal reason

### DIFF
--- a/server/services/config/approvalStatuses.js
+++ b/server/services/config/approvalStatuses.js
@@ -42,7 +42,7 @@ module.exports = {
         rotlFail: { approvalStatus: 'INELIGIBLE', refusedReason: 'FAIL_RTN' },
         communityCurfew: { approvalStatus: 'INELIGIBLE', refusedReason: 'CURFEW' },
         returnedAtRisk: { approvalStatus: 'INELIGIBLE', refusedReason: 'S116' },
-        serving4YearsOrMore: { approvalStatus: 'INELIGIBLE', refusedReason: 'SERVING_4_OR_MORE_YEARS' },
+        serving4YearsOrMore: { approvalStatus: 'INELIGIBLE', refusedReason: 'CJA03_4YRS' },
         hdcCurfewConditions: { approvalStatus: 'INELIGIBLE', refusedReason: 'HDC_RECALL' },
         servingRecall: { approvalStatus: 'INELIGIBLE', refusedReason: 'LRCOMP' },
         deportation: { approvalStatus: 'INELIGIBLE', refusedReason: 'FNP' },


### PR DESCRIPTION
I had just made this up as I didn't realise that this gets sent to elite2-api and it has to match the
reference data there.

There are 3 options which mention 4 year or longer sentences, Louise has identified that this is the
correct code.