### PR TITLE
DCS-267 Adding active LDU script

### DIFF
--- a/job/gatherActiveLdus.js
+++ b/job/gatherActiveLdus.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+const logger = require('../log')
+const db = require('../server/data/dataAccess/db')
+const { unwrapResult } = require('../server/utils/functionalHelpers')
+
+const nomisClientBuilder = require('../server/data/nomisClientBuilder')
+const createSignInService = require('../server/authentication/signInService')
+const createDeliusClient = require('../server/data/deliusClient')
+const createRoService = require('../server/services/roService')
+
+const signInService = createSignInService()
+const deliusClient = createDeliusClient(signInService)
+const roService = createRoService(deliusClient, nomisClientBuilder)
+
+const getBookingIds = async () => {
+  const query = {
+    text: `select booking_id
+    from licences
+    where stage != 'ELIGIBILITY'`,
+  }
+
+  const { rows } = await db.query(query)
+  return rows.map(row => row.booking_id)
+}
+
+module.exports = async () => {
+  const bookingIds = await getBookingIds()
+  const token = await signInService.getAnonymousClientCredentialsTokens()
+  const ldus = new Set()
+  const missingRos = new Set()
+
+  let count = 0
+  for (const bookingId of bookingIds) {
+    const [ro, roError] = unwrapResult(await roService.findResponsibleOfficer(bookingId, token.token))
+    if (roError) {
+      logger.error(`Error retrieving RO for booking: '${bookingId}', reason: ${roError.message}`)
+      missingRos.add({ bookingId, reason: roError.message })
+    } else {
+      count += 1
+      ldus.add(ro.lduCode)
+    }
+  }
+  logger.info(`m Retrieved ldus: ${Array.from(ldus)} from ${count}/${bookingIds.length} bookings`, {
+    ldus: Array.from(ldus),
+    missingRos: Array.from(missingRos),
+  })
+}

--- a/job/run.js
+++ b/job/run.js
@@ -1,0 +1,4 @@
+const logger = require('../log')
+const job = require('./gatherActiveLdus')
+
+job().catch(error => logger.error(error, 'Problem polling for reminders'))

--- a/log.js
+++ b/log.js
@@ -1,17 +1,11 @@
-const winston = require('winston')
-const { AzureApplicationInsightsLogger } = require('winston-azure-application-insights')
+// eslint-disable-next-line import/order
 const appInsights = require('./azure-appinsights')
+const { AzureApplicationInsightsLogger } = require('winston-azure-application-insights')
+const winston = require('winston')
 const { flattenMeta } = require('./server/misc')
 
 const logger = new winston.Logger()
 
-logger.setLevels({
-  audit: 0,
-  error: 1,
-  warn: 2,
-  info: 3,
-  debug: 4,
-})
 winston.addColors({
   audit: 'cyan',
   error: 'red',
@@ -72,6 +66,5 @@ if (appInsights) {
     return flattenMeta(meta)
   })
 }
-/** @type {winston.LoggerInstance & {audit?: Function }} */
-const log = logger
-module.exports = log
+
+module.exports = logger

--- a/log.js
+++ b/log.js
@@ -7,7 +7,6 @@ const { flattenMeta } = require('./server/misc')
 const logger = new winston.Logger()
 
 winston.addColors({
-  audit: 'cyan',
   error: 'red',
   warn: 'yellow',
   info: 'green',

--- a/server/data/audit.js
+++ b/server/data/audit.js
@@ -19,7 +19,7 @@ module.exports = {
       throw new Error(`Unknown audit key: ${key}`)
     }
 
-    logger.audit('AUDIT', { key })
+    logger.info('AUDIT', { key })
 
     return addItem(key, user, data)
       .then(() => {

--- a/server/data/deliusClient.js
+++ b/server/data/deliusClient.js
@@ -50,7 +50,8 @@ module.exports = signInService => {
 
       return result.body
     } catch (error) {
-      logger.warn('Error calling delius', path, error.response, error.stack)
+      const message = error && error.response && error.response.text
+      logger.error(`Error calling delius: ${path}, message: '${message}'`, error.stack)
       throw error
     }
   }


### PR DESCRIPTION
In order to prevent prison staff from processing cases for probation teams which aren't currently part of HDC, We need to populate a whitelist table with active LDU (local delivery unit) codes.

This script will return the LDUs for each licence that has been processed in the app. This will be the current LDU of the officer responsible for the offender - we will then compare these results with a list of LDUs for a probation area (officers could have moved teams or reassigned) to create a master list.

This PR also fixes an issue with the logger where `setLevels` on Winston lead to incorrect severity level reporting. This seems to be an issue with overwriting some monkey patching which the app insights instrumentation applies.  

(Also reducing the amount of logging which occurs when delius errors)