### PR TITLE
Attempting to set correct error severity

### DIFF
--- a/azure-appinsights.js
+++ b/azure-appinsights.js
@@ -6,7 +6,6 @@ const packageData = JSON.parse(fs.readFileSync('./package.json'))
 if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
   appInsights
     .setup(process.env.APPINSIGHTS_INSTRUMENTATIONKEY)
-    .setAutoCollectExceptions(false) // logger handles these
     .setDistributedTracingMode(appInsights.DistributedTracingModes.AI_AND_W3C)
     .start()
   appInsights.defaultClient.context.tags['ai.cloud.role'] = `${packageData.name}`


### PR DESCRIPTION
Currently all traces report the same severity.
The docs for winston app insights suggest that enabling exception capturing should lead to errors being reported at level 3.