### PR TITLE
DCS-181 HDC - Risk Management Information not displaying for the Decision Maker

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalTaskListSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalTaskListSpec.groovy
@@ -59,8 +59,8 @@ class ApprovalTaskListSpec extends GebReportingSpec {
     when: 'I view the tasklist'
     to TaskListPage, testData.markAndrewsBookingId
 
-    then: 'I see only eligibility, address, return to PCA, refuse'
-    taskListActions.size() == 4
+    then: 'I see only eligibility, address, Risk Management return to PCA, refuse'
+    taskListActions.size() == 5
 
     and: 'I can only refuse the licence'
     taskListAction(tasks.decision).text() == 'Refuse HDC'

--- a/server/routes/viewModels/taskLists/dmTasks.js
+++ b/server/routes/viewModels/taskLists/dmTasks.js
@@ -13,6 +13,7 @@ module.exports = ({ decisions, tasks, stage }) => {
   const {
     insufficientTimeStop,
     addressWithdrawn,
+    addressUnsuitable,
     curfewAddressRejected,
     bassReferralNeeded,
     confiscationOrder,
@@ -35,7 +36,7 @@ module.exports = ({ decisions, tasks, stage }) => {
   }
 
   if (addressWithdrawn || curfewAddressRejected) {
-    return [
+    const t = [
       { task: 'eligibilitySummaryTask' },
       {
         title: 'Proposed curfew address',
@@ -46,6 +47,21 @@ module.exports = ({ decisions, tasks, stage }) => {
           text: 'View',
         },
       },
+    ]
+
+    if (!(addressUnsuitable || addressWithdrawn)) {
+      t.push({
+        title: 'Risk management',
+        label: riskManagement.getLabel({ decisions, tasks }),
+        action: {
+          type: 'btn-secondary',
+          href: '/hdc/review/risk/',
+          text: 'View',
+        },
+      })
+    }
+
+    t.push(
       {
         title: 'Return to prison case admin',
         action: {
@@ -62,8 +78,9 @@ module.exports = ({ decisions, tasks, stage }) => {
           href: '/hdc/approval/refuseReason/',
           text: 'Refuse HDC',
         },
-      },
-    ]
+      }
+    )
+    return t
   }
 
   return [

--- a/test/routes/viewModels/taskListModelsTestDM.js
+++ b/test/routes/viewModels/taskListModelsTestDM.js
@@ -135,6 +135,28 @@ describe('TaskList models', () => {
       ).to.eql([eligibilitySummary, proposedCurfewAddressWithdrawn, returnPCA, finalDecisionRefuse])
     })
 
+    it('should display refusal tasks if address by Risk Management test but not bassReferralNeeded', () => {
+      expect(
+        taskListModel(
+          'DM',
+          false,
+          {
+            decisions: {
+              insufficientTimeStop: false,
+              bassReferralNeeded: false,
+              addressWithdrawn: false,
+              addressUnsuitable: true,
+              curfewAddressRejected: true,
+            },
+            tasks: {},
+            stage: 'APPROVAL',
+          },
+          {},
+          null
+        )
+      ).to.eql([eligibilitySummary, proposedCurfewAddress, returnPCA, finalDecisionRefuse])
+    })
+
     it('should display refusal tasks if address rejected but not bassReferralNeeded', () => {
       expect(
         taskListModel(
@@ -145,6 +167,7 @@ describe('TaskList models', () => {
               insufficientTimeStop: false,
               bassReferralNeeded: false,
               addressWithdrawn: false,
+              addressUnsuitable: false,
               curfewAddressRejected: true,
             },
             tasks: {},
@@ -153,7 +176,7 @@ describe('TaskList models', () => {
           {},
           null
         )
-      ).to.eql([eligibilitySummary, proposedCurfewAddress, returnPCA, finalDecisionRefuse])
+      ).to.eql([eligibilitySummary, proposedCurfewAddress, riskManagement, returnPCA, finalDecisionRefuse])
     })
 
     it('should display standard tasks if address approved', () => {


### PR DESCRIPTION
When a curfew address is rejected then show the DM the Risk Management task iff the address was rejected by this task, not the 'Proposed curfew address' task.