### PR TITLE
DCS-233 Extracting out service to retrieve RO contact details

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ const createCaseListFormatter = require('./services/utils/caseListFormatter')
 const createUserAdminService = require('./services/userAdminService')
 const createUserService = require('./services/userService')
 const createNotificationService = require('./services/notificationService')
+const createRoContactDetailsService = require('./services/roContactDetailsService')
 const createReminderService = require('./services/reminderService')
 
 const createNomisPushService = require('./services/nomisPushService')
@@ -47,9 +48,10 @@ const reportingService = createReportingService(audit)
 const userAdminService = createUserAdminService(nomisClientBuilder, userClient, signInService, prisonerService)
 const userService = createUserService(nomisClientBuilder)
 const deadlineService = createDeadlineService(licenceClient)
+const roContactDetailsService = createRoContactDetailsService(userAdminService)
 const notificationService = createNotificationService(
   prisonerService,
-  userAdminService,
+  roContactDetailsService,
   configClient,
   notifyClient,
   audit,

--- a/server/services/roContactDetailsService.js
+++ b/server/services/roContactDetailsService.js
@@ -1,0 +1,37 @@
+const R = require('ramda')
+const { isEmpty } = require('../utils/functionalHelpers')
+const logger = require('../../log.js')
+
+const logIfMissing = (val, message) => {
+  if (isEmpty(val)) {
+    logger.error(message)
+  }
+}
+
+module.exports = function createRoContactDetailsService(userAdminService) {
+  async function getContactDetails(deliusId) {
+    const ro = await userAdminService.getRoUserByDeliusId(deliusId)
+
+    if (ro) {
+      const email = R.prop('email', ro)
+      const orgEmail = R.prop('orgEmail', ro)
+      const organisation = R.prop('organisation', ro)
+
+      logIfMissing(orgEmail, `Missing orgEmail for RO: ${deliusId}`)
+      logIfMissing(email, `Missing email for RO: ${deliusId}`)
+      logIfMissing(organisation, `Missing organisation for RO: ${deliusId}`)
+
+      return {
+        email,
+        orgEmail,
+        organisation,
+      }
+    }
+
+    return null
+  }
+
+  return {
+    getContactDetails,
+  }
+}

--- a/test/services/roContactDetailServiceTest.js
+++ b/test/services/roContactDetailServiceTest.js
@@ -1,0 +1,40 @@
+const createRoContactDetailsService = require('../../server/services/roContactDetailsService')
+
+describe('roContactDetailsService', () => {
+  let service
+  let userAdminService
+
+  beforeEach(() => {
+    userAdminService = {
+      getRoUserByDeliusId: sinon.stub(),
+    }
+
+    service = createRoContactDetailsService(userAdminService)
+  })
+
+  describe('getContactDetails', () => {
+    it('successfully return all data', async () => {
+      const fullContactInfo = {
+        email: 'ro@ro.email',
+        orgEmail: 'admin@ro.email',
+        organisation: 'NPS Dewsbury (Kirklees and Wakefield)',
+      }
+
+      userAdminService.getRoUserByDeliusId = sinon.stub().resolves(fullContactInfo)
+
+      const result = await service.getContactDetails('delius-1')
+
+      expect(result).to.eql(fullContactInfo)
+      expect(userAdminService.getRoUserByDeliusId).to.be.calledWith('delius-1')
+    })
+
+    it('no staff record', async () => {
+      userAdminService.getRoUserByDeliusId = sinon.stub().resolves(null)
+
+      const result = await service.getContactDetails('delius-1')
+
+      expect(result).to.eql(null)
+      expect(userAdminService.getRoUserByDeliusId).to.be.calledWith('delius-1')
+    })
+  })
+})


### PR DESCRIPTION
This is to start to provide a central place where we can start to using delius and probation teams service as the source of org emails.

This will initially only be a fallback for when we haven't got the RO user's details in the staff ids table.

The naming might be a bit off here - going to talk to Louise about naming around RO vs COM, but RO is currently how we describe the role across licences