### PR TITLE
DCS-263 bugfix to add UNIQUE constraint

### DIFF
--- a/migrations/20191202091906_create-active-local-delivery-units-table.js
+++ b/migrations/20191202091906_create-active-local-delivery-units-table.js
@@ -6,7 +6,10 @@ exports.up = knex =>
         .timestamp('timestamp')
         .notNullable()
         .defaultTo(knex.fn.now())
-      table.string('ldu_code', 10).notNullable()
+      table
+        .string('ldu_code', 10)
+        .notNullable()
+        .unique()
       table.index(['ldu_code'], 'ldu_code')
     }),
   ])


### PR DESCRIPTION
The migration file to create active_local_delivery_units needed the ldu_code field to have a UNIQUE contraint. Otherwise ON CONFLICT causes an error.