### PR TITLE
DCS-262 Recording warnings when issues occur

### DIFF
--- a/migrations/20191213164035_create-warning-table.js
+++ b/migrations/20191213164035_create-warning-table.js
@@ -1,0 +1,20 @@
+exports.up = knex =>
+  knex.schema.createTable('warnings', table => {
+    table.increments('id').primary('pk_warnings')
+    table
+      .timestamp('timestamp')
+      .notNullable()
+      .defaultTo(knex.fn.now())
+    table
+      .integer('booking_id')
+      .unique()
+      .notNullable()
+    table.string('code').notNullable()
+    table.string('message').notNullable()
+    table.boolean('acknowledged').notNullable()
+    table.index(['timestamp'], 'timestamp')
+    table.index(['acknowledged'], 'acknowledged')
+    table.index(['booking_id'], 'bookingId')
+  })
+
+exports.down = knex => knex.schema.dropTable('warnings')

--- a/migrations/20191213164035_create-warning-table.js
+++ b/migrations/20191213164035_create-warning-table.js
@@ -1,20 +1,21 @@
 exports.up = knex =>
-  knex.schema.createTable('warnings', table => {
-    table.increments('id').primary('pk_warnings')
-    table
-      .timestamp('timestamp')
-      .notNullable()
-      .defaultTo(knex.fn.now())
-    table
-      .integer('booking_id')
-      .unique()
-      .notNullable()
-    table.string('code').notNullable()
-    table.string('message').notNullable()
-    table.boolean('acknowledged').notNullable()
-    table.index(['timestamp'], 'timestamp')
-    table.index(['acknowledged'], 'acknowledged')
-    table.index(['booking_id'], 'bookingId')
-  })
+  knex.schema
+    .createTable('warnings', table => {
+      table.increments('id').primary('pk_warnings')
+      table
+        .timestamp('timestamp')
+        .notNullable()
+        .defaultTo(knex.fn.now())
+      table.integer('booking_id').notNullable()
+      table.string('code').notNullable()
+      table.string('message').notNullable()
+      table.boolean('acknowledged').notNullable()
+      table.index(['timestamp'], 'timestamp')
+      table.index(['acknowledged'], 'acknowledged')
+      table.index(['booking_id'], 'bookingId')
+    })
+    .then(() =>
+      knex.raw(`CREATE UNIQUE INDEX unique_active_warning ON warnings (booking_id, code) WHERE acknowledged = false;`)
+    )
 
 exports.down = knex => knex.schema.dropTable('warnings')

--- a/server/data/probationTeamsClient.js
+++ b/server/data/probationTeamsClient.js
@@ -14,7 +14,6 @@ const apiUrl = `${config.probationTeams.apiUrl}`
  */
 
 /**
- *
  * @return { ProbationTeamsClient }
  */
 module.exports = signInService => {

--- a/server/data/warningClient.js
+++ b/server/data/warningClient.js
@@ -1,0 +1,60 @@
+/**
+ * @typedef {import('../../types/licences').WarningClient} WarningClient
+ */
+
+const db = require('./dataAccess/db')
+
+/**
+ * @type { WarningClient }
+ */
+const WarningClient = {
+  async raiseWarning(bookingId, code, messsage) {
+    const query = {
+      text: `INSERT INTO warnings (booking_id, code, message, acknowledged) VALUES ($1, $2, $3, false) ON CONFLICT (booking_id) DO NOTHING`,
+      values: [bookingId, code, messsage],
+    }
+    return db.query(query)
+  },
+
+  async acknowledgeWarning(errorId) {
+    const query = {
+      text: `UPDATE warnings SET acknowledged = true WHERE id=$1`,
+      values: [errorId],
+    }
+
+    const { rows } = await db.query(query)
+    return parseInt(rows[0].count, 10) > 0
+  },
+
+  async getOutstandingWarnings() {
+    const query = {
+      text: `SELECT id
+      ,      booking_id "bookingId"
+      ,      timestamp 
+      ,      code
+      ,      message
+      FROM warnings   
+      where acknowledged = false
+      ORDER BY timestamp DESC
+      LIMIT 500`,
+    }
+    return db.query(query).rows
+  },
+
+  getAcknowledgedWarnings() {
+    const query = {
+      text: `SELECT id
+      ,      booking_id "bookingId"
+      ,      timestamp 
+      ,      code
+      ,      message
+      FROM warnings   
+      where acknowledged = true
+      ORDER BY timestamp DESC
+      LIMIT 500`,
+    }
+    return db.query(query).rows
+  },
+}
+
+module.exports = WarningClient

--- a/server/data/warningClient.js
+++ b/server/data/warningClient.js
@@ -10,7 +10,8 @@ const db = require('./dataAccess/db')
 const WarningClient = {
   async raiseWarning(bookingId, code, messsage) {
     const query = {
-      text: `INSERT INTO warnings (booking_id, code, message, acknowledged) VALUES ($1, $2, $3, false) ON CONFLICT (booking_id) DO NOTHING`,
+      text: `INSERT INTO warnings (booking_id, code, message, acknowledged) VALUES ($1, $2, $3, false) 
+      ON CONFLICT (booking_id, code) where acknowledged = false DO NOTHING`,
       values: [bookingId, code, messsage],
     }
     return db.query(query)

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ const dbLockingClient = require('./data/dbLockingClient')
 const nomisClientBuilder = require('./data/nomisClientBuilder')
 const pdfFormatter = require('./services/utils/pdfFormatter')
 const lduActiveClient = require('./data/activeLduClient')
+const warningClient = require('./data/warningClient')
 
 const notifyClient = new NotifyClient(config.notifications.notifyKey)
 const createSignInService = require('./authentication/signInService')
@@ -46,6 +47,7 @@ const licenceService = createLicenceService(licenceClient)
 const conditionsService = createConditionsService(config)
 const deliusClient = createDeliusClient(signInService)
 const probationTeamsClient = createProbationTeamsClient(signInService)
+
 const roService = createRoService(deliusClient, nomisClientBuilder)
 const caService = createCaService(roService, lduActiveClient)
 const prisonerService = createPrisonerService(nomisClientBuilder, roService)
@@ -76,7 +78,8 @@ const notificationService = createNotificationService(
   audit,
   licenceService,
   prisonerService,
-  roContactDetailsService
+  roContactDetailsService,
+  warningClient
 )
 const reminderService = createReminderService(
   roContactDetailsService,

--- a/server/services/notifications/notificationService.js
+++ b/server/services/notifications/notificationService.js
@@ -66,13 +66,10 @@ module.exports = function createNotificationService(
     const [responsibleOfficer, error] = unwrapResult(result)
     if (error) {
       logger.error(`Problem retrieving contact details: ${error.message}`)
-      switch (error.code) {
-        case STAFF_NOT_LINKED:
-          await warningClient.raiseWarning(bookingId, error.code, error.message)
-          return
-        default:
-          return
+      if (error.code === STAFF_NOT_LINKED) {
+        await warningClient.raiseWarning(bookingId, error.code, error.message)
       }
+      return
     }
 
     if (isEmpty(prison)) {

--- a/server/services/roContactDetailsService.js
+++ b/server/services/roContactDetailsService.js
@@ -84,10 +84,10 @@ module.exports = function createRoContactDetailsService(userAdminService, roServ
         return localDetails
       }
 
-      const [mailboxes, mailboxesError] = unwrapResult(await getMailboxes(deliusRo.deliusId, deliusRo.lduCode))
+      const [mailboxes, staffLookupError] = unwrapResult(await getMailboxes(deliusRo.deliusId, deliusRo.lduCode))
 
-      if (mailboxesError) {
-        return mailboxesError
+      if (staffLookupError) {
+        return staffLookupError
       }
 
       return {

--- a/test/data/warningClientTest.js
+++ b/test/data/warningClientTest.js
@@ -19,7 +19,8 @@ describe('warningClient', () => {
 
   describe('raiseWarning', () => {
     it('should pass in the correct sql', () => {
-      const expectedInsert = `INSERT INTO warnings (booking_id, code, message, acknowledged) VALUES ($1, $2, $3, false) ON CONFLICT (booking_id) DO NOTHING`
+      const expectedInsert = `INSERT INTO warnings (booking_id, code, message, acknowledged) VALUES ($1, $2, $3, false) 
+      ON CONFLICT (booking_id, code) where acknowledged = false DO NOTHING`
 
       const result = warningClientProxy().raiseWarning(1, 'code-1', 'messsage-1')
 

--- a/test/data/warningClientTest.js
+++ b/test/data/warningClientTest.js
@@ -1,0 +1,98 @@
+const proxyquire = require('proxyquire')
+
+proxyquire.noCallThru()
+
+describe('warningClient', () => {
+  let queryStub
+
+  const warningClientProxy = (query = queryStub) => {
+    return proxyquire('../../server/data/warningClient', {
+      './dataAccess/db': {
+        query,
+      },
+    })
+  }
+
+  beforeEach(() => {
+    queryStub = sinon.stub()
+  })
+
+  describe('raiseWarning', () => {
+    it('should pass in the correct sql', () => {
+      const expectedInsert = `INSERT INTO warnings (booking_id, code, message, acknowledged) VALUES ($1, $2, $3, false) ON CONFLICT (booking_id) DO NOTHING`
+
+      const result = warningClientProxy().raiseWarning(1, 'code-1', 'messsage-1')
+
+      return result.then(() => {
+        const { text, values } = queryStub.getCalls()[0].args[0]
+        expect(text).to.include(expectedInsert)
+        expect(values).to.eql([1, 'code-1', 'messsage-1'])
+      })
+    })
+  })
+
+  describe('acknowledgeWarning', () => {
+    it('should pass in the correct sql', async () => {
+      queryStub = sinon.stub().resolves({ rows: [{ count: 1 }] })
+      const expectedInsert = `UPDATE warnings SET acknowledged = true WHERE id=$1`
+
+      await warningClientProxy().acknowledgeWarning(1)
+
+      const { text, values } = queryStub.getCalls()[0].args[0]
+      expect(text).to.include(expectedInsert)
+      expect(values).to.eql([1])
+    })
+
+    it('should return true if warning is present', async () => {
+      queryStub = sinon.stub().resolves({ rows: [{ count: 1 }] })
+      const result = await warningClientProxy().acknowledgeWarning(1)
+      expect(result).to.eql(true)
+    })
+
+    it('should return false if warning is not present', async () => {
+      queryStub = sinon.stub().resolves({ rows: [{ count: 0 }] })
+      const result = await warningClientProxy().acknowledgeWarning(1)
+      expect(result).to.eql(false)
+    })
+  })
+
+  describe('getAcknowledgedWarnings', () => {
+    it('should pass in the correct sql', async () => {
+      queryStub = sinon.stub().resolves({ rows: [{ count: 1 }] })
+
+      await warningClientProxy().getAcknowledgedWarnings()
+
+      const { text, values } = queryStub.getCalls()[0].args[0]
+      expect(text).to.eql(`SELECT id
+      ,      booking_id "bookingId"
+      ,      timestamp 
+      ,      code
+      ,      message
+      FROM warnings   
+      where acknowledged = true
+      ORDER BY timestamp DESC
+      LIMIT 500`)
+      expect(values).to.eql(undefined)
+    })
+  })
+
+  describe('getOutstandingWarnings', () => {
+    it('should pass in the correct sql', async () => {
+      queryStub = sinon.stub().resolves({ rows: [{ count: 1 }] })
+
+      await warningClientProxy().getOutstandingWarnings()
+
+      const { text, values } = queryStub.getCalls()[0].args[0]
+      expect(text).to.eql(`SELECT id
+      ,      booking_id "bookingId"
+      ,      timestamp 
+      ,      code
+      ,      message
+      FROM warnings   
+      where acknowledged = false
+      ORDER BY timestamp DESC
+      LIMIT 500`)
+      expect(values).to.eql(undefined)
+    })
+  })
+})

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -75,3 +75,18 @@ export interface PrisonerService {
 export interface CaService {
   getReasonForNotContinuing: (bookingId: number, token: string) => Promise<string | undefined>
 }
+
+export interface Warning {
+  id: number
+  bookingId: number
+  timestamp: Date
+  code: string
+  messsage: string
+}
+
+export interface WarningClient {
+  raiseWarning: (bookingId: number, code: string, messsage: string) => Promise<void>
+  acknowledgeWarning: (errorId: number) => Promise<boolean>
+  getOutstandingWarnings: () => Promise<List<Warning>>
+  getAcknowledgedWarnings: () => Promise<List<Warning>> 
+}


### PR DESCRIPTION
This provide a general error/warnings queue to expose to the internal team.

This ticket covers storing warnings whenever a CA attempts to assign a case to an RO who has an unlinked account.
These ROs will not be notified that a case has been assigned to them - and some manual work needs to be done to fix the record.

There are other places where we merely log errors on things which end up biting us which could be surfaced in the queue and hopefully reduce the maintenance overhead of the service.