### PR TITLE
DCS-233 Calling delius when staff doesn't exist.

### DIFF
--- a/server/data/deliusClient.js
+++ b/server/data/deliusClient.js
@@ -1,7 +1,6 @@
 const superagent = require('superagent')
 const logger = require('../../log')
 const config = require('../config')
-const { unauthorisedError } = require('../utils/errors')
 
 const timeoutSpec = {
   response: config.nomis.timeout.response,
@@ -36,7 +35,7 @@ module.exports = signInService => {
   async function deliusGet({ path } = {}) {
     const token = await signInService.getAnonymousClientCredentialsTokens('delius')
     if (!token) {
-      throw unauthorisedError()
+      throw Error(`Failed to get token when attempting to call delius: ${path}`)
     }
 
     try {

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ const reportingService = createReportingService(audit)
 const userAdminService = createUserAdminService(nomisClientBuilder, userClient, signInService, prisonerService)
 const userService = createUserService(nomisClientBuilder)
 const deadlineService = createDeadlineService(licenceClient)
-const roContactDetailsService = createRoContactDetailsService(userAdminService)
+const roContactDetailsService = createRoContactDetailsService(userAdminService, roService)
 const notificationService = createNotificationService(
   prisonerService,
   roContactDetailsService,

--- a/server/services/roContactDetailsService.js
+++ b/server/services/roContactDetailsService.js
@@ -8,7 +8,7 @@ const logIfMissing = (val, message) => {
   }
 }
 
-module.exports = function createRoContactDetailsService(userAdminService) {
+module.exports = function createRoContactDetailsService(userAdminService, roService) {
   async function getContactDetails(deliusId) {
     const ro = await userAdminService.getRoUserByDeliusId(deliusId)
 
@@ -27,6 +27,9 @@ module.exports = function createRoContactDetailsService(userAdminService) {
         organisation,
       }
     }
+
+    const staff = await roService.getStaffByCode(deliusId)
+    logger.info('Found staff result:', staff)
 
     return null
   }

--- a/test/data/deliusClientTest.js
+++ b/test/data/deliusClientTest.js
@@ -23,7 +23,10 @@ describe('deliusClient', () => {
   describe('deliusClient', () => {
     it('should throw error on GET when no token', () => {
       signInService.getAnonymousClientCredentialsTokens.resolves(null)
-      return expect(deliusClient.getROPrisoners('1')).to.be.rejectedWith('Unauthorised access')
+      return expect(deliusClient.getROPrisoners('1')).to.be.rejectedWith(
+        Error,
+        /Failed to get token when attempting to call delius: .*?\/staff\/staffCode\/1\/managedOffenders/
+      )
     })
   })
 

--- a/test/services/roContactDetailServiceTest.js
+++ b/test/services/roContactDetailServiceTest.js
@@ -3,13 +3,17 @@ const createRoContactDetailsService = require('../../server/services/roContactDe
 describe('roContactDetailsService', () => {
   let service
   let userAdminService
+  let roService
 
   beforeEach(() => {
     userAdminService = {
       getRoUserByDeliusId: sinon.stub(),
     }
+    roService = {
+      getStaffByCode: sinon.stub(),
+    }
 
-    service = createRoContactDetailsService(userAdminService)
+    service = createRoContactDetailsService(userAdminService, roService)
   })
 
   describe('getContactDetails', () => {
@@ -26,6 +30,7 @@ describe('roContactDetailsService', () => {
 
       expect(result).to.eql(fullContactInfo)
       expect(userAdminService.getRoUserByDeliusId).to.be.calledWith('delius-1')
+      expect(roService.getStaffByCode).not.to.be.calledWith('delius-1')
     })
 
     it('no staff record', async () => {
@@ -35,6 +40,7 @@ describe('roContactDetailsService', () => {
 
       expect(result).to.eql(null)
       expect(userAdminService.getRoUserByDeliusId).to.be.calledWith('delius-1')
+      expect(roService.getStaffByCode).to.be.calledWith('delius-1')
     })
   })
 })


### PR DESCRIPTION
Merely logging result for now.

Also throwing error if can't get a token using client credentials when calling delius.

This would have previously thrown an auth error which would log the user out of the app but as this is client credential this situation would only happen with a programming error (so should result in a 500 status)