### PR TITLE
DCS-264: CA tasklist displays any error messages and also disables co…

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -50,6 +50,13 @@ $path: "/public/images/";
     text-align: center;
 }
 
+.button.button-disabled{
+    color: $white;
+    background-color: govuk-colour("green");
+    min-width: 120px;
+    text-align: center;
+}
+
 .hdc-footer-wrapper {
     max-width: 1170px;
     padding-left: 15px;
@@ -374,7 +381,7 @@ a.namedAnchor {
 }
 
 // Case lists status markers
-.terminalStateAlert {
+.terminalStateAlert, .error {
     font-weight: bold;
     color: $red;
 }

--- a/server/routes/config/taskListErrors.js
+++ b/server/routes/config/taskListErrors.js
@@ -1,0 +1,7 @@
+module.exports = {
+  NO_OFFENDER_NUMBER: 'Offender number required but it is not entered in Delius',
+  NO_COM_ASSIGNED: 'A Community Offender Manager has not been assigned. Please contact the Delius team',
+  LDU_INACTIVE: 'The Local Delivery Unit is in a geographical area that is currently inactive. Please refer via Nomis',
+  COM_NOT_ALLOCATED:
+    'The Community Offender Manager (COM) assigned is a pseudo. Please arrange for an actual COM to be assigned',
+}

--- a/server/routes/viewModels/taskListModels.js
+++ b/server/routes/viewModels/taskListModels.js
@@ -3,6 +3,7 @@ const getDmTasks = require('./taskLists/dmTasks')
 const { getRoTasksPostApproval, getRoTasks } = require('./taskLists/roTasks')
 const { getCaTasksEligibility, getCaTasksFinalChecks, getCaTasksPostApproval } = require('./taskLists/caTasks')
 const getVaryTasks = require('./taskLists/varyTasks')
+const proposedAddress = require('./taskLists/tasks/proposedAddress')
 
 const taskListsConfig = {
   caTasksEligibility: {
@@ -35,7 +36,8 @@ module.exports = (
   postRelease,
   { decisions, tasks, stage },
   { version = null, versionDetails = null, approvedVersion = {}, approvedVersionDetails = {}, licence = {} } = {},
-  allowedTransition
+  allowedTransition,
+  errors
 ) => {
   const taskListName = getTaskListName(role, stage, postRelease)
 
@@ -47,6 +49,27 @@ module.exports = (
     caTasksFinalChecks: getCaTasksFinalChecks,
     caTasksPostApproval: getCaTasksPostApproval(stage),
     vary: getVaryTasks({ version, versionDetails, approvedVersion, approvedVersionDetails, licence }),
+  }
+  if (errors && errors.length > 0) {
+    return [
+      {
+        task: 'eligibilityTask',
+      },
+      {
+        title: 'Inform the offender',
+        label: 'You should now tell the offender using the relevant HDC form from NOMIS',
+        action: {
+          type: 'btn-secondary',
+          href: '/caseList/active',
+          text: 'Back to case list',
+        },
+      },
+      {
+        title: 'Curfew address',
+        label: proposedAddress.getLabel({ decisions, tasks }),
+        action: { text: 'Start now', type: 'btn-disabled', href: '' },
+      },
+    ]
   }
 
   if (!getTaskListTasksMethod[taskListName]) {

--- a/server/routes/viewModels/taskLists/caTasks.js
+++ b/server/routes/viewModels/taskLists/caTasks.js
@@ -17,35 +17,6 @@ const createLicence = require('./tasks/createLicence')
 const finalChecks = require('./tasks/finalChecks')
 
 module.exports = {
-  getCaTasksEligibilityLduInactive: ({ optedOut, eligible, decisions, tasks }) => {
-    const { eligibility, optOut } = tasks
-    const eligibilityDone = eligibility === 'DONE'
-    const optOutUnstarted = optOut === 'UNSTARTED'
-
-    return [
-      {
-        task: 'eligibilityTask',
-        visible: true,
-      },
-      {
-        title: 'Inform the offender',
-        label: 'You should now tell the offender using the relevant HDC form from NOMIS',
-        action: {
-          type: 'btn-secondary',
-          href: '/caseList/active',
-          text: 'Back to case list',
-        },
-        visible: eligibilityDone && optOutUnstarted && !optedOut,
-      },
-      {
-        title: 'Curfew address',
-        label: proposedAddress.getLabel({ decisions, tasks }),
-        action: { text: 'Start now', type: 'btn-disabled', href: '' },
-        visible: eligible,
-      },
-    ]
-  },
-
   getCaTasksEligibility: ({ decisions, tasks, allowedTransition }) => {
     const { optedOut, eligible, bassReferralNeeded, addressUnsuitable } = decisions
     const { eligibility, optOut } = tasks

--- a/server/routes/viewModels/taskLists/caTasks.js
+++ b/server/routes/viewModels/taskLists/caTasks.js
@@ -17,6 +17,35 @@ const createLicence = require('./tasks/createLicence')
 const finalChecks = require('./tasks/finalChecks')
 
 module.exports = {
+  getCaTasksEligibilityLduInactive: ({ optedOut, eligible, decisions, tasks }) => {
+    const { eligibility, optOut } = tasks
+    const eligibilityDone = eligibility === 'DONE'
+    const optOutUnstarted = optOut === 'UNSTARTED'
+
+    return [
+      {
+        task: 'eligibilityTask',
+        visible: true,
+      },
+      {
+        title: 'Inform the offender',
+        label: 'You should now tell the offender using the relevant HDC form from NOMIS',
+        action: {
+          type: 'btn-secondary',
+          href: '/caseList/active',
+          text: 'Back to case list',
+        },
+        visible: eligibilityDone && optOutUnstarted && !optedOut,
+      },
+      {
+        title: 'Curfew address',
+        label: proposedAddress.getLabel({ decisions, tasks }),
+        action: { text: 'Start now', type: 'btn-disabled', href: '' },
+        visible: eligible,
+      },
+    ]
+  },
+
   getCaTasksEligibility: ({ decisions, tasks, allowedTransition }) => {
     const { optedOut, eligible, bassReferralNeeded, addressUnsuitable } = decisions
     const { eligibility, optOut } = tasks

--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -33,6 +33,15 @@ block content
   if !user.role
     p Error
   else
+    if errorObject
+    div.largeMarginBottom
+    if errorObject && Object.keys(errorObject).length !== 0
+      div.error-summary(role="alert" aria-labelledby="error-summary-heading" tabindex="-1")
+        h2.heading-medium.error-summary-heading.center.noMargin.smallPaddingTopBottom#error-summary-heading
+          | There is a problem
+        ul.error-summary-list
+          each errorMsg in errorObject
+            li.error #{errorMsg}
     include prisonerDetails
 
     div.paddingBottom

--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -33,15 +33,14 @@ block content
   if !user.role
     p Error
   else
-    if errorObject
-    div.largeMarginBottom
-    if errorObject && Object.keys(errorObject).length !== 0
-      div.error-summary(role="alert" aria-labelledby="error-summary-heading" tabindex="-1")
-        h2.heading-medium.error-summary-heading.center.noMargin.smallPaddingTopBottom#error-summary-heading
-          | There is a problem
-        ul.error-summary-list
-          each errorMsg in errorObject
-            li.error #{errorMsg}
+    if errors 
+      div.largeMarginBottom
+        div.error-summary(role="alert" aria-labelledby="error-summary-heading" tabindex="-1")
+          h2.heading-medium.error-summary-heading.center.noMargin.smallPaddingTopBottom#error-summary-heading
+            | There is a problem
+          ul.error-summary-list
+            each errorMsg in errors
+              li.error #{errorMsg}
     include prisonerDetails
 
     div.paddingBottom

--- a/server/views/taskList/tasks/eligibilityTask.pug
+++ b/server/views/taskList/tasks/eligibilityTask.pug
@@ -1,13 +1,5 @@
-div.largeMarginBottom
-  if errorObject && Object.keys(errorObject).length !== 0
-    div.error-summary(role="alert" aria-labelledby="error-summary-heading" tabindex="-1")
-      h2.heading-medium.error-summary-heading.center.noMargin.smallPaddingTopBottom#error-summary-heading
-        | There is a problem
-      ul.error-summary-list
-        each errorMsg in errorObject
-          li.error #{errorMsg}
-  div
-    h2.heading-medium Check eligibility
+div
+  h2.heading-medium Check eligibility
   if licenceStatus.tasks.eligibility !== 'DONE'
     div.pure-g
       div.pure-u-1.pure-u-md-3-4

--- a/server/views/taskList/tasks/eligibilityTask.pug
+++ b/server/views/taskList/tasks/eligibilityTask.pug
@@ -1,4 +1,11 @@
 div.largeMarginBottom
+  if errorObject && Object.keys(errorObject).length !== 0
+    div.error-summary(role="alert" aria-labelledby="error-summary-heading" tabindex="-1")
+      h2.heading-medium.error-summary-heading.center.noMargin.smallPaddingTopBottom#error-summary-heading
+        | There is a problem
+      ul.error-summary-list
+        each errorMsg in errorObject
+          li.error #{errorMsg}
   div
     h2.heading-medium Check eligibility
   if licenceStatus.tasks.eligibility !== 'DONE'

--- a/server/views/taskList/vary/standardTask.pug
+++ b/server/views/taskList/vary/standardTask.pug
@@ -15,6 +15,7 @@ mixin action(actionConfig)
   - var isLink = actionConfig.type === 'link'
   - var isButton = actionConfig.type === 'btn'
   - var isSecondaryButton = actionConfig.type === 'btn-secondary'
+  - var isDisabledButton = actionConfig.type === 'btn-disabled'
   - var target = actionConfig.newTab ? '_blank' : null
   - var link = actionConfig.href.charAt(actionConfig.href.length - 1) === '/' ? actionConfig.href + prisonerInfo.bookingId : actionConfig.href
 
@@ -26,6 +27,9 @@ mixin action(actionConfig)
 
   else if isSecondaryButton
     a.taskListAction.center.button.button-secondary(href=link, target=target) #{actionConfig.text}
+  
+  else if isDisabledButton
+    a.taskListAction.center.button.button-disabled(disabled) #{actionConfig.text}
 
 mixin label(text)
   - var sections = text.split('||')

--- a/test/routes/taskListTest.js
+++ b/test/routes/taskListTest.js
@@ -7,6 +7,7 @@ const {
   appSetup,
   auditStub,
   createSignInServiceStub,
+  createCaServiceStub,
 } = require('../supertestSetup')
 
 const standardRouter = require('../../server/routes/routeWorkers/standardRouter')
@@ -34,17 +35,140 @@ const prisonerInfoResponse = {
 describe('GET /taskList/:prisonNumber', () => {
   let prisonerService
   let licenceService
+  let caService
 
   beforeEach(() => {
     licenceService = createLicenceServiceStub()
     prisonerService = createPrisonerServiceStub()
-    prisonerService.getPrisonerDetails = sinon.stub().resolves(prisonerInfoResponse)
+    prisonerService.getPrisonerDetails = sinon.stub().returns(prisonerInfoResponse)
+    caService = createCaServiceStub
   })
 
   describe('User is CA', () => {
+    it('should call caService.getReasonForNotContinuing', async () => {
+      licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(() => {
+          expect(caService.getReasonForNotContinuing).to.be.calledOnce()
+        })
+    })
+
+    it('should return error message for NO_OFFENDER_NUMBER', async () => {
+      licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
+      caService.getReasonForNotContinuing.resolves({ NO_OFFENDER_NUMBER: 'NO_OFFENDER_NUMBER' })
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).to.include('Offender number required but it is not entered in Delius')
+        })
+    })
+
+    it('should return error message for NO_COM_ASSIGNED', async () => {
+      licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
+      caService.getReasonForNotContinuing.resolves({ NO_COM_ASSIGNED: 'NO_COM_ASSIGNED' })
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).to.include('A Community Offender Manager has not been assigned')
+        })
+    })
+
+    it('should return error messages for LDU_INACTIVE plus COM_NOT_ALLOCATED', async () => {
+      licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
+      const errors = { LDU_INACTIVE: 'LDU_INACTIVE', COM_NOT_ALLOCATED: 'COM_NOT_ALLOCATED' }
+      caService.getReasonForNotContinuing.resolves(errors)
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).to.include(
+            'The Local Delivery Unit is in a geographical area that is currently inactive. Please refer via Nomis'
+          )
+          expect(res.text).to.include('The Community Offender Manager (COM) assigned is a pseudo.')
+        })
+    })
+
+    it('should disable the Start now button if there is an error', async () => {
+      licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
+      caService.getReasonForNotContinuing.resolves({ LDU_INACTIVE: 'LDU_INACTIVE' })
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).to.include('button-disabled')
+        })
+    })
+
+    it('should NOT disable the Start now button if there are no errors', async () => {
+      licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
+      caService.getReasonForNotContinuing.resolves()
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).to.not.include('button-disabled')
+        })
+    })
+
     it('should call getPrisonerDetails from prisonerDetailsService', () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: {} })
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
       return request(app)
         .get('/taskList/123')
         .expect(200)
@@ -57,7 +181,11 @@ describe('GET /taskList/:prisonNumber', () => {
 
     it('should should show ARD if no CRD', () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: {} })
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
       return request(app)
         .get('/taskList/123')
         .expect(200)
@@ -86,7 +214,11 @@ describe('GET /taskList/:prisonNumber', () => {
         },
       })
 
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
 
       return request(app)
         .get('/taskList/1233456')
@@ -99,7 +231,11 @@ describe('GET /taskList/:prisonNumber', () => {
     it('should handle no eligibility', () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: {} })
 
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
 
       return request(app)
         .get('/taskList/1233456')
@@ -112,7 +248,11 @@ describe('GET /taskList/:prisonNumber', () => {
     context('when the is no licence in the db for the offender', () => {
       it('should still load the taskList', () => {
         licenceService.getLicence.resolves(null)
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+        const app = createApp({
+          licenceServiceStub: licenceService,
+          prisonerServiceStub: prisonerService,
+          caServiceStub: caService,
+        })
         return request(app)
           .get('/taskList/123')
           .expect(200)
@@ -131,7 +271,11 @@ describe('GET /taskList/:prisonNumber', () => {
     })
 
     it('should redirect to eligibility section', () => {
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
 
       return request(app)
         .post('/taskList/eligibilityStart')
@@ -144,7 +288,11 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('licence exists in db', () => {
       it('should not create a new licence', () => {
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+        const app = createApp({
+          licenceServiceStub: licenceService,
+          prisonerServiceStub: prisonerService,
+          caServiceStub: caService,
+        })
 
         return request(app)
           .post('/taskList/eligibilityStart')
@@ -161,7 +309,11 @@ describe('GET /taskList/:prisonNumber', () => {
         licenceService.getLicence.resolves(undefined)
         licenceService.createLicence.resolves()
 
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+        const app = createApp({
+          licenceServiceStub: licenceService,
+          prisonerServiceStub: prisonerService,
+          caServiceStub: caService,
+        })
 
         return request(app)
           .post('/taskList/eligibilityStart')
@@ -177,7 +329,11 @@ describe('GET /taskList/:prisonNumber', () => {
         licenceService.getLicence.resolves(undefined)
         licenceService.createLicence.resolves()
 
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+        const app = createApp({
+          licenceServiceStub: licenceService,
+          prisonerServiceStub: prisonerService,
+          caServiceStub: caService,
+        })
 
         return request(app)
           .post('/taskList/eligibilityStart')
@@ -200,7 +356,11 @@ describe('GET /taskList/:prisonNumber', () => {
     })
 
     it('should redirect to vary/evidence page', () => {
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
 
       return request(app)
         .post('/taskList/varyStart')
@@ -211,7 +371,11 @@ describe('GET /taskList/:prisonNumber', () => {
 
     context('licence does not exist in db', () => {
       it('should create a new licence', () => {
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+        const app = createApp({
+          licenceServiceStub: licenceService,
+          prisonerServiceStub: prisonerService,
+          caServiceStub: caService,
+        })
 
         return request(app)
           .post('/taskList/varyStart')
@@ -231,7 +395,11 @@ describe('GET /taskList/:prisonNumber', () => {
         licenceService.getLicence.resolves(undefined)
         licenceService.createLicence.resolves()
 
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+        const app = createApp({
+          licenceServiceStub: licenceService,
+          prisonerServiceStub: prisonerService,
+          caServiceStub: caService,
+        })
 
         return request(app)
           .post('/taskList/varyStart')
@@ -249,7 +417,11 @@ describe('GET /taskList/:prisonNumber', () => {
 
   describe('GET /image/:imageId', () => {
     it('should return an image', () => {
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
 
       return request(app)
         .get('/taskList/image/123')
@@ -260,7 +432,11 @@ describe('GET /taskList/:prisonNumber', () => {
     it('should return placeholder if no image returned from nomis', () => {
       prisonerService.getPrisonerImage.resolves(null)
 
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService })
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
 
       return request(app)
         .get('/taskList/image/123')
@@ -272,7 +448,10 @@ describe('GET /taskList/:prisonNumber', () => {
   describe('User is RO', () => {
     it('should pass the client credential token not the user one', () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: {} })
-      const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService }, 'roUser')
+      const app = createApp(
+        { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+        'roUser'
+      )
       return request(app)
         .get('/taskList/123')
         .expect(200)
@@ -288,7 +467,10 @@ describe('GET /taskList/:prisonNumber', () => {
         licenceService.getLicence.resolves(undefined)
         prisonerService.getPrisonerDetails.resolves({ agencyLocationId: 'Out' })
 
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService }, 'roUser')
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'roUser'
+        )
 
         return request(app)
           .get('/taskList/123')
@@ -303,7 +485,10 @@ describe('GET /taskList/:prisonNumber', () => {
         licenceService.getLicence.resolves({ stage: 'VARY', licence: { variedFromLicenceNotInSystem: true } })
         prisonerService.getPrisonerDetails.resolves({ agencyLocationId: 'Out' })
 
-        const app = createApp({ licenceServiceStub: licenceService, prisonerServiceStub: prisonerService }, 'roUser')
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'roUser'
+        )
 
         return request(app)
           .get('/taskList/123')
@@ -317,18 +502,20 @@ describe('GET /taskList/:prisonNumber', () => {
   })
 })
 
-function createApp({ licenceServiceStub, prisonerServiceStub }, user) {
+function createApp({ licenceServiceStub, prisonerServiceStub, caServiceStub }, user) {
   const prisonerService = prisonerServiceStub || createPrisonerServiceStub()
   const licenceService = licenceServiceStub || createLicenceServiceStub()
   const signInService = createSignInServiceStub()
+  const caService = caServiceStub || createCaServiceStub
 
-  const baseRouter = standardRouter({ licenceService, prisonerService, audit: auditStub, signInService })
+  const baseRouter = standardRouter({ licenceService, prisonerService, audit: auditStub, signInService, caService })
   const route = baseRouter(
     createRoute({
       licenceService,
       prisonerService,
       caseListService: caseListServiceStub,
       audit: auditStub,
+      caService,
     }),
     { licenceRequired: false }
   )

--- a/test/routes/taskListTest.js
+++ b/test/routes/taskListTest.js
@@ -65,7 +65,7 @@ describe('GET /taskList/:prisonNumber', () => {
 
     it('should return error message for NO_OFFENDER_NUMBER', async () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
-      caService.getReasonForNotContinuing.resolves({ NO_OFFENDER_NUMBER: 'NO_OFFENDER_NUMBER' })
+      caService.getReasonForNotContinuing.resolves(['NO_OFFENDER_NUMBER'])
 
       const app = createApp({
         licenceServiceStub: licenceService,
@@ -84,7 +84,7 @@ describe('GET /taskList/:prisonNumber', () => {
 
     it('should return error message for NO_COM_ASSIGNED', async () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
-      caService.getReasonForNotContinuing.resolves({ NO_COM_ASSIGNED: 'NO_COM_ASSIGNED' })
+      caService.getReasonForNotContinuing.resolves(['NO_COM_ASSIGNED'])
 
       const app = createApp({
         licenceServiceStub: licenceService,
@@ -103,7 +103,7 @@ describe('GET /taskList/:prisonNumber', () => {
 
     it('should return error messages for LDU_INACTIVE plus COM_NOT_ALLOCATED', async () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
-      const errors = { LDU_INACTIVE: 'LDU_INACTIVE', COM_NOT_ALLOCATED: 'COM_NOT_ALLOCATED' }
+      const errors = ['LDU_INACTIVE', 'COM_NOT_ALLOCATED']
       caService.getReasonForNotContinuing.resolves(errors)
 
       const app = createApp({
@@ -126,7 +126,7 @@ describe('GET /taskList/:prisonNumber', () => {
 
     it('should disable the Start now button if there is an error', async () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
-      caService.getReasonForNotContinuing.resolves({ LDU_INACTIVE: 'LDU_INACTIVE' })
+      caService.getReasonForNotContinuing.resolves(['LDU_INACTIVE'])
 
       const app = createApp({
         licenceServiceStub: licenceService,
@@ -145,7 +145,7 @@ describe('GET /taskList/:prisonNumber', () => {
 
     it('should NOT disable the Start now button if there are no errors', async () => {
       licenceService.getLicence.resolves({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
-      caService.getReasonForNotContinuing.resolves()
+      caService.getReasonForNotContinuing.resolves([])
 
       const app = createApp({
         licenceServiceStub: licenceService,

--- a/test/services/caServiceTest.js
+++ b/test/services/caServiceTest.js
@@ -15,10 +15,10 @@ describe('caService', () => {
     caService = createCaService(roService, lduActiveClient, config)
 
     describe('getReasonForNotContinuing', async () => {
-      it('Should return null', async () => {
+      it('Should return []', async () => {
         lduActiveClient.isLduPresent = sinon.stub().resolves(true)
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql(null)
+        expect(result).to.eql([])
       })
     })
   })
@@ -30,17 +30,17 @@ describe('caService', () => {
     })
 
     describe('getReasonForNotContinuing', async () => {
-      it('should return null because RO is allocated, Ldu is active', async () => {
+      it('should return [] because RO is allocated, Ldu is active', async () => {
         lduActiveClient.isLduPresent = sinon.stub().resolves(true)
 
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql(null)
+        expect(result).to.eql([])
       })
 
       it('should return LDU_INACTIVE', async () => {
         lduActiveClient.isLduPresent = sinon.stub().resolves(false)
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql({ LDU_INACTIVE: 'LDU_INACTIVE' })
+        expect(result).to.eql(['LDU_INACTIVE'])
       })
 
       it('should return COM_NOT_ALLOCATED', async () => {
@@ -48,7 +48,7 @@ describe('caService', () => {
         responsibleOfficer.isAllocated = false
 
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql({ COM_NOT_ALLOCATED: 'COM_NOT_ALLOCATED' })
+        expect(result).to.eql(['COM_NOT_ALLOCATED'])
       })
 
       it('should return LDU_INACTIVE and COM_NOT_ALLOCATED', async () => {
@@ -57,7 +57,7 @@ describe('caService', () => {
         roService = { findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer) }
 
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).to.eql({ LDU_INACTIVE: 'LDU_INACTIVE', COM_NOT_ALLOCATED: 'COM_NOT_ALLOCATED' })
+        expect(result).to.eql(['LDU_INACTIVE', 'COM_NOT_ALLOCATED'])
       })
     })
   })
@@ -78,13 +78,13 @@ describe('caService', () => {
     })
     it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
       const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-      expect(result).to.eql({ NO_OFFENDER_NUMBER: 'NO_OFFENDER_NUMBER' })
+      expect(result).to.eql(['NO_OFFENDER_NUMBER'])
     })
 
     it('should return NO_COM_ASSIGNED', async () => {
       error.code = 'NO_COM_ASSIGNED'
       const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-      expect(result).to.eql({ NO_COM_ASSIGNED: 'NO_COM_ASSIGNED' })
+      expect(result).to.eql(['NO_COM_ASSIGNED'])
     })
   })
 })

--- a/test/services/caServiceTest.js
+++ b/test/services/caServiceTest.js
@@ -1,102 +1,90 @@
 const createCaService = require('../../server/services/caService')
-// nb: the continueCaToRoFeatureFlag is negated in the caService so false will be true and vice-versa
+
+let roService
+let caService
+const lduActiveClient = { isLduPresent: () => {} }
+const responsibleOfficer = {
+  isAllocated: true,
+  lduCode: 'ldu-123',
+}
+roService = { findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer) }
+
 describe('caService', () => {
-  let roService
-  let caService
-  const lduActiveClient = { isLduPresent: () => {} }
+  describe('Allow CA to proceed to RO', async () => {
+    const config = { continueCaToRoFeatureFlag: false }
+    caService = createCaService(roService, lduActiveClient, config)
 
-  describe('Creating the caService', () => {
-    describe('Ro is allocated, ldu is active and continueCaToRoFeatureFlag is true', async () => {
-      const responsibleOfficer = {
-        isAllocated: true,
-        lduCode: 'ldu-123',
-      }
-
-      roService = { findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer) }
-      const config = { continueCaToRoFeatureFlag: false }
-      caService = createCaService(roService, lduActiveClient, config)
-
+    describe('getReasonForNotContinuing', async () => {
       it('Should return null', async () => {
         lduActiveClient.isLduPresent = sinon.stub().resolves(true)
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
         expect(result).to.eql(null)
       })
     })
+  })
 
-    describe('Responsible Officer is allocated and Ldu is determined but continueCaToRoFeatureFlag is false', () => {
-      const responsibleOfficer = {
-        isAllocated: true,
-        lduCode: 'ldu-123',
-      }
-
-      beforeEach(() => {
-        roService = {
-          findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer),
-        }
-
-        const config = { continueCaToRoFeatureFlag: true }
-
-        caService = createCaService(roService, lduActiveClient, config)
-      })
-
-      describe('getReasonForNotContinuing ', () => {
-        it('should return null because Ro is COM and ldu is active but continueCaToRoFeatureFlag is false', async () => {
-          lduActiveClient.isLduPresent = sinon.stub().resolves(true)
-
-          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-          expect(result).to.eql(null)
-        })
-
-        it('should return LDU_INACTIVE because ldu is not active', async () => {
-          lduActiveClient.isLduPresent = sinon.stub().resolves(false)
-          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-          expect(result).to.eql('LDU_INACTIVE')
-        })
-
-        it('should return COM_NOT_ALLOCATED because COM has not been assigned', async () => {
-          lduActiveClient.isLduPresent = sinon.stub().resolves(true)
-          responsibleOfficer.isAllocated = false
-
-          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-          expect(result).to.eql('COM_NOT_ALLOCATED')
-        })
-
-        it('should return LDU_INACTIVE because continueCaToRoFeatureFlag is false', async () => {
-          lduActiveClient.isLduPresent = sinon.stub().resolves(false)
-
-          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-          expect(result).to.eql('LDU_INACTIVE')
-        })
-      })
+  describe('Prevent CA from proceeding to RO', async () => {
+    beforeEach(() => {
+      const config = { continueCaToRoFeatureFlag: true }
+      caService = createCaService(roService, lduActiveClient, config)
     })
 
-    describe('Responsible officer not assigned or Ldu not determined, roService returns error', () => {
-      const error = {
-        code: 'NO_OFFENDER_NUMBER',
-        message: 'Offender number not entered in delius',
+    describe('getReasonForNotContinuing', async () => {
+      it('should return null because RO is allocated, Ldu is active', async () => {
+        lduActiveClient.isLduPresent = sinon.stub().resolves(true)
+
+        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+        expect(result).to.eql(null)
+      })
+
+      it('should return LDU_INACTIVE', async () => {
+        lduActiveClient.isLduPresent = sinon.stub().resolves(false)
+        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+        expect(result).to.eql({ LDU_INACTIVE: 'LDU_INACTIVE' })
+      })
+
+      it('should return COM_NOT_ALLOCATED', async () => {
+        lduActiveClient.isLduPresent = sinon.stub().resolves(true)
+        responsibleOfficer.isAllocated = false
+
+        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+        expect(result).to.eql({ COM_NOT_ALLOCATED: 'COM_NOT_ALLOCATED' })
+      })
+
+      it('should return LDU_INACTIVE and COM_NOT_ALLOCATED', async () => {
+        lduActiveClient.isLduPresent = sinon.stub().resolves(false)
+        responsibleOfficer.isAllocated = false
+        roService = { findResponsibleOfficer: sinon.stub().resolves(responsibleOfficer) }
+
+        const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+        expect(result).to.eql({ LDU_INACTIVE: 'LDU_INACTIVE', COM_NOT_ALLOCATED: 'COM_NOT_ALLOCATED' })
+      })
+    })
+  })
+  describe('Responsible officer not assigned or Ldu not determined, roService returns error', () => {
+    const error = {
+      code: 'NO_OFFENDER_NUMBER',
+      message: 'Offender number not entered in delius',
+    }
+
+    beforeEach(() => {
+      roService = {
+        findResponsibleOfficer: sinon.stub().resolves(error),
       }
 
-      beforeEach(() => {
-        roService = {
-          findResponsibleOfficer: sinon.stub().resolves(error),
-        }
+      const config = { continueCaToRoFeatureFlag: true }
 
-        const config = { continueCaToRoFeatureFlag: true }
+      caService = createCaService(roService, lduActiveClient, config)
+    })
+    it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
+      const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+      expect(result).to.eql({ NO_OFFENDER_NUMBER: 'NO_OFFENDER_NUMBER' })
+    })
 
-        caService = createCaService(roService, lduActiveClient, config)
-      })
-      describe('getReasonForNotContinuing', () => {
-        it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
-          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-          expect(result).to.eql('NO_OFFENDER_NUMBER')
-        })
-
-        it('should return NO_COM_ASSIGNED', async () => {
-          error.code = 'NO_COM_ASSIGNED'
-          const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-          expect(result).to.eql('NO_COM_ASSIGNED')
-        })
-      })
+    it('should return NO_COM_ASSIGNED', async () => {
+      error.code = 'NO_COM_ASSIGNED'
+      const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
+      expect(result).to.eql({ NO_COM_ASSIGNED: 'NO_COM_ASSIGNED' })
     })
   })
 })

--- a/test/supertestSetup.js
+++ b/test/supertestSetup.js
@@ -108,6 +108,10 @@ const createNomisPushServiceStub = () => ({
   pushChecksPassed: sinon.stub().resolves(),
 })
 
+const createCaServiceStub = {
+  getReasonForNotContinuing: sinon.stub().resolves({}),
+}
+
 function testFormPageGets(app, routes, licenceServiceStub) {
   context('licence exists for bookingId', () => {
     routes.forEach(route => {
@@ -189,6 +193,7 @@ const setup = {
   authenticationMiddleware,
   testFormPageGets,
   users,
+  createCaServiceStub,
   appSetup(route, user = 'caUser', prefix = '') {
     const app = express()
 

--- a/test/supertestSetup.js
+++ b/test/supertestSetup.js
@@ -109,7 +109,7 @@ const createNomisPushServiceStub = () => ({
 })
 
 const createCaServiceStub = {
-  getReasonForNotContinuing: sinon.stub().resolves({}),
+  getReasonForNotContinuing: sinon.stub().resolves([]),
 }
 
 function testFormPageGets(app, routes, licenceServiceStub) {

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -75,7 +75,7 @@ export interface PrisonerService {
 } 
 
 export interface CaService {
-  getReasonForNotContinuing: (bookingId: number, token: string) => Promise<object | undefined>
+  getReasonForNotContinuing: (bookingId: number, token: string) => Promise<Array<string> | undefined>
 }
 
 export interface Warning {

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -75,7 +75,7 @@ export interface PrisonerService {
 } 
 
 export interface CaService {
-  getReasonForNotContinuing: (bookingId: number, token: string) => Promise<string | undefined>
+  getReasonForNotContinuing: (bookingId: number, token: string) => Promise<object | undefined>
 }
 
 export interface Warning {


### PR DESCRIPTION
…ntinue button

http://localhost:3000/hdc/taskList/bookingId

The CA is prevented from progressing from from the tasklist if there are any errors during the eligibility stage.
This means the CA will not be able to complete the curfew address or handoff to the RO

The errors can result from the info in delius not being consistent or the  LDU not being active. 

The tasklist will display the error messages in a red border, similar to the GDS style but they  aren't hyperlinked because there is nothing on the page to link them to.

The Start now button is disabled if any errors are identified.