### PR TITLE
DCS-263-add UNIQUE constraint

### DIFF
--- a/migrations/20191206100315_alter_active_local_delivery_units.js
+++ b/migrations/20191206100315_alter_active_local_delivery_units.js
@@ -1,0 +1,20 @@
+exports.up = knex =>
+  Promise.all([
+    knex.schema.alterTable('active_local_delivery_units', table => {
+      table
+        .string('ldu_code', 10)
+        .notNullable()
+        .unique()
+        .alter()
+    }),
+  ])
+
+exports.down = knex =>
+  Promise.all([
+    knex.schema.alterTable('active_local_delivery_units', table => {
+      table
+        .string('ldu_code', 10)
+        .notNullable()
+        .alter()
+    }),
+  ])


### PR DESCRIPTION
The migration to create the active_local_delivery_units table has a column called ldu_code.
The UNIQUE constraint was previously missed so a new migration has been created to alter the table and add the constraint to ldu_code