### PR TITLE
DCS 203 BASS journey changed to accept Approved Premises Address

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/ApprovedPremisesAddressPageBassReferral.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/ApprovedPremisesAddressPageBassReferral.groovy
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.licences.pages.assessment
+
+import geb.Page
+
+class ApprovedPremisesAddressPageBassReferral extends Page {
+
+  static url = '/hdc/bassReferral/approvedPremisesAddress'
+
+  static at = {
+    browser.currentUrl.contains(url)
+  }
+
+  static content = {}
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/BassAreaCheckPage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/BassAreaCheckPage.groovy
@@ -21,5 +21,11 @@ class BassAreaCheckPage extends Page {
     areaReasons { $('#bassAreaReason') }
 
     areaRadios(required: false) { $(name: "bassAreaSuitable").module(RadioButtons) }
+
+    approvedRadios(required: false) { $(name: "approvedPremisesRequiredYesNo").module(RadioButtons) }
+
+    approvedAddressRequired(required: false) {$( name: 'approvedAddressRequired')}
+
+    saveAndContinue(required: false){ $('#continueBtn')}
   }
 }

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/BassAreaSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/BassAreaSpec.groovy
@@ -26,7 +26,7 @@ class BassAreaSpec extends GebReportingSpec {
     actions.logOut()
   }
 
-  def 'Answer initially blank'() {
+    def 'The question "Does the offender need to be sent to approved premises?" is displayed on page load'(){
 
     given: 'At task list page'
     to TaskListPage, testData.markAndrewsBookingId
@@ -37,15 +37,77 @@ class BassAreaSpec extends GebReportingSpec {
     then: 'I see the bass area page'
     at BassAreaCheckPage
 
-    and: 'The options are unset'
-    areaRadios.checked == null
+    and: 'The question "Does the offender need to be sent to approved premises?" is displayed'
+    approvedAddressRequired.isDisplayed()
 
-    and: 'The reason input is always shown'
+    }
+
+    def 'The radio buttons for the Approved Premises question  are not selected on page load'(){
+
+      given: 'At task list page'
+      to TaskListPage, testData.markAndrewsBookingId
+
+      when: 'I start the BASS area task'
+      taskListAction('BASS area check').click()
+
+      then: 'I see the bass area page'
+      at BassAreaCheckPage
+
+      and: 'The radios for approved premises are displayed'
+      approvedRadios.checked == null
+
+    }
+
+    def 'The question "Is the area suitable for the offender to live in?" is hidden until Approved Premises radio is clicked for No'() {
+
+      given: 'At task list page'
+      to TaskListPage, testData.markAndrewsBookingId
+
+      when: 'I start the BASS area task'
+      taskListAction('BASS area check').click()
+
+      then: 'I see the bass area page'
+      at BassAreaCheckPage
+
+      and: 'The options are unset'
+      areaRadios.checked == null
+
+      and: "The Area Suitable question and text are hidden"
+      !areaReasons.isDisplayed()
+
+      then: 'I select No to Approved Premises required'
+      approvedRadios.value('No')
+
+      and: 'The reason input is displayed'
+      areaReasons.isDisplayed()
+
+      and: 'The requested area is shown'
+      bass.proposed.town == 'BASS Town'
+      bass.proposed.county == 'BASS County'
+  }
+
+  def 'The question "Is the area suitable for the offender to live in?" is hidden again if the Approved Premises radio is clicked for Yes'() {
+
+    given: 'At task list page'
+    to TaskListPage, testData.markAndrewsBookingId
+
+    when: 'I start the BASS area task'
+    taskListAction('BASS area check').click()
+
+    then: 'I see the bass area page'
+    at BassAreaCheckPage
+
+    then: 'I select No to Approved Premises required'
+    approvedRadios.value('No')
+
+    and: 'The reason input is displayed'
     areaReasons.isDisplayed()
 
-    and: 'The requested area is shown'
-    bass.proposed.town == 'BASS Town'
-    bass.proposed.county == 'BASS County'
+    then: 'I select No to Approved Premises required'
+    approvedRadios.value('Yes')
+
+    and: 'The reason input is displayed'
+    !areaReasons.isDisplayed()
   }
 
   def 'Shows previously saved values'() {
@@ -56,18 +118,27 @@ class BassAreaSpec extends GebReportingSpec {
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
 
+    then: 'I select No to Approved Premises required'
+    approvedRadios.value('No')
+
     then: 'I see the previous values'
     areaRadios.checked == 'No'
     areaReasons.text() == 'Reason'
   }
 
-  def 'Modified choices are not saved after return to tasklist'() {
+  def 'Choices are not saved if return to tasklist without selecting Save and Continue'() {
 
-    given: 'On the bass area page'
+    given: 'At task list page'
+    to TaskListPage, testData.markAndrewsBookingId
+
+    when: 'I start the BASS area task'
+    taskListAction('BASS area check').click()
+
+    then: 'I see the bass area page'
     at BassAreaCheckPage
 
     when: 'I select new options'
-    areaRadios.checked = 'Yes'
+    approvedRadios.value('Yes')
 
     and: 'I choose return to tasklist'
     $('#backLink').click()
@@ -76,19 +147,21 @@ class BassAreaSpec extends GebReportingSpec {
     and: 'I go back to the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
 
-    then: 'I see the original values'
-    areaRadios.checked == 'No'
+    then: 'Then the Approved Premises radios are not checked'
+    approvedRadios.checked == null
   }
 
-  def 'Does not show radios when no specific area'() {
+   def 'If the prisoner has not requested a specific Bass area then the "Suitable area" radios are not displayed but the text box is displayed'() {
 
     given: 'No specific area requested'
     testData.loadLicence('assessment/bassArea-unstarted-no-area')
 
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
+    then: 'I select Approved Address No option'
+    approvedRadios.value('No')
 
-    then: 'The radios are not shown'
+    and: 'The radios are not shown'
     !areaRadios.isDisplayed()
 
     and: 'The reason input is always shown'
@@ -96,5 +169,39 @@ class BassAreaSpec extends GebReportingSpec {
 
     and: 'No preferred area message is shown'
     $('#noSpecificAreaMessage').isDisplayed()
+  }
+
+   def 'If the Approved premises YES radio is selected followed by the SAVE AND CONTINUE button, the user is taken to the Approved premises address input page'() {
+
+    given: 'No specific area requested'
+    testData.loadLicence('assessment/bassArea-unstarted-no-area')
+
+    when: 'I view the bass area page'
+    to BassAreaCheckPage, testData.markAndrewsBookingId
+    then: 'I select Approved Address YES option'
+    approvedRadios.value('Yes')
+
+    and: 'Then I select SAVE AND CONTINUE'
+    saveAndContinue.click()
+
+    then: 'The Approved premises address page is presented'
+    currentUrl.contains "/hdc/bassReferral/approvedPremisesAddress"
+  }
+
+  def 'If the Approved premises NO radio is selected followed by the SAVE AND CONTINUE button, the user is taken to the Tasklist page'() {
+
+    given: 'No specific area requested'
+    testData.loadLicence('assessment/bassArea-unstarted-no-area')
+
+    when: 'I view the bass area page'
+    to BassAreaCheckPage, testData.markAndrewsBookingId
+    then: 'I select Approved Address NO option'
+    approvedRadios.value('No')
+
+    and: 'Then I select SAVE AND CONTINUE'
+    saveAndContinue.click()
+
+    then: 'The Approved premises address page is presented'
+    currentUrl.contains "/hdc/taskList/"
   }
 }

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/BassAreaSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/BassAreaSpec.groovy
@@ -5,6 +5,7 @@ import spock.lang.Shared
 import spock.lang.Stepwise
 import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
 import uk.gov.justice.digital.hmpps.licences.pages.assessment.BassAreaCheckPage
+import uk.gov.justice.digital.hmpps.licences.pages.assessment.ApprovedPremisesAddressPageBassReferral
 import uk.gov.justice.digital.hmpps.licences.util.Actions
 import uk.gov.justice.digital.hmpps.licences.util.TestData
 
@@ -38,7 +39,7 @@ class BassAreaSpec extends GebReportingSpec {
     at BassAreaCheckPage
 
     and: 'The question "Does the offender need to be sent to approved premises?" is displayed'
-    approvedAddressRequired.isDisplayed()
+    approvedAddressRequired.displayed
 
     }
 
@@ -73,13 +74,13 @@ class BassAreaSpec extends GebReportingSpec {
       areaRadios.checked == null
 
       and: "The Area Suitable question and text are hidden"
-      !areaReasons.isDisplayed()
+      !areaReasons.displayed
 
-      then: 'I select No to Approved Premises required'
-      approvedRadios.value('No')
+      when: 'I select No to Approved Premises required'
+      approvedRadios.checked = 'No'
 
-      and: 'The reason input is displayed'
-      areaReasons.isDisplayed()
+      then: 'The reason input is displayed'
+      areaReasons.displayed
 
       and: 'The requested area is shown'
       bass.proposed.town == 'BASS Town'
@@ -97,17 +98,17 @@ class BassAreaSpec extends GebReportingSpec {
     then: 'I see the bass area page'
     at BassAreaCheckPage
 
-    then: 'I select No to Approved Premises required'
-    approvedRadios.value('No')
+    when: 'I select No to Approved Premises required'
+    approvedRadios.checked = 'No'
 
-    and: 'The reason input is displayed'
-    areaReasons.isDisplayed()
+    then: 'The reason input is displayed'
+    areaReasons.displayed
 
-    then: 'I select No to Approved Premises required'
-    approvedRadios.value('Yes')
+    when: 'I select No to Approved Premises required'
+    approvedRadios.checked = 'Yes'
 
-    and: 'The reason input is displayed'
-    !areaReasons.isDisplayed()
+    then: 'The reason input is displayed'
+    !areaReasons.displayed
   }
 
   def 'Shows previously saved values'() {
@@ -118,8 +119,8 @@ class BassAreaSpec extends GebReportingSpec {
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
 
-    then: 'I select No to Approved Premises required'
-    approvedRadios.value('No')
+    and: 'I select No to Approved Premises required'
+    approvedRadios.checked = 'No'
 
     then: 'I see the previous values'
     areaRadios.checked == 'No'
@@ -138,13 +139,15 @@ class BassAreaSpec extends GebReportingSpec {
     at BassAreaCheckPage
 
     when: 'I select new options'
-    approvedRadios.value('Yes')
+    approvedRadios.checked = 'Yes'
 
     and: 'I choose return to tasklist'
     $('#backLink').click()
+
+    then: ' I am returned to the tasklist'
     at TaskListPage
 
-    and: 'I go back to the bass area page'
+    when: 'I go back to the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
 
     then: 'Then the Approved Premises radios are not checked'
@@ -158,17 +161,18 @@ class BassAreaSpec extends GebReportingSpec {
 
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
-    then: 'I select Approved Address No option'
-    approvedRadios.value('No')
 
-    and: 'The radios are not shown'
-    !areaRadios.isDisplayed()
+    and: 'I select Approved Address No option'
+    approvedRadios.checked = 'No'
 
-    and: 'The reason input is always shown'
-    areaReasons.isDisplayed()
+    then: 'The "Suitable area" radios are not shown'
+    !areaRadios.displayed
 
-    and: 'No preferred area message is shown'
-    $('#noSpecificAreaMessage').isDisplayed()
+    and: 'But the "Reason" input is always shown'
+    areaReasons.displayed
+
+    and: 'The "No preferred area" message is shown'
+    $('#noSpecificAreaMessage').displayed
   }
 
    def 'If the Approved premises YES radio is selected followed by the SAVE AND CONTINUE button, the user is taken to the Approved premises address input page'() {
@@ -178,14 +182,15 @@ class BassAreaSpec extends GebReportingSpec {
 
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
-    then: 'I select Approved Address YES option'
-    approvedRadios.value('Yes')
+
+    and : 'I select Approved Address YES option'
+    approvedRadios.checked ='Yes'
 
     and: 'Then I select SAVE AND CONTINUE'
     saveAndContinue.click()
 
     then: 'The Approved premises address page is presented'
-    currentUrl.contains "/hdc/bassReferral/approvedPremisesAddress"
+    at ApprovedPremisesAddressPageBassReferral
   }
 
   def 'If the Approved premises NO radio is selected followed by the SAVE AND CONTINUE button, the user is taken to the Tasklist page'() {
@@ -195,13 +200,14 @@ class BassAreaSpec extends GebReportingSpec {
 
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
-    then: 'I select Approved Address NO option'
-    approvedRadios.value('No')
+
+    and: 'I select Approved Address NO option'
+    approvedRadios.checked = 'No'
 
     and: 'Then I select SAVE AND CONTINUE'
     saveAndContinue.click()
 
-    then: 'The Approved premises address page is presented'
-    currentUrl.contains "/hdc/taskList/"
+    then: 'The Tasklist page is presented'
+    at TaskListPage
   }
 }

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/BassAreaSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/BassAreaSpec.groovy
@@ -161,8 +161,9 @@ class BassAreaSpec extends GebReportingSpec {
 
     when: 'I view the bass area page'
     to BassAreaCheckPage, testData.markAndrewsBookingId
-    then: 'I select Approved Address No option'
-    approvedRadios.value('No')
+
+    and: 'I select Approved Address No option'
+    approvedRadios.checked ='No'
 
     and: 'I select Approved Address No option'
     approvedRadios.checked = 'No'
@@ -211,39 +212,5 @@ class BassAreaSpec extends GebReportingSpec {
 
     then: 'The Tasklist page is presented'
     at TaskListPage
-  }
-
-   def 'If the Approved premises YES radio is selected followed by the SAVE AND CONTINUE button, the user is taken to the Approved premises address input page'() {
-
-    given: 'No specific area requested'
-    testData.loadLicence('assessment/bassArea-unstarted-no-area')
-
-    when: 'I view the bass area page'
-    to BassAreaCheckPage, testData.markAndrewsBookingId
-    then: 'I select Approved Address YES option'
-    approvedRadios.value('Yes')
-
-    and: 'Then I select SAVE AND CONTINUE'
-    saveAndContinue.click()
-
-    then: 'The Approved premises address page is presented'
-    currentUrl.contains "/hdc/bassReferral/approvedPremisesAddress"
-  }
-
-  def 'If the Approved premises NO radio is selected followed by the SAVE AND CONTINUE button, the user is taken to the Tasklist page'() {
-
-    given: 'No specific area requested'
-    testData.loadLicence('assessment/bassArea-unstarted-no-area')
-
-    when: 'I view the bass area page'
-    to BassAreaCheckPage, testData.markAndrewsBookingId
-    then: 'I select Approved Address NO option'
-    approvedRadios.value('No')
-
-    and: 'Then I select SAVE AND CONTINUE'
-    saveAndContinue.click()
-
-    then: 'The Approved premises address page is presented'
-    currentUrl.contains "/hdc/taskList/"
   }
 }

--- a/server/app.js
+++ b/server/app.js
@@ -357,7 +357,7 @@ module.exports = function createApp({
 
   app.use('/hdc/proposedAddress/', secureRoute(addressRouter({ licenceService, nomisPushService })))
   app.use('/hdc/approval/', secureRoute(approvalRouter({ licenceService, prisonerService, nomisPushService })))
-  app.use('/hdc/bassReferral/', secureRoute(bassReferralRouter({ licenceService })))
+  app.use('/hdc/bassReferral/', secureRoute(bassReferralRouter({ licenceService, nomisPushService })))
   app.use('/hdc/licenceConditions/', secureRoute(conditionsRouter({ licenceService, conditionsService })))
   app.use('/hdc/curfew/', secureRoute(curfewRouter({ licenceService, nomisPushService })))
   app.use('/hdc/eligibility/', secureRoute(eligibilityRouter({ licenceService, nomisPushService })))

--- a/server/routes/bassReferral.js
+++ b/server/routes/bassReferral.js
@@ -1,10 +1,11 @@
 const { asyncMiddleware } = require('../utils/middleware')
 const createStandardRoutes = require('./routeWorkers/standard')
 const formConfig = require('./config/bassReferral')
-const { getIn, firstItem } = require('../utils/functionalHelpers')
+const { getIn, firstItem, mergeWithRight } = require('../utils/functionalHelpers')
 const recordList = require('../services/utils/recordList')
 
-module.exports = ({ licenceService }) => (router, audited) => {
+module.exports = ({ licenceService, nomisPushService }) => (router, audited,  pushToNomis ) => {  // NB: pushToNomis may need to be { pushToNomis }
+
   const standard = createStandardRoutes({ formConfig, licenceService, sectionName: 'bassReferral' })
 
   router.post('/rejected/:bookingId', audited, asyncMiddleware(reject('area', 'rejected')))
@@ -22,6 +23,80 @@ module.exports = ({ licenceService }) => (router, audited) => {
       return res.redirect(`${nextPath}${bookingId}`)
     }
   }
+
+  router.get('/approvedPremisesChoice/:bookingId', asyncMiddleware(getChoice))
+  function getChoice(req, res) {
+ 
+    const { bookingId } = req.params
+    const { licence } = res.locals
+    const data = { decision: getApprovedPremisesChoice(getIn(licence, ['licence'])) }
+    const viewData = { data, errorObject: {}, bookingId }
+
+    return res.render('bassReferral/approvedPremisesChoice', viewData)
+  }
+
+  function getApprovedPremisesChoice(licence) {
+    if (isYes(licence, ['proposedAddress', 'optOut', 'decision'])) {
+      return 'OptOut'
+    }
+
+    if (isYes(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])) {
+      return 'ApprovedPremises'
+    }
+
+    return null
+  }
+
+  function isYes(licence, pathSegments) {
+    const answer = getIn(licence, pathSegments)
+    return answer && answer === 'Yes'
+  }
+
+
+
+  router.post(
+    '/approvedPremisesChoice/:bookingId',
+    audited,
+    asyncMiddleware(async (req, res) => {
+      const { bookingId } = req.params
+      const { decision } = req.body
+      const { licence } = res.locals
+
+      const bassReferral = getIn(licence, ['licence', 'bassReferral'])
+      const newCurfew = mergeWithRight(bassReferral, approvedPremisesContents[decision])
+
+      const proposedAddress = getIn(licence, ['licence', 'proposedAddress'])
+      const newProposedAddress = mergeWithRight(proposedAddress, proposedAddressContents[decision])
+
+      await Promise.all([
+        licenceService.updateSection('proposedAddress', bookingId, newProposedAddress),
+        licenceService.updateSection('bassReferral', bookingId, newCurfew),
+      ])
+
+      if (pushToNomis && decision === 'OptOut') {
+        await nomisPushService.pushStatus({
+          bookingId,
+          data: { type: 'optOut', status: 'Yes' },
+          username: req.user.username,
+        })
+      }
+
+      const nextPath = formConfig.approvedPremisesChoice.nextPath[decision] || `/hdc/taskList/`
+
+      return res.redirect(`${nextPath}${bookingId}`)
+    })
+  )
+
+  const approvedPremisesContents = {
+    OptOut: { approvedPremises: { required: 'No' } },
+    ApprovedPremises: { approvedPremises: { required: 'Yes' } },
+  }
+
+  const proposedAddressContents = {
+    OptOut: { optOut: { decision: 'Yes' } },
+    ApprovedPremises: { optOut: { decision: 'No' } },
+  }
+
 
   router.get(
     '/bassOffer/:bookingId',

--- a/server/routes/bassReferral.js
+++ b/server/routes/bassReferral.js
@@ -5,8 +5,6 @@ const { getIn, firstItem, mergeWithRight } = require('../utils/functionalHelpers
 const recordList = require('../services/utils/recordList')
 
 module.exports = ({ licenceService, nomisPushService }) => (router, audited, pushToNomis) => {
-  // NB: pushToNomis may need to be { pushToNomis }
-
   const standard = createStandardRoutes({ formConfig, licenceService, sectionName: 'bassReferral' })
 
   router.post('/rejected/:bookingId', audited, asyncMiddleware(reject('area', 'rejected')))

--- a/server/routes/bassReferral.js
+++ b/server/routes/bassReferral.js
@@ -4,7 +4,8 @@ const formConfig = require('./config/bassReferral')
 const { getIn, firstItem, mergeWithRight } = require('../utils/functionalHelpers')
 const recordList = require('../services/utils/recordList')
 
-module.exports = ({ licenceService, nomisPushService }) => (router, audited,  pushToNomis ) => {  // NB: pushToNomis may need to be { pushToNomis }
+module.exports = ({ licenceService, nomisPushService }) => (router, audited, pushToNomis) => {
+  // NB: pushToNomis may need to be { pushToNomis }
 
   const standard = createStandardRoutes({ formConfig, licenceService, sectionName: 'bassReferral' })
 
@@ -26,7 +27,6 @@ module.exports = ({ licenceService, nomisPushService }) => (router, audited,  pu
 
   router.get('/approvedPremisesChoice/:bookingId', asyncMiddleware(getChoice))
   function getChoice(req, res) {
- 
     const { bookingId } = req.params
     const { licence } = res.locals
     const data = { decision: getApprovedPremisesChoice(getIn(licence, ['licence'])) }
@@ -51,8 +51,6 @@ module.exports = ({ licenceService, nomisPushService }) => (router, audited,  pu
     const answer = getIn(licence, pathSegments)
     return answer && answer === 'Yes'
   }
-
-
 
   router.post(
     '/approvedPremisesChoice/:bookingId',
@@ -96,7 +94,6 @@ module.exports = ({ licenceService, nomisPushService }) => (router, audited,  pu
     OptOut: { optOut: { decision: 'Yes' } },
     ApprovedPremises: { optOut: { decision: 'No' } },
   }
-
 
   router.get(
     '/bassOffer/:bookingId',

--- a/server/routes/config/bassReferral.js
+++ b/server/routes/config/bassReferral.js
@@ -86,10 +86,69 @@ module.exports = {
           responseType: 'optionalString',
         },
       },
+      {
+        approvedPremisesRequiredYesNo: {
+          responseType: 'requiredYesNo',
+          validationMessage: 'Select Yes or No',
+        },
+      },
+    ],
+    nextPath: {
+      decisions: [
+        {
+          discriminator: 'approvedPremisesRequiredYesNo',
+          Yes: '/hdc/bassReferral/approvedPremisesAddress/',
+          No: '/hdc/taskList/',
+        },
+      ],
+      path: '/hdc/taskList/',
+    },
+  },
+  approvedPremisesAddress: {
+    licenceSection: 'approvedPremisesAddress',
+    validate: true,
+    fields: [
+      {
+        addressLine1: {
+          responseType: 'requiredString',
+          validationMessage: 'Enter an address',
+        },
+      },
+      {
+        addressLine2: {
+          responseType: 'optionalString',
+        },
+      },
+      {
+        addressTown: {
+          responseType: 'requiredString',
+          validationMessage: 'Enter a town or city',
+        },
+      },
+      {
+        postCode: {
+          responseType: 'requiredPostcode',
+          validationMessage: 'Enter a postcode',
+        },
+      },
+      {
+        telephone: {
+          responseType: 'optionalPhone',
+          validationMessage: 'Enter a telephone number in the right format',
+        },
+      },
     ],
     nextPath: {
       path: '/hdc/taskList/',
       change: '/hdc/review/licenceDetails/',
+    },
+  },
+  approvedPremisesChoice: {
+    pageDataMap: ['licence'],
+    nextPath: {
+      discriminator: 'decision',
+      ApprovedPremises: '/hdc/bassReferral/approvedPremisesAddress/',
+      OptOut: '/hdc/taskList/',
     },
   },
   bassOffer: {

--- a/server/routes/forms.js
+++ b/server/routes/forms.js
@@ -35,8 +35,15 @@ module.exports = ({ formService }) => router => {
 
       const completionDate = moment().format(formsDateFormat)
       const filename = curfewAddressCheckFormFileName(prisoner)
-
-      return res.renderPDF('forms/curfewAddress', { ...pageData, port, completionDate }, { filename, pdfOptions })
+      const approvedPremisesAddress =
+        getIn(licence, ['curfew', 'approvedPremisesAddress']) ||
+        getIn(licence, ['bassReferral', 'approvedPremisesAddress']) ||
+        {}
+      return res.renderPDF(
+        'forms/curfewAddress',
+        { ...pageData, approvedPremisesAddress, port, completionDate },
+        { filename, pdfOptions }
+      )
     })
   )
 

--- a/server/routes/viewModels/taskLists/caTasks.js
+++ b/server/routes/viewModels/taskLists/caTasks.js
@@ -140,7 +140,10 @@ module.exports = {
           href: '/hdc/risk/riskManagement/',
           text: 'View/Edit',
         },
-        visible: (!approvedPremisesRequired && curfewAddressApproved) || addressUnsuitable || bassChecksDone,
+        visible:
+          (!approvedPremisesRequired && curfewAddressApproved) ||
+          addressUnsuitable ||
+          (bassChecksDone && !approvedPremisesRequired),
       },
       {
         title: 'Victim liaison',

--- a/server/routes/viewModels/taskLists/caTasks.js
+++ b/server/routes/viewModels/taskLists/caTasks.js
@@ -107,7 +107,7 @@ module.exports = {
       title: 'Curfew address',
       label: proposedAddress.getLabel({ decisions, tasks }),
       action: proposedAddress.getCaAction({ decisions, tasks }),
-      visible: allowedTransition === 'caToRo',
+      visible: !bassReferralNeeded && allowedTransition === 'caToRo',
     }
 
     const bassTask = {

--- a/server/routes/viewModels/taskLists/dmTasks.js
+++ b/server/routes/viewModels/taskLists/dmTasks.js
@@ -98,7 +98,7 @@ module.exports = licenceStatus => {
       label: bassOffer.getLabel(licenceStatus),
       action: {
         type: 'btn-secondary',
-        href: '/hdc/review/bassOffer/',
+        href: approvedPremisesRequired ? '/hdc/review/approvedPremisesAddress/': '/hdc/review/bassOffer/',
         text: 'View',
       },
     },

--- a/server/routes/viewModels/taskLists/dmTasks.js
+++ b/server/routes/viewModels/taskLists/dmTasks.js
@@ -98,7 +98,7 @@ module.exports = licenceStatus => {
       label: bassOffer.getLabel(licenceStatus),
       action: {
         type: 'btn-secondary',
-        href: approvedPremisesRequired ? '/hdc/review/approvedPremisesAddress/': '/hdc/review/bassOffer/',
+        href: approvedPremisesRequired ? '/hdc/review/approvedPremisesAddress/' : '/hdc/review/bassOffer/',
         text: 'View',
       },
     },

--- a/server/routes/viewModels/taskLists/tasks/bassAddress.js
+++ b/server/routes/viewModels/taskLists/tasks/bassAddress.js
@@ -1,9 +1,19 @@
-const { standardAction } = require('./utils/actions')
+const { standardAction, viewEdit } = require('./utils/actions')
 
 module.exports = {
   getLabel: ({ decisions, tasks }) => {
-    const { bassAreaNotSuitable, bassWithdrawn, bassWithdrawalReason, bassAccepted } = decisions
+    const {
+      bassAreaNotSuitable,
+      bassWithdrawn,
+      bassWithdrawalReason,
+      bassAccepted,
+      approvedPremisesRequired,
+    } = decisions
     const { bassOffer, bassAddress } = tasks
+
+    if (approvedPremisesRequired) {
+      return 'Approved premises required'
+    }
 
     if (bassAreaNotSuitable) {
       return 'BASS area rejected'
@@ -24,7 +34,11 @@ module.exports = {
   },
 
   getCaAction: ({ tasks }) => {
-    const { bassAddress } = tasks
-    return standardAction(bassAddress, '/hdc/bassReferral/bassOffer/')
+    const { bassAddress, approvedPremisesAddress } = tasks
+    if (approvedPremisesAddress === 'DONE') {
+      return viewEdit('/hdc/bassReferral/approvedPremisesChoice/')
+    } else {
+      return standardAction(bassAddress, '/hdc/bassReferral/bassOffer/')
+    }
   },
 }

--- a/server/routes/viewModels/taskLists/tasks/bassAddress.js
+++ b/server/routes/viewModels/taskLists/tasks/bassAddress.js
@@ -37,8 +37,7 @@ module.exports = {
     const { bassAddress, approvedPremisesAddress } = tasks
     if (approvedPremisesAddress === 'DONE') {
       return viewEdit('/hdc/bassReferral/approvedPremisesChoice/')
-    } else {
-      return standardAction(bassAddress, '/hdc/bassReferral/bassOffer/')
     }
+    return standardAction(bassAddress, '/hdc/bassReferral/bassOffer/')
   },
 }

--- a/server/routes/viewModels/taskLists/tasks/bassArea.js
+++ b/server/routes/viewModels/taskLists/tasks/bassArea.js
@@ -9,6 +9,9 @@ module.exports = {
       if (bassAreaSpecified) {
         return bassAreaSuitable ? 'BASS area suitable' : 'BASS area is not suitable'
       }
+      if (!bassAreaSpecified && decisions.approvedPremisesRequired === true) {
+        return 'Approved premises required'
+      }
       return 'No specific BASS area requested'
     }
     return 'Not completed'

--- a/server/routes/viewModels/taskLists/tasks/bassArea.js
+++ b/server/routes/viewModels/taskLists/tasks/bassArea.js
@@ -2,23 +2,30 @@ const { standardAction } = require('./utils/actions')
 
 module.exports = {
   getLabel: ({ decisions, tasks }) => {
-    const { bassAreaSpecified, bassAreaSuitable } = decisions
-    const { bassAreaCheck } = tasks
+    const { bassAreaSpecified, bassAreaSuitable, approvedPremisesRequired } = decisions
+    const { bassAreaCheck, approvedPremisesAddress } = tasks
 
-    if (bassAreaCheck === 'DONE') {
+    if (bassAreaCheck === 'DONE' && approvedPremisesAddress !== 'DONE') {
       if (bassAreaSpecified) {
         return bassAreaSuitable ? 'BASS area suitable' : 'BASS area is not suitable'
       }
-      if (!bassAreaSpecified && decisions.approvedPremisesRequired === true) {
+      if (!bassAreaSpecified && approvedPremisesRequired === true) {
         return 'Approved premises required'
       }
       return 'No specific BASS area requested'
+    }
+
+    if (approvedPremisesAddress === 'DONE') {
+      return 'Approved premises required'
     }
     return 'Not completed'
   },
 
   getRoAction: ({ tasks }) => {
-    const { bassAreaCheck } = tasks
+    const { bassAreaCheck, approvedPremisesAddress } = tasks
+    if (approvedPremisesAddress === 'DONE') {
+      return standardAction(approvedPremisesAddress, '/hdc/bassReferral/bassAreaCheck/')
+    }
     return standardAction(bassAreaCheck, '/hdc/bassReferral/bassAreaCheck/')
   },
 }

--- a/server/routes/viewModels/taskLists/tasks/bassOffer.js
+++ b/server/routes/viewModels/taskLists/tasks/bassOffer.js
@@ -9,11 +9,11 @@ module.exports = {
       bassAccepted,
       bassAreaSuitable,
       approvedPremisesRequired,
-      optedOut
+      optedOut,
     } = decisions
     const { bassOffer, bassAreaCheck, approvedPremisesAddress } = tasks
-    
-    if(optedOut){
+
+    if (optedOut) {
       return 'Opted out'
     }
 
@@ -39,7 +39,7 @@ module.exports = {
       return 'WARNING||Address not available'
     }
 
-    if (bassAreaCheck === 'DONE' && bassAreaSuitable) {
+    if (bassAreaCheck === 'DONE' && bassAreaSuitable && approvedPremisesAddress !== 'DONE') {
       return 'Not completed'
     }
 
@@ -53,7 +53,7 @@ module.exports = {
   getAction: ({ decisions, tasks }) => {
     const { bassWithdrawn, approvedPremisesRequired } = decisions
     const { bassAreaCheck, bassOffer, optOut, curfewAddress, bassRequest } = tasks
-    
+
     if (bassWithdrawn) {
       return change('/hdc/bassReferral/bassOffer/')
     }

--- a/server/routes/viewModels/taskLists/tasks/bassOffer.js
+++ b/server/routes/viewModels/taskLists/tasks/bassOffer.js
@@ -1,9 +1,21 @@
-const { standardAction, change } = require('./utils/actions')
+const { standardAction, change, viewEdit } = require('./utils/actions')
 
 module.exports = {
   getLabel: ({ decisions, tasks }) => {
-    const { bassAreaNotSuitable, bassWithdrawn, bassWithdrawalReason, bassAccepted, bassAreaSuitable } = decisions
-    const { bassOffer, bassAreaCheck } = tasks
+    const {
+      bassAreaNotSuitable,
+      bassWithdrawn,
+      bassWithdrawalReason,
+      bassAccepted,
+      bassAreaSuitable,
+      approvedPremisesRequired,
+      optedOut
+    } = decisions
+    const { bassOffer, bassAreaCheck, approvedPremisesAddress } = tasks
+    
+    if(optedOut){
+      return 'Opted out'
+    }
 
     if (bassAreaNotSuitable) {
       return 'BASS area rejected'
@@ -31,15 +43,23 @@ module.exports = {
       return 'Not completed'
     }
 
+    if (approvedPremisesRequired) {
+      return approvedPremisesAddress === 'DONE' ? 'Approved premises required' : 'Not completed'
+    }
+
     return 'BASS referral requested'
   },
 
   getAction: ({ decisions, tasks }) => {
-    const { bassWithdrawn } = decisions
+    const { bassWithdrawn, approvedPremisesRequired } = decisions
     const { bassAreaCheck, bassOffer, optOut, curfewAddress, bassRequest } = tasks
-
+    
     if (bassWithdrawn) {
       return change('/hdc/bassReferral/bassOffer/')
+    }
+
+    if (bassAreaCheck === 'DONE' && approvedPremisesRequired === true) {
+      return viewEdit('/hdc/bassReferral/approvedPremisesChoice/')
     }
 
     if (bassAreaCheck === 'DONE') {

--- a/server/routes/viewModels/taskLists/tasks/createLicence.js
+++ b/server/routes/viewModels/taskLists/tasks/createLicence.js
@@ -2,11 +2,15 @@ const { continueBtn } = require('./utils/actions')
 
 module.exports = {
   getCaAction: ({ decisions, tasks, stage }) => {
-    const { approved, bassReferralNeeded, addressWithdrawn } = decisions
-    const { bassAddress } = tasks
+    const { approved, bassReferralNeeded, addressWithdrawn, approvedPremisesRequired } = decisions
+    const { bassAddress , approvedPremisesAddress} = tasks
 
     if (!approved || stage === 'MODIFIED_APPROVAL') {
       return null
+    }
+
+    if (approvedPremisesRequired) {
+      return approvedPremisesAddress === 'DONE' ? continueBtn('/hdc/pdf/selectLicenceType/') : null
     }
 
     if (bassReferralNeeded) {

--- a/server/routes/viewModels/taskLists/tasks/createLicence.js
+++ b/server/routes/viewModels/taskLists/tasks/createLicence.js
@@ -3,7 +3,7 @@ const { continueBtn } = require('./utils/actions')
 module.exports = {
   getCaAction: ({ decisions, tasks, stage }) => {
     const { approved, bassReferralNeeded, addressWithdrawn, approvedPremisesRequired } = decisions
-    const { bassAddress , approvedPremisesAddress} = tasks
+    const { bassAddress, approvedPremisesAddress } = tasks
 
     if (!approved || stage === 'MODIFIED_APPROVAL') {
       return null

--- a/server/services/utils/formValidation.js
+++ b/server/services/utils/formValidation.js
@@ -492,7 +492,8 @@ function approvedAddressValidationConfig(licence) {
       section: 'curfew',
       missingMessage: 'Enter the approved premises address details',
     }
-  } else if (getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo']) === 'Yes'){
+  }
+  if (getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo']) === 'Yes') {
     return {
       formResponse: getIn(licence, ['bassReferral', 'approvedPremisesAddress']),
       formType: 'approvedPremisesAddress',

--- a/server/services/utils/formValidation.js
+++ b/server/services/utils/formValidation.js
@@ -287,13 +287,7 @@ function validateGroup({ licence, group, bespokeConditions }) {
       },
     ],
     PROCESSING_RO_APPROVED_PREMISES: [
-      {
-        formResponse: getIn(licence, ['curfew', 'approvedPremisesAddress']),
-        formType: 'approvedPremisesAddress',
-        pageConfig: curfewConfig.approvedPremisesAddress,
-        section: 'curfew',
-        missingMessage: 'Enter the approved premises address details',
-      },
+      approvedAddressValidationConfig(licence),
       {
         formResponse: getIn(licence, ['licenceConditions', 'standard']),
         formType: 'standard',
@@ -487,4 +481,24 @@ function isFulfilled(requirement, data) {
   const requiredAnswer = requirement[requirementName]
 
   return data[requirementName] === requiredAnswer
+}
+
+function approvedAddressValidationConfig(licence) {
+  if (getIn(licence, ['curfew', 'approvedPremises', 'required']) === 'Yes') {
+    return {
+      formResponse: getIn(licence, ['curfew', 'approvedPremisesAddress']),
+      formType: 'approvedPremisesAddress',
+      pageConfig: curfewConfig.approvedPremisesAddress,
+      section: 'curfew',
+      missingMessage: 'Enter the approved premises address details',
+    }
+  } else if (getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo']) === 'Yes'){
+    return {
+      formResponse: getIn(licence, ['bassReferral', 'approvedPremisesAddress']),
+      formType: 'approvedPremisesAddress',
+      pageConfig: bassConfig.approvedPremisesAddress,
+      section: 'bassReferral',
+      missingMessage: 'Enter the approved premises address details',
+    }
+  }
 }

--- a/server/services/utils/pdfFormatter/pdfFormatter.js
+++ b/server/services/utils/pdfFormatter/pdfFormatter.js
@@ -73,10 +73,10 @@ function readEntry(data, spec) {
 }
 
 function pickCurfewAddress(licence) {
-  const approvedPremisesRequired = getIn(licence, ['curfew', 'approvedPremises', 'required'])
+  const approvedPremisesRequired = getIn(licence, ['curfew', 'approvedPremises', 'required']) || getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])
 
   if (approvedPremisesRequired === 'Yes') {
-    return getIn(licence, ['curfew', 'approvedPremisesAddress'])
+    return getIn(licence, ['curfew', 'approvedPremisesAddress']) || getIn(licence, ['bassReferral', 'approvedPremisesAddress'])
   }
 
   const bassRequested = getIn(licence, ['bassReferral', 'bassRequest', 'bassRequested'])

--- a/server/services/utils/pdfFormatter/pdfFormatter.js
+++ b/server/services/utils/pdfFormatter/pdfFormatter.js
@@ -73,10 +73,15 @@ function readEntry(data, spec) {
 }
 
 function pickCurfewAddress(licence) {
-  const approvedPremisesRequired = getIn(licence, ['curfew', 'approvedPremises', 'required']) || getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])
+  const approvedPremisesRequired =
+    getIn(licence, ['curfew', 'approvedPremises', 'required']) ||
+    getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])
 
   if (approvedPremisesRequired === 'Yes') {
-    return getIn(licence, ['curfew', 'approvedPremisesAddress']) || getIn(licence, ['bassReferral', 'approvedPremisesAddress'])
+    return (
+      getIn(licence, ['curfew', 'approvedPremisesAddress']) ||
+      getIn(licence, ['bassReferral', 'approvedPremisesAddress'])
+    )
   }
 
   const bassRequested = getIn(licence, ['bassReferral', 'bassRequest', 'bassRequested'])

--- a/server/utils/licenceStatus.js
+++ b/server/utils/licenceStatus.js
@@ -455,16 +455,15 @@ function getCurfewAddressState(licence, optedOut, bassReferralNeeded, curfewAddr
 }
 
 function getCurfewAddressReviewState(licence) {
-  let approvedPremisesRequiredAnswer
-  let approvedPremisesAddressAnswer
+  const approvedPremisesRequiredAnswer =
+    getIn(licence, ['curfew', 'approvedPremises', 'required']) ||
+    getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo']) ||
+    {}
 
-    approvedPremisesRequiredAnswer = getIn(licence, ['curfew', 'approvedPremises', 'required']) 
-    || getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])
-    || {}
-
-    approvedPremisesAddressAnswer = getIn(licence, ['curfew', 'approvedPremisesAddress']) 
-    || getIn(licence, ['bassReferral', 'approvedPremisesAddress']) 
-    || {}
+  let approvedPremisesAddressAnswer =
+    getIn(licence, ['curfew', 'approvedPremisesAddress']) ||
+    getIn(licence, ['bassReferral', 'approvedPremisesAddress']) ||
+    {}
 
   if (approvedPremisesRequiredAnswer === 'No') {
     approvedPremisesAddressAnswer = {}

--- a/server/utils/licenceStatus.js
+++ b/server/utils/licenceStatus.js
@@ -40,7 +40,6 @@ function getLicenceStatus(licenceRecord) {
   const results = getRequiredState(stage, licenceRecord.licence)
   const postApproval = isPostDecision(stage)
   const createLicence = postApproval ? getLicenceCreatedTaskState(licenceRecord) : taskStates.UNSTARTED
-
   return results.reduce(combiner, { stage, postApproval, decisions: {}, tasks: { createLicence } })
 }
 
@@ -456,8 +455,20 @@ function getCurfewAddressState(licence, optedOut, bassReferralNeeded, curfewAddr
 }
 
 function getCurfewAddressReviewState(licence) {
-  const approvedPremisesRequiredAnswer = getIn(licence, ['curfew', 'approvedPremises', 'required']) || {}
-  const approvedPremisesAddressAnswer = getIn(licence, ['curfew', 'approvedPremisesAddress']) || {}
+  let approvedPremisesRequiredAnswer
+  let approvedPremisesAddressAnswer
+
+    approvedPremisesRequiredAnswer = getIn(licence, ['curfew', 'approvedPremises', 'required']) 
+    || getIn(licence, ['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])
+    || {}
+
+    approvedPremisesAddressAnswer = getIn(licence, ['curfew', 'approvedPremisesAddress']) 
+    || getIn(licence, ['bassReferral', 'approvedPremisesAddress']) 
+    || {}
+
+  if (approvedPremisesRequiredAnswer === 'No') {
+    approvedPremisesAddressAnswer = {}
+  }
 
   const approvedPremisesAddressState = () => {
     if (isEmpty(approvedPremisesAddressAnswer)) {

--- a/server/utils/licenceStatusLabels.js
+++ b/server/utils/licenceStatusLabels.js
@@ -117,7 +117,6 @@ function caProcessingLabel(licenceStatus) {
   ]
 
   const addressRouteLabels = [
-    { decision: 'approvedPremisesRequired', label: status.approvedPremisesRequired },
     { decision: 'curfewAddressWithdrawn', label: status.addressRejected },
     { decision: 'curfewAddressRejected', label: status.addressRejected },
   ]
@@ -127,11 +126,12 @@ function caProcessingLabel(licenceStatus) {
     { decision: 'postponed', label: status.postponed },
     { decision: 'excluded', label: status.notEligible },
     { decision: 'optedOut', label: status.optedOut },
+    { decision: 'approvedPremisesRequired', label: status.approvedPremisesRequired },
   ]
 
   const labels = licenceStatus.decisions.bassReferralNeeded
-    ? commonLabels.concat(bassRouteLabels)
-    : commonLabels.concat(addressRouteLabels)
+  ? commonLabels.concat(bassRouteLabels)
+  : commonLabels.concat(addressRouteLabels)
 
   return getLabel(labels, licenceStatus) || status.addressSuitable
 }
@@ -157,7 +157,7 @@ function roProcessingLabel(licenceStatus) {
 
   if (licenceStatus.decisions.bassReferralNeeded) {
     if (licenceStatus.tasks.bassAreaCheck === taskStates.UNSTARTED) {
-      return status.bassRequest
+      return status.notStarted
     }
 
     if (licenceStatus.decisions.bassAreaNotSuitable) {

--- a/server/utils/licenceStatusLabels.js
+++ b/server/utils/licenceStatusLabels.js
@@ -130,8 +130,8 @@ function caProcessingLabel(licenceStatus) {
   ]
 
   const labels = licenceStatus.decisions.bassReferralNeeded
-  ? commonLabels.concat(bassRouteLabels)
-  : commonLabels.concat(addressRouteLabels)
+    ? commonLabels.concat(bassRouteLabels)
+    : commonLabels.concat(addressRouteLabels)
 
   return getLabel(labels, licenceStatus) || status.addressSuitable
 }

--- a/server/utils/licenceStatusTransitions.js
+++ b/server/utils/licenceStatusTransitions.js
@@ -169,7 +169,6 @@ function canSendCaToDm(licenceStatus) {
 }
 
 function getRequiredTasks(decisions, tasks) {
-
   if (decisions.approvedPremisesRequired) {
     return [tasks.approvedPremisesAddress, tasks.finalChecks]
   }

--- a/server/utils/licenceStatusTransitions.js
+++ b/server/utils/licenceStatusTransitions.js
@@ -169,6 +169,11 @@ function canSendCaToDm(licenceStatus) {
 }
 
 function getRequiredTasks(decisions, tasks) {
+
+  if (decisions.approvedPremisesRequired) {
+    return [tasks.approvedPremisesAddress, tasks.finalChecks]
+  }
+
   if (decisions.bassReferralNeeded) {
     return [tasks.bassOffer, tasks.finalChecks]
   }

--- a/server/views/bassReferral/approvedPremisesAddress.pug
+++ b/server/views/bassReferral/approvedPremisesAddress.pug
@@ -1,5 +1,4 @@
 extends ../layout
-//- include ../proposedAddress/includes/addressDetail
 
 block content
 

--- a/server/views/bassReferral/approvedPremisesAddress.pug
+++ b/server/views/bassReferral/approvedPremisesAddress.pug
@@ -1,0 +1,51 @@
+extends ../layout
+//- include ../proposedAddress/includes/addressDetail
+
+block content
+
+  -var address = approvedPremisesAddress || {}
+
+  div.pure-g.pure-u-1
+    div.borderBottomLight
+      include ../includes/back
+      include ../includes/personalDetailsSummary
+
+      h2.heading-large Approved premises address
+
+      if Object.keys(errorObject).length !== 0
+        div.pure-g
+          div.error-summary.pure-u-1.pure-u-md-1-2(role="alert" aria-labelledby="error-summary-heading" tabindex="-1")
+            h2.heading-medium.error-summary-heading#error-summary-heading
+              | There is a problem
+            ul.error-summary-list
+              each error, index in errorObject
+                li
+                  a(href="#" + index) #{error}
+
+      form(method="post")
+        input(type="hidden" name="_csrf" value=csrfToken)
+        input(type="hidden" name="bookingId" value=bookingId || '')
+        div.pure-g.paddingBottom
+          div.pure-u-1.pure-u-md-1-2
+            div.pure-g
+              div.pure-u-1.pure-u-md-3-5
+
+                div.form-group.midMarginBottom
+                  label.form-label(for="addressLine1") Building and street
+                  input(id="addressLine1" name="addressLine1" value=data.addressLine1 autofocus aria-label="Building and street" class=errorObject.addressLine1 ? "form-control form-control-error" : "form-control")
+                  input.form-control.smallMarginTop(id="addressLine2" name="addressLine2" value=data.addressLine2)
+
+                div.form-group.midMarginBottom
+                  label.form-label(for="addressTown") Town or city
+                  input(id="addressTown" name="addressTown" value=data.addressTown aria-label="Town or city" class=errorObject.addressTown ? "form-control form-control-error" : "form-control")
+
+                div.form-group.midMarginBottom.pure-u-sm-1.pure-u-md-1-2
+                  label.form-label(for="postCode") Postcode
+                  input(id="postCode" name="postCode" value=data.postCode aria-label="Postcode" class=errorObject.postCode ? "form-control form-control-error" : "form-control")
+
+                div.form-group.pure-u-sm-1.pure-u-md-3-4
+                  label.form-label(for="telephone") Telephone
+                  input.form-control(id="telephone" name="telephone" value=data.telephone aria-label="Telephone" class=errorObject.telephone ? "form-control form-control-error" : "form-control")
+
+
+        include ../includes/formSubmit

--- a/server/views/bassReferral/approvedPremisesChoice.pug
+++ b/server/views/bassReferral/approvedPremisesChoice.pug
@@ -1,0 +1,14 @@
+extends ../formTemplates/formTemplate
+
+block question
+  | Does the offender need to be sent to approved premises?
+
+block formItems
+  div.form-group.smallPaddingTop
+
+    div.multiple-choice()
+      input#ApprovedPremises(type="radio" checked=data && data.decision === 'ApprovedPremises' name="decision" value="ApprovedPremises")
+      label(for="ApprovedPremises") Yes, the offender needs to be sent to approved premises
+    div.multiple-choice
+      input#optout(type="radio" checked=data && data.decision === 'OptOut' name="decision" value="OptOut")
+      label(for="optout") No, they opted out of HDC

--- a/server/views/bassReferral/bassAreaCheck.pug
+++ b/server/views/bassReferral/bassAreaCheck.pug
@@ -29,58 +29,51 @@ block content
         div.pure-u-1-2
         div#noSpecificAreaMessage Offender does not have a preferred BASS area
 
-    div.pure-u-1.pure-u-md-1-2
 
-    hr
-
-    if bassRequest.specificArea === 'Yes'
-      h2.heading-medium Is the area suitable for the offender to live in?
 
     form(method="post")
       input(type="hidden" name="_csrf" value=csrfToken)
       input(type="hidden" name="bookingId" value=bookingId || '')
       input(type="hidden" name="bassAreaCheckSeen" value='true')
-      div.paddingBottom.largeMarginBottom
+      
 
-        if bassRequest.specificArea === 'Yes'
-          div.form-group.inline.smallPaddingTop
-            div.multiple-choice
-              input#yes(type="radio" checked=bassAreaCheck.bassAreaSuitable === 'Yes' name="bassAreaSuitable" value="Yes")
-              label(for="yes") Yes
+      
+      div.form-group.inline
 
-            div.multiple-choice
-              input#no(type="radio" checked=bassAreaCheck.bassAreaSuitable === 'No' name="bassAreaSuitable" value="No")
-              label(for="no") No
+        h3(name = 'approvedAddressRequired' class = 'heading-medium pure-u-2-5' ) Does the offender need to be sent to approved premises?
+        
+        div#approvedPremisesRequiredYesNo(class=  errorObject.approvedPremisesRequiredYesNo ? "form-group form-group-error inline " : "form-group inline ")
+          div.multiple-choice
+            input#approvedPremisesRequiredYes(type="radio" checked=bassAreaCheck.approvedPremisesRequiredYesNo === 'Yes' name="approvedPremisesRequiredYesNo" value="Yes")
+            label(for="approvedPremisesRequiredYes") Yes
+          div.multiple-choice(data-target="bassAreaDetails")
+            input#approvedPremisesRequiredNo(type="radio" checked=bassAreaCheck.approvedPremisesRequiredYesNo === 'No' name="approvedPremisesRequiredYesNo" value="No")
+            label(for="approvedPremisesRequiredNo") No
+            
 
-        div#bassAreaDetails.panel.panel-border-narrow
-
+        div#bassAreaDetails.js-hidden
           if bassRequest.specificArea === 'Yes'
-            label(for='bassAreaReason') Explain your decision
-          else
-            label(for='bassAreaReason') Enter any information that may affect the choice of BASS accommodation (optional)
+            h2.heading-medium Is the area suitable for the offender to live in?
 
-          textarea(name='bassAreaReason' id='bassAreaReason' class='form-control' rows='2' aria-label="Provide reasons why the BASS area is unsuitable")
-            if bassAreaCheck.bassAreaReason
-              | #{bassAreaCheck.bassAreaReason}
+            div.form-group.inline.smallPaddingTop
+              div.multiple-choice
+                input#yes(type="radio" checked=bassAreaCheck.bassAreaSuitable === 'Yes' name="bassAreaSuitable" value="Yes")
+                label(for="yes") Yes
 
-        div.pure-u-1.pure-u-sm-5-12.pure-g
-          div.form-group.inline
+              div.multiple-choice
+                input#no(type="radio" checked=bassAreaCheck.bassAreaSuitable === 'No' name="bassAreaSuitable" value="No")
+                label(for="no") No
 
-          h3.heading-medium Does the offender need to be sent to approved premises?
-          
-          div#approvedPremisesRequiredYesNo(class=  errorObject.approvedPremisesRequiredYesNo ? "form-group form-group-error inline " : "form-group inline ")
-            div.multiple-choice
-              input#approvedPremisesRequiredYes(type="radio" checked=bassAreaCheck.approvedPremisesRequiredYesNo === 'Yes' name="approvedPremisesRequiredYesNo" value="Yes")
-              label(for="approvedPremisesRequiredYes") Yes
-            div.multiple-choice
-              input#approvedPremisesRequiredNo(type="radio" checked=bassAreaCheck.approvedPremisesRequiredYesNo === 'No' name="approvedPremisesRequiredYesNo" value="No")
-              label(for="approvedPremisesRequiredNo") No
-
-        include ../includes/formSubmit
-
-      //- if (action === 'change')
-      //-   include ../includes/formSubmit
-      //- else
-      //-   include ../includes/saveAndReturn
+          div.panel.panel-border-narrow   
+            if bassRequest.specificArea === 'Yes'
+              label(for='bassAreaReason') Explain your decision
+            else
+              label(for='bassAreaReason') Enter any information that may affect the choice of BASS accommodation (optional)
+        
+            textarea(name='bassAreaReason' id='bassAreaReason' class='form-control' rows='2' aria-label="Provide reasons why the BASS area is unsuitable")
+              if bassAreaCheck.bassAreaReason
+                | #{bassAreaCheck.bassAreaReason}
 
 
+
+      include ../includes/formSubmit

--- a/server/views/bassReferral/bassAreaCheck.pug
+++ b/server/views/bassReferral/bassAreaCheck.pug
@@ -63,9 +63,24 @@ block content
             if bassAreaCheck.bassAreaReason
               | #{bassAreaCheck.bassAreaReason}
 
-      if (action === 'change')
+        div.pure-u-1.pure-u-sm-5-12.pure-g
+          div.form-group.inline
+
+          h3.heading-medium Does the offender need to be sent to approved premises?
+          
+          div#approvedPremisesRequiredYesNo(class=  errorObject.approvedPremisesRequiredYesNo ? "form-group form-group-error inline " : "form-group inline ")
+            div.multiple-choice
+              input#approvedPremisesRequiredYes(type="radio" checked=bassAreaCheck.approvedPremisesRequiredYesNo === 'Yes' name="approvedPremisesRequiredYesNo" value="Yes")
+              label(for="approvedPremisesRequiredYes") Yes
+            div.multiple-choice
+              input#approvedPremisesRequiredNo(type="radio" checked=bassAreaCheck.approvedPremisesRequiredYesNo === 'No' name="approvedPremisesRequiredYesNo" value="No")
+              label(for="approvedPremisesRequiredNo") No
+
         include ../includes/formSubmit
-      else
-        include ../includes/saveAndReturn
+
+      //- if (action === 'change')
+      //-   include ../includes/formSubmit
+      //- else
+      //-   include ../includes/saveAndReturn
 
 

--- a/server/views/forms/curfewAddress.pug
+++ b/server/views/forms/curfewAddress.pug
@@ -6,8 +6,9 @@ block content
   span.alert (This form may be disclosed to the offender on request)
 
   include includes/offender
-
-  if isBass
+  if isBass && isAp
+    include includes/approvedPremises
+  else if isBass
     include includes/bassArea
   else if isAp
     include includes/approvedPremises

--- a/server/views/review/includes/approvedPremisesAddress.pug
+++ b/server/views/review/includes/approvedPremisesAddress.pug
@@ -1,6 +1,6 @@
 include ./itemAndError
--var address = data.curfew && data.curfew.approvedPremisesAddress || {}
--var errors = errorObject.curfew && errorObject.curfew.approvedPremisesAddress || {}
+-var address = data.curfew && data.curfew.approvedPremisesAddress || data.bassReferral && data.bassReferral.approvedPremisesAddress ||{}
+-var errors = errorObject.curfew && errorObject.curfew.approvedPremisesAddress || errorObject.bassReferral && errorObject.bassReferral.approvedPremisesAddress ||{}
 
 div.pure-g.borderBottomLight.midPaddingTopBottom
   div.pure-u-1-2

--- a/server/views/review/includes/licenceSummary.pug
+++ b/server/views/review/includes/licenceSummary.pug
@@ -30,7 +30,14 @@ mixin errorMessageOrBlock(errorMessage, errorId)
 
 div.largeMarginBottom
 
-  if sections.bassArea
+  if (sections.bassArea && sections.approvedPremisesAddress)
+    div.borderBottom
+        +titleRow('Approved premises', 'approvedPremisesDetails')
+          +roCase
+            +change("/hdc/bassReferral/bassAreaCheck/" + bookingId, 'addressEditLink')
+        +errorMessageOrBlock( errorObject.bassReferral && errorObject.bassReferral.approvedPremisesAddress, 'approvedPremisesAddress-error')
+          include approvedPremisesAddress
+  else if sections.bassArea
     div.borderBottom
       +titleRow('Proposed BASS area', 'bassAreaDetails')
         +roCase

--- a/test/routes/viewModels/taskListModelsTestCA.js
+++ b/test/routes/viewModels/taskListModelsTestCA.js
@@ -137,6 +137,17 @@ describe('TaskList models', () => {
     visible: true,
   }
 
+  const bassAddressWithApprovedAddress = {
+    title: 'BASS address',
+    label: 'Approved premises required',
+    action: {
+      href: '/hdc/bassReferral/approvedPremisesChoice/',
+      text: 'View/Edit',
+      type: 'btn-secondary',
+    },
+    visible: true,
+  }
+
   const riskManagement = {
     action: {
       href: '/hdc/risk/riskManagement/',
@@ -622,6 +633,38 @@ describe('TaskList models', () => {
           'caToRo'
         )
       ).to.eql([curfewAddress, refuse, submitCurfewAddress])
+    })
+
+    it('should show  Bass Address task with Approved Premises label and View/Edit button if AP input)', () => {
+      expect(
+        taskListModel(
+          'CA',
+          false,
+          {
+            decisions: {
+              bassReferralNeeded: true,
+              approvedPremisesRequired: true,
+            },
+            tasks: {
+              approvedPremisesAddress: 'DONE',
+              bassAreaCheck: 'DONE',
+            },
+            stage: 'PROCESSING_CA',
+          },
+          { approvedPremisesAddress: 'DONE' },
+          'null'
+        )
+      ).to.eql([
+        bassAddressWithApprovedAddress,
+        victimLiasion,
+        curfewHours,
+        additionalConditionsEdit,
+        reportingInstructionsReview,
+        reviewCase,
+        postponeOrRefuse,
+        refuse,
+        submitDecisionMaker,
+      ])
     })
   })
 

--- a/test/routes/viewModels/taskListModelsTestRO.js
+++ b/test/routes/viewModels/taskListModelsTestRO.js
@@ -29,6 +29,17 @@ describe('TaskList models', () => {
     visible: true,
   }
 
+  const bassAreaCheckWithApprovedAddress = {
+    action: {
+      href: '/hdc/bassReferral/bassAreaCheck/',
+      text: 'Change',
+      type: 'link',
+    },
+    label: 'Approved premises required',
+    title: 'BASS area check',
+    visible: true,
+  }
+
   const riskManagement = {
     title: 'Risk management',
     label: 'Not completed',
@@ -446,6 +457,30 @@ describe('TaskList models', () => {
         )
       ).to.eql([
         proposedCurfewAddress,
+        victimLiasion,
+        curfewHours,
+        additionalConditions,
+        reportingInstructions,
+        curfewAddressCheck,
+        submitCA,
+      ])
+    })
+
+    it('should show the Bass area check task with a label of Approved premises address if approved premises has been input', () => {
+      expect(
+        taskListModel(
+          'RO',
+          false,
+          {
+            decisions: { approvedPremisesRequired: true, bassReferralNeeded: true, curfewAddressRejected: false },
+            tasks: { curfewAddress: 'DONE', approvedPremisesAddress: 'DONE' },
+            stage: 'PROCESSING_RO',
+          },
+          {},
+          'roToCa'
+        )
+      ).to.eql([
+        bassAreaCheckWithApprovedAddress,
         victimLiasion,
         curfewHours,
         additionalConditions,

--- a/test/routes/viewModels/taskLists/tasks/bassAreaTest.js
+++ b/test/routes/viewModels/taskLists/tasks/bassAreaTest.js
@@ -78,5 +78,18 @@ describe('bass area task', () => {
         type: 'btn',
       })
     })
+
+    it('should show change link to Bass area check if approvedPremisesAddress: DONE, irrespective of value in bassAreaCheck', () => {
+      expect(
+        getRoAction({
+          decisions: {},
+          tasks: { approvedPremisesAddress: 'DONE', bassAreaCheck: 'SOMETHING' },
+        })
+      ).to.eql({
+        text: 'Change',
+        href: '/hdc/bassReferral/bassAreaCheck/',
+        type: 'link',
+      })
+    })
   })
 })

--- a/test/services/formValidationTest.js
+++ b/test/services/formValidationTest.js
@@ -1491,9 +1491,12 @@ describe('validation', () => {
       describe('bassAreaCheck', () => {
         const pageConfig = bassAreaCheck
         const options = [
-          { formResponse: { bassAreaSuitable: 'Yes' }, outcome: {} },
-          { formResponse: { bassAreaSuitable: 'No' }, outcome: { bassAreaReason: 'Enter a reason' } },
-          { formResponse: { bassAreaSuitable: 'No', bassAreaReason: 'reason' }, outcome: {} },
+          { formResponse: { bassAreaSuitable: 'Yes', approvedPremisesRequiredYesNo: 'No' }, outcome: {} },
+          { formResponse: { bassAreaSuitable: 'No', approvedPremisesRequiredYesNo: 'No' }, outcome: { bassAreaReason: 'Enter a reason' } },
+          { formResponse: { bassAreaSuitable: 'No', bassAreaReason: 'reason', approvedPremisesRequiredYesNo: 'No' }, outcome: {} },
+          { formResponse: { approvedPremisesRequiredYesNo: 'No' }, outcome: {} },
+          { formResponse: { approvedPremisesRequiredYesNo: 'Yes' }, outcome: {} },
+          { formResponse: { approvedPremisesRequiredYesNo: '' }, outcome: { approvedPremisesRequiredYesNo: "Select Yes or No" } },
         ]
 
         options.forEach(option => {
@@ -2118,7 +2121,7 @@ describe('validation', () => {
 
       context('bass requested', () => {
         const validBassRequest = { bassRequested: 'Yes', specificArea: 'No' }
-        const validBassAreaCheck = { bassAreaSuitable: 'Yes' }
+        const validBassAreaCheck = { bassAreaSuitable: 'Yes', approvedPremisesRequiredYesNo: "No" }
         const validBassLicence = {
           ...validLicence,
           bassReferral: {
@@ -2159,7 +2162,7 @@ describe('validation', () => {
 
       context('bass area suitable', () => {
         const validBassRequest = { bassRequested: 'No', specificArea: 'No' }
-        const validBassAreaCheck = { bassAreaSuitable: 'Yes' }
+        const validBassAreaCheck = { bassAreaSuitable: 'Yes', approvedPremisesRequiredYesNo: 'No' }
         const validBassLicence = {
           curfew: { curfewHours: validCurfewHours },
           bassReferral: {

--- a/test/services/formValidationTest.js
+++ b/test/services/formValidationTest.js
@@ -1492,11 +1492,20 @@ describe('validation', () => {
         const pageConfig = bassAreaCheck
         const options = [
           { formResponse: { bassAreaSuitable: 'Yes', approvedPremisesRequiredYesNo: 'No' }, outcome: {} },
-          { formResponse: { bassAreaSuitable: 'No', approvedPremisesRequiredYesNo: 'No' }, outcome: { bassAreaReason: 'Enter a reason' } },
-          { formResponse: { bassAreaSuitable: 'No', bassAreaReason: 'reason', approvedPremisesRequiredYesNo: 'No' }, outcome: {} },
+          {
+            formResponse: { bassAreaSuitable: 'No', approvedPremisesRequiredYesNo: 'No' },
+            outcome: { bassAreaReason: 'Enter a reason' },
+          },
+          {
+            formResponse: { bassAreaSuitable: 'No', bassAreaReason: 'reason', approvedPremisesRequiredYesNo: 'No' },
+            outcome: {},
+          },
           { formResponse: { approvedPremisesRequiredYesNo: 'No' }, outcome: {} },
           { formResponse: { approvedPremisesRequiredYesNo: 'Yes' }, outcome: {} },
-          { formResponse: { approvedPremisesRequiredYesNo: '' }, outcome: { approvedPremisesRequiredYesNo: "Select Yes or No" } },
+          {
+            formResponse: { approvedPremisesRequiredYesNo: '' },
+            outcome: { approvedPremisesRequiredYesNo: 'Select Yes or No' },
+          },
         ]
 
         options.forEach(option => {
@@ -2121,7 +2130,7 @@ describe('validation', () => {
 
       context('bass requested', () => {
         const validBassRequest = { bassRequested: 'Yes', specificArea: 'No' }
-        const validBassAreaCheck = { bassAreaSuitable: 'Yes', approvedPremisesRequiredYesNo: "No" }
+        const validBassAreaCheck = { bassAreaSuitable: 'Yes', approvedPremisesRequiredYesNo: 'No' }
         const validBassLicence = {
           ...validLicence,
           bassReferral: {

--- a/test/utils/licenceStatusLabelsTest.js
+++ b/test/utils/licenceStatusLabelsTest.js
@@ -265,7 +265,7 @@ describe('getStatusLabel', () => {
             decisions: { bassReferralNeeded: true },
             tasks: { bassAreaCheck: 'UNSTARTED' },
           },
-          label: 'BASS request',
+          label: 'Not started',
         },
         {
           status: {

--- a/test/utils/licenceStatusTransitionsTest.js
+++ b/test/utils/licenceStatusTransitionsTest.js
@@ -653,7 +653,7 @@ describe('getAllowedTransition', () => {
     it('should allow CA to DM when approved premises', () => {
       const status = {
         stage: 'PROCESSING_CA',
-        tasks: { finalChecks: 'DONE' },
+        tasks: { finalChecks: 'DONE', approvedPremisesAddress: 'DONE' },
         decisions: { approvedPremisesRequired: true },
       }
 


### PR DESCRIPTION
http://localhost:3000/hdc/bassReferral/bassAreaCheck/
http://localhost:3000/hdc/bassReferral/approvedPremisesAddress/
http://localhost:3000/hdc/bassReferral/approvedPremisesChoice/

Previously if the prisoner requested a Bass address, the RO didn't have the ability to change it. The RO can now override the Bass request to an Approved Premises (AP) address.

The option to use an AP address begins in the Bass Area Check screen where a new radio button group has been added asking if an AP is required. The two options are Yes and No.
If Yes is selected, the RO is taken to the AP address screen where he can enter the address details. If No is selected, the user is returned to the tasklist screen

Also previously, the bassAreaCheck page displayed the 'Is the area suitable for the offender to live in?' question all the time.
Have now hidden this question and associated textbox unless RO selects No for 'Does the offender need to be sent to approved premises?'

The additional journey has required new logic to manage the tasklists and caselist statuses/labels. There may be occasions where RO initially selects No for AP and Yes for Bass Area suitability only to later go back and change AP address to Yes. This would result in incorrect Caselist and Tasklist status/labels. Have revised the logic so that Approved Premises address takes precedence over any Bass Area check status/labels.
The status of Opted Out will show if user decides to opt out.

The new journey was made to be similar to the journey where a user requested his own Curfew Address but instead the RO decided an AP was appropriate. In that journey there is an intermediary page (after the RO's intervention) where the CA  could request AP address. A similar intermediary page (hdc/bassReferral/approvedPremisesChoice) has been added to this new BASS -> AP address journey. This intermediary page is presented when the CA selects the 'view/edit' button against the Bass Address task in the Tasklist.

Added new validation for approvedPremisesAddress
Added error handling in bassAreaCheck.pug'
Updated the current unit tests to account for the new code. Specifically, added the approvedPremisesRequiredYesNo to the object for the Bass address screen.

Please don't merge into Master yet as tests need to be written
