### PR TITLE
DCS-276 Ignoring when is COM is not the responsible officer.

### DIFF
--- a/server/services/roService.js
+++ b/server/services/roService.js
@@ -146,6 +146,7 @@ function formatCom(com) {
     )
     return {
       name: name || null,
+      isAllocated: true,
       deliusId: getIn(com, [0, 'staffCode']) || null,
       nomsNumber: rest.nomsNumber,
       lduCode: rest.lduCode,
@@ -163,19 +164,14 @@ function formatCom(com) {
  * @returns {ResponsibleOfficerResult}
  */
 function extractOffenderManager(offenderNumber, offenderManagers) {
-  const responsibleOfficer = offenderManagers.find(
-    manager => manager.isResponsibleOfficer && !manager.isPrisonOffenderManager
-  )
+  const responsibleOfficer = offenderManagers.find(manager => !manager.isPrisonOffenderManager)
   if (!responsibleOfficer) {
     return { message: `Offender has not been assigned a COM: ${offenderNumber}` }
-  }
-  if (responsibleOfficer.isUnallocated) {
-    // TODO: Need to potentially alert clearing office, if not assigned.
-    logger.warn(`responsible officer is an 'unallocated user': ${offenderNumber}`)
   }
   const {
     staff: { forenames, surname },
     staffCode,
+    isUnallocated,
     team: { localDeliveryUnit },
     probationArea,
   } = responsibleOfficer
@@ -187,6 +183,7 @@ function extractOffenderManager(offenderNumber, offenderManagers) {
   )
   return {
     name,
+    isAllocated: !isUnallocated,
     deliusId: staffCode,
     nomsNumber: offenderNumber,
     lduCode: localDeliveryUnit.code,

--- a/test/services/roServiceTest.js
+++ b/test/services/roServiceTest.js
@@ -42,6 +42,7 @@ describe('roService', () => {
   describe('formatCom', () => {
     it('should extract first coms first and last name and capitalise', () => {
       const expectedOutput = {
+        isAllocated: true,
         deliusId: 'deliusStaffCode',
         name: 'First Last',
         lduCode: 'code-1',
@@ -152,6 +153,7 @@ describe('roService', () => {
       const expectedComData = {
         deliusId: 'delius1',
         name: 'Comfirst Comlast',
+        isAllocated: true,
         lduCode: 'code-1',
         lduDescription: 'lduDescription-1',
         nomsNumber: 'AAAA12',
@@ -199,6 +201,7 @@ describe('roService', () => {
           isResponsibleOfficer: true,
           staff: { forenames: 'Jo', surname: 'Smith' },
           staffCode: 'CODE-1',
+          isUnallocated: false,
           team: { localDeliveryUnit: { code: 'LDU-1', description: 'LDU-1 Description' } },
           probationArea: { code: 'PROB-1', description: 'PROB-1 Description' },
         },
@@ -207,6 +210,7 @@ describe('roService', () => {
       const expectedComData = {
         deliusId: 'CODE-1',
         lduCode: 'LDU-1',
+        isAllocated: true,
         lduDescription: 'LDU-1 Description',
         name: 'Jo Smith',
         nomsNumber: 1,
@@ -218,7 +222,7 @@ describe('roService', () => {
     })
 
     it('offender has not been assigned a COM', () => {
-      deliusClient.getAllOffenderManagers.resolves([{ isResponsibleOfficer: false }])
+      deliusClient.getAllOffenderManagers.resolves([{ isPrisonOffenderManager: true }])
 
       const expectedComData = {
         message: 'Offender has not been assigned a COM: 1',

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -8,6 +8,7 @@ interface ResponsibleOfficer {
   lduDescription: string
   probationAreaCode: string
   probationAreaDescription: string
+  isAllocated: boolean,
 }
 
 interface ResponsibleOfficerAndContactDetails extends ResponsibleOfficer {


### PR DESCRIPTION
Also enriching responsible officer with allocated state.

We don't need to explicitly info or handle the situation when the COM has not been assigned as the responsible officer:
* When sending a notification, the fact they've received the email will lead to the RO initiating the data fix
* When checking if a CA should process a case, the COM won't be the RO as this happens soon after sentencing.

Also allowing querying whether the officer is an unallocated user at higher levels rather than throwing away.