### PR TITLE
DCS-293 Send emails for unlinked users

### DIFF
--- a/server/services/notifications/caAndDmNotificationSender.js
+++ b/server/services/notifications/caAndDmNotificationSender.js
@@ -8,7 +8,7 @@ const { getIn, isEmpty } = require('../../utils/functionalHelpers')
 /**
  *  @param {PrisonerService} prisonerService
  */
-module.exports = function createNotificationService(
+module.exports = function createCaAndDmNotificationSender(
   prisonerService,
   roContactDetailsService,
   configClient,

--- a/server/services/notifications/roNotificationSender.js
+++ b/server/services/notifications/roNotificationSender.js
@@ -9,7 +9,7 @@ const { getRoCaseDueDate, getRoNewCaseDueDate } = require('../../utils/dueDates'
 /**
  * @return {RoNotificationSender}
  */
-module.exports = function createNotificationService(
+module.exports = function createRoNotificationSender(
   notificationSender,
   { notifications: { activeNotificationTypes, clearingOfficeEmail, clearingOfficeEmailEnabled }, domain }
 ) {
@@ -42,7 +42,7 @@ module.exports = function createNotificationService(
 
       const sendToRo = !isEmpty(email)
       const sendToRoOrg = !isEmpty(functionalMailbox)
-      const sendToClearing = sendToClearingOffice && !clearingOfficeEmailDisabled && (sendToRo || sendToRoOrg)
+      const sendToClearing = sendToClearingOffice && !clearingOfficeEmailDisabled
 
       return [
         ...(sendToRo ? [{ personalisation, email, templateName: templateNames.STANDARD }] : []),

--- a/server/services/roContactDetailsService.js
+++ b/server/services/roContactDetailsService.js
@@ -41,6 +41,7 @@ module.exports = function createRoContactDetailsService(userAdminService, roServ
 
     return {
       ...deliusRo,
+      isUnlinkedAccount: false,
       email,
       functionalMailbox: orgEmail,
       organisation,
@@ -51,6 +52,7 @@ module.exports = function createRoContactDetailsService(userAdminService, roServ
    * @typedef Mailboxes
    * @property {string} email
    * @property {string} functionalMailbox
+   * @property {boolean} isUnlinkedAccount
    *
    * @param {string} deliusId
    * @param {string} lduCode
@@ -65,6 +67,7 @@ module.exports = function createRoContactDetailsService(userAdminService, roServ
     const functionalMailbox = await probationTeamsClient.getFunctionalMailbox(lduCode)
     logger.info(`Got functional mailbox: '${functionalMailbox}' for '${lduCode}'`)
     return {
+      isUnlinkedAccount: staff.username === undefined,
       email: staff.email,
       functionalMailbox,
     }
@@ -92,9 +95,10 @@ module.exports = function createRoContactDetailsService(userAdminService, roServ
 
       return {
         ...deliusRo,
+        isUnlinkedAccount: mailboxes.isUnlinkedAccount,
         email: mailboxes.email,
         functionalMailbox: mailboxes.functionalMailbox,
-        organisation: deliusRo.lduDescription, // TODO: check this
+        organisation: `${deliusRo.lduDescription} (${deliusRo.lduCode})`,
       }
     },
 

--- a/server/services/roService.js
+++ b/server/services/roService.js
@@ -8,7 +8,7 @@
 const setCase = require('case')
 const logger = require('../../log.js')
 const { isEmpty } = require('../utils/functionalHelpers')
-const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, STAFF_NOT_PRESENT, STAFF_NOT_LINKED } = require('./serviceErrors')
+const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, STAFF_NOT_PRESENT } = require('./serviceErrors')
 
 /**
  * @param {DeliusClient} deliusClient
@@ -33,10 +33,6 @@ module.exports = function createRoService(deliusClient, nomisClientBuilder) {
     async getStaffByCode(staffCode) {
       try {
         const result = await deliusClient.getStaffDetailsByStaffCode(staffCode)
-
-        if (!result.email || !result.username) {
-          return { code: STAFF_NOT_LINKED, message: `Staff and user not linked in delius: ${staffCode}` }
-        }
         return result
       } catch (error) {
         if (error.status === 404) {

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -12,6 +12,8 @@ interface ResponsibleOfficer {
 }
 
 interface ResponsibleOfficerAndContactDetails extends ResponsibleOfficer {
+  /** This officer's user and staff record are not linked in delius, false if unknown */
+  isUnlinkedAccount: boolean,
   email?: string
   organisation?: string
   functionalMailbox?: string


### PR DESCRIPTION
Allow sending email to clearing house, even if the responsible has an unlinked user and staff account