### PR TITLE
DCS-264-feature flag created and tests updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
       NOMIS_AUTH_URL: https://nomis-oauth2-server.herokuapp.com/auth
       DELIUS_API_URL: https://licences-demo-mocks.herokuapp.com/communityapi
       PROBATION_TEAMS_API_URL: https://licences-demo-mocks.herokuapp.com/probationteams
+      CONTINUE_CA_TO_RO_FEATURE_FLAG: yes
     steps:
       - checkout
       - attach_workspace:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - PDF_SERVICE_HOST=http://hdc-pdfgenerator:8080
       - GLOBAL_SEARCH_URL=http://localhost:3002/global-search
       - ENABLE_TEST_UTILS=true
+      - CONTINUE_CA_TO_RO_FEATURE_FLAG=yes
 
   probation-teams:
     image: mojdigitalstudio/probation-teams:latest

--- a/helm_deploy/licences/templates/_envs.tpl
+++ b/helm_deploy/licences/templates/_envs.tpl
@@ -117,6 +117,9 @@ env:
 
   - name: PROBATION_TEAMS_API_URL
     value: {{ .Values.env.PROBATION_TEAMS_API_URL | quote }}
+  
+  - name: CONTINUE_CA_TO_RO_FEATURE_FLAG
+    value: {{ .Values.env.CONTINUE_CA_TO_RO_FEATURE_FLAG | quote }}
 
   - name: NODE_ENV
     value: production

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -31,3 +31,4 @@ env:
   DELIUS_API_URL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
   DELIUS_API_PREFIX: "/secure"
   PROBATION_TEAMS_API_URL: "https://probation-teams-dev.prison.service.justice.gov.uk"
+  CONTINUE_CA_TO_RO_FEATURE_FLAG: "yes"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -29,6 +29,7 @@ env:
   DELIUS_API_URL: "https://community-api-secure.pre-prod.delius.probation.hmpps.dsd.io"
   DELIUS_API_PREFIX: "/secure"
   PROBATION_TEAMS_API_URL: "https://probation-teams-preprod.prison.service.justice.gov.uk"
+  CONTINUE_CA_TO_RO_FEATURE_FLAG: "no"
 
 whitelist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -29,6 +29,7 @@ env:
   DELIUS_API_URL: "https://community-api-secure.probation.service.justice.gov.uk"
   DELIUS_API_PREFIX: "/secure"
   PROBATION_TEAMS_API_URL: "https://probation-teams.prison.service.justice.gov.uk"
+  CONTINUE_CA_TO_RO_FEATURE_FLAG: "no"
 
 whitelist:
   office: "217.33.148.210/32"

--- a/server/config.js
+++ b/server/config.js
@@ -147,4 +147,6 @@ module.exports = {
     autostart: get('SCHEDULED_JOBS_AUTOSTART', 'no') === 'yes',
     overlapTimeout: get('SCHEDULED_JOBS_OVERLAP', 5000),
   },
+
+  continueCaToRoFeatureFlag: get('CONTINUE_CA_TO_RO_FEATURE_FLAG', 'yes'),
 }

--- a/server/config.js
+++ b/server/config.js
@@ -148,5 +148,5 @@ module.exports = {
     overlapTimeout: get('SCHEDULED_JOBS_OVERLAP', 5000),
   },
 
-  continueCaToRoFeatureFlag: get('CONTINUE_CA_TO_RO_FEATURE_FLAG', 'yes'),
+  continueCaToRoFeatureFlag: get('CONTINUE_CA_TO_RO_FEATURE_FLAG', 'no') === 'yes',
 }

--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ const deliusClient = createDeliusClient(signInService)
 const probationTeamsClient = createProbationTeamsClient(signInService)
 
 const roService = createRoService(deliusClient, nomisClientBuilder)
-const caService = createCaService(roService, lduActiveClient)
+const caService = createCaService(roService, lduActiveClient, config)
 const prisonerService = createPrisonerService(nomisClientBuilder, roService)
 const caseListFormatter = createCaseListFormatter(logger, licenceClient)
 const caseListService = createCaseListService(nomisClientBuilder, roService, licenceClient, caseListFormatter)

--- a/server/services/caService.js
+++ b/server/services/caService.js
@@ -16,9 +16,13 @@ const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, LDU_INACTIVE, COM_NOT_ALLOCATED } =
  * @param {RoService} roService
  * @returns {CaService} caService
  */
-module.exports = function createCaService(roService, lduActiveClient) {
+module.exports = function createCaService(roService, lduActiveClient, { continueCaToRoFeatureFlag }) {
   return {
     async getReasonForNotContinuing(bookingId, token) {
+      if (continueCaToRoFeatureFlag === 'yes') {
+        return null
+      }
+
       const [ro, error] = unwrapResult(await roService.findResponsibleOfficer(bookingId, token))
 
       if (error) {

--- a/server/services/caService.js
+++ b/server/services/caService.js
@@ -19,7 +19,7 @@ const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, LDU_INACTIVE, COM_NOT_ALLOCATED } =
 module.exports = function createCaService(roService, lduActiveClient, { continueCaToRoFeatureFlag }) {
   return {
     async getReasonForNotContinuing(bookingId, token) {
-      if (continueCaToRoFeatureFlag === 'yes') {
+      if (!continueCaToRoFeatureFlag) {
         return null
       }
 

--- a/test/services/caServiceTest.js
+++ b/test/services/caServiceTest.js
@@ -5,67 +5,97 @@ describe('caService', () => {
   let caService
   const lduActiveClient = { isLduPresent: () => {} }
 
-  describe('Responsible Officer is allocated and Ldu determined', () => {
-    const responsibleOfficer = {
-      isAllocated: true,
-      lduCode: 'ldu-123',
-    }
-
-    beforeEach(() => {
-      roService = {
-        findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer),
+  describe('Creating the caService', () => {
+    describe('Ro is allocated, ldu is active and continueCaToRoFeatureFlag is yes', async () => {
+      const responsibleOfficer = {
+        isAllocated: true,
+        lduCode: 'ldu-123',
       }
-      caService = createCaService(roService, lduActiveClient)
-    })
 
-    describe('getReasonForNotContinuing ', () => {
-      it('should return null because Ro is COM and ldu is active', async () => {
+      roService = { findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer) }
+      const config = { continueCaToRoFeatureFlag: 'yes' }
+      caService = createCaService(roService, lduActiveClient, config)
+
+      it('Should return null', async () => {
         lduActiveClient.isLduPresent = sinon.stub().resolves(true)
-
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
         expect(result).to.eql(null)
       })
-
-      it('should return LDU_INACTIVE because ldu is not active', async () => {
-        lduActiveClient.isLduPresent = sinon.stub().resolves(false)
-
-        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql('LDU_INACTIVE')
-      })
-
-      it('should return COM_NOT_ALLOCATED because COM has not been assigned', async () => {
-        lduActiveClient.isLduPresent = sinon.stub().resolves(true)
-        responsibleOfficer.isAllocated = false
-
-        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql('COM_NOT_ALLOCATED')
-        responsibleOfficer.isAllocated = true
-      })
     })
-  })
 
-  describe('Responsible officer not assigned or Ldu not determined', () => {
-    const error = {
-      code: 'NO_OFFENDER_NUMBER',
-      message: 'Offender number not entered in delius',
-    }
-
-    beforeEach(() => {
-      roService = {
-        findResponsibleOfficer: sinon.stub().resolves(error),
+    describe('Responsible Officer is allocated and Ldu is determined but continueCaToRoFeatureFlag is no', () => {
+      const responsibleOfficer = {
+        isAllocated: true,
+        lduCode: 'ldu-123',
       }
-      caService = createCaService(roService, lduActiveClient)
-    })
-    describe('getReasonForNotContinuing', () => {
-      it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
-        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql('NO_OFFENDER_NUMBER')
+
+      beforeEach(() => {
+        roService = {
+          findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer),
+        }
+
+        const config = { continueCaToRoFeatureFlag: 'no' }
+
+        caService = createCaService(roService, lduActiveClient, config)
       })
 
-      it('should return NO_COM_ASSIGNED', async () => {
-        error.code = 'NO_COM_ASSIGNED'
-        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql('NO_COM_ASSIGNED')
+      describe('getReasonForNotContinuing ', () => {
+        it('should return null because Ro is COM and ldu is active but continueCaToRoFeatureFlag is no', async () => {
+          lduActiveClient.isLduPresent = sinon.stub().resolves(true)
+
+          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+          expect(result).to.eql(null)
+        })
+
+        it('should return LDU_INACTIVE because ldu is not active', async () => {
+          lduActiveClient.isLduPresent = sinon.stub().resolves(false)
+          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+          expect(result).to.eql('LDU_INACTIVE')
+        })
+
+        it('should return COM_NOT_ALLOCATED because COM has not been assigned', async () => {
+          lduActiveClient.isLduPresent = sinon.stub().resolves(true)
+          responsibleOfficer.isAllocated = false
+
+          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+          expect(result).to.eql('COM_NOT_ALLOCATED')
+        })
+
+        it('should return LDU_INACTIVE because continueCaToRoFeatureFlag is no', async () => {
+          lduActiveClient.isLduPresent = sinon.stub().resolves(false)
+
+          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+          expect(result).to.eql('LDU_INACTIVE')
+        })
+      })
+    })
+
+    describe('Responsible officer not assigned or Ldu not determined, roService returns error', () => {
+      const error = {
+        code: 'NO_OFFENDER_NUMBER',
+        message: 'Offender number not entered in delius',
+      }
+
+      beforeEach(() => {
+        roService = {
+          findResponsibleOfficer: sinon.stub().resolves(error),
+        }
+
+        const config = { continueCaToRoFeatureFlag: 'no' }
+
+        caService = createCaService(roService, lduActiveClient, config)
+      })
+      describe('getReasonForNotContinuing', () => {
+        it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
+          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+          expect(result).to.eql('NO_OFFENDER_NUMBER')
+        })
+
+        it('should return NO_COM_ASSIGNED', async () => {
+          error.code = 'NO_COM_ASSIGNED'
+          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+          expect(result).to.eql('NO_COM_ASSIGNED')
+        })
       })
     })
   })

--- a/test/services/caServiceTest.js
+++ b/test/services/caServiceTest.js
@@ -1,19 +1,19 @@
 const createCaService = require('../../server/services/caService')
-
+// nb: the continueCaToRoFeatureFlag is negated in the caService so false will be true and vice-versa
 describe('caService', () => {
   let roService
   let caService
   const lduActiveClient = { isLduPresent: () => {} }
 
   describe('Creating the caService', () => {
-    describe('Ro is allocated, ldu is active and continueCaToRoFeatureFlag is yes', async () => {
+    describe('Ro is allocated, ldu is active and continueCaToRoFeatureFlag is true', async () => {
       const responsibleOfficer = {
         isAllocated: true,
         lduCode: 'ldu-123',
       }
 
       roService = { findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer) }
-      const config = { continueCaToRoFeatureFlag: 'yes' }
+      const config = { continueCaToRoFeatureFlag: false }
       caService = createCaService(roService, lduActiveClient, config)
 
       it('Should return null', async () => {
@@ -23,7 +23,7 @@ describe('caService', () => {
       })
     })
 
-    describe('Responsible Officer is allocated and Ldu is determined but continueCaToRoFeatureFlag is no', () => {
+    describe('Responsible Officer is allocated and Ldu is determined but continueCaToRoFeatureFlag is false', () => {
       const responsibleOfficer = {
         isAllocated: true,
         lduCode: 'ldu-123',
@@ -34,13 +34,13 @@ describe('caService', () => {
           findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer),
         }
 
-        const config = { continueCaToRoFeatureFlag: 'no' }
+        const config = { continueCaToRoFeatureFlag: true }
 
         caService = createCaService(roService, lduActiveClient, config)
       })
 
       describe('getReasonForNotContinuing ', () => {
-        it('should return null because Ro is COM and ldu is active but continueCaToRoFeatureFlag is no', async () => {
+        it('should return null because Ro is COM and ldu is active but continueCaToRoFeatureFlag is false', async () => {
           lduActiveClient.isLduPresent = sinon.stub().resolves(true)
 
           const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
@@ -61,7 +61,7 @@ describe('caService', () => {
           expect(result).to.eql('COM_NOT_ALLOCATED')
         })
 
-        it('should return LDU_INACTIVE because continueCaToRoFeatureFlag is no', async () => {
+        it('should return LDU_INACTIVE because continueCaToRoFeatureFlag is false', async () => {
           lduActiveClient.isLduPresent = sinon.stub().resolves(false)
 
           const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
@@ -81,7 +81,7 @@ describe('caService', () => {
           findResponsibleOfficer: sinon.stub().resolves(error),
         }
 
-        const config = { continueCaToRoFeatureFlag: 'no' }
+        const config = { continueCaToRoFeatureFlag: true }
 
         caService = createCaService(roService, lduActiveClient, config)
       })


### PR DESCRIPTION
This is the first part of the overall DCS-264 ticket.
Have created a continueCaToRoFeatureFlag key in config.js and passed the config object to the caService as an arg in the service building process in index.js.

The unit tests have been updated to include the the key. 
If the key is set to true, the caService will return 'null'
if the key is set to false, the caService will return the error codes or messages.
