### PR TITLE
DCS-265: new column in activeLdu table

### DIFF
--- a/migrations/20200103140313_add_probation_area_code_to_active_local_delivery_units_table.js
+++ b/migrations/20200103140313_add_probation_area_code_to_active_local_delivery_units_table.js
@@ -1,0 +1,13 @@
+exports.up = knex =>
+  Promise.all([
+    knex.schema.alterTable('active_local_delivery_units', table => {
+      table.string('probation_area_code').notNullable()
+    }),
+  ])
+
+exports.down = knex =>
+  Promise.all([
+    knex.schema.table('active_local_delivery_units', table => {
+      table.dropColumn('probation_area_code')
+    }),
+  ])

--- a/server/data/activeLduClient.js
+++ b/server/data/activeLduClient.js
@@ -1,19 +1,19 @@
 const db = require('./dataAccess/db')
 
 module.exports = {
-  async addLdu(lduCode) {
+  async addLdu(lduCode, probationAreaCode) {
     const query = {
-      text: `INSERT INTO active_local_delivery_units (ldu_code) VALUES ($1) 
+      text: `INSERT INTO active_local_delivery_units (ldu_code, probation_area_code) VALUES ($1, $2) 
       ON CONFLICT (ldu_code) DO NOTHING`,
-      values: [lduCode],
+      values: [lduCode, probationAreaCode],
     }
     return db.query(query)
   },
 
-  async isLduPresent(lduCode) {
+  async isLduPresent(lduCode, probationAreaCode) {
     const query = {
-      text: `SELECT count(*) FROM active_local_delivery_units WHERE ldu_code=$1`,
-      values: [lduCode],
+      text: `SELECT count(*) FROM active_local_delivery_units WHERE ldu_code=$1 AND probation_area_code=$2`,
+      values: [lduCode, probationAreaCode],
     }
 
     const { rows } = await db.query(query)

--- a/server/services/caService.js
+++ b/server/services/caService.js
@@ -40,9 +40,9 @@ module.exports = function createCaService(roService, lduActiveClient, { continue
         }
       }
 
-      const { lduCode, isAllocated } = ro
+      const { lduCode, isAllocated, probationAreaCode } = ro
 
-      const isLduActive = await lduActiveClient.isLduPresent(lduCode)
+      const isLduActive = await lduActiveClient.isLduPresent(lduCode, probationAreaCode)
 
       if (!isLduActive || !isAllocated) {
         return [...(!isLduActive ? [LDU_INACTIVE] : []), ...(!isAllocated ? [COM_NOT_ALLOCATED] : [])]

--- a/test/data/activeLduClient.test.js
+++ b/test/data/activeLduClient.test.js
@@ -9,32 +9,33 @@ afterEach(() => {
 
 describe('Save and retrieve LDU codes', () => {
   const lduCode = 'ABCDE'
+  const probationAreaCode = 'N02'
 
   describe('addLdu', () => {
     test('should pass in the correct sql', async () => {
-      await activeLduClient.addLdu(lduCode)
+      await activeLduClient.addLdu(lduCode, probationAreaCode)
 
       const { text, values } = db.query.mock.calls[0][0]
-      expect(text).toContain(`INSERT INTO active_local_delivery_units (ldu_code) VALUES ($1) 
+      expect(text).toContain(`INSERT INTO active_local_delivery_units (ldu_code, probation_area_code) VALUES ($1, $2) 
       ON CONFLICT (ldu_code) DO NOTHING`)
-      expect(values).toEqual([lduCode])
+      expect(values).toEqual([lduCode, probationAreaCode])
     })
   })
 
   describe('isLduPresent', () => {
     test('should pass in the correct sql', async () => {
       db.query.mockReturnValue({ rows: [{ count: 1 }] })
-      await activeLduClient.isLduPresent(lduCode)
+      await activeLduClient.isLduPresent(lduCode, probationAreaCode)
 
       const { text, values } = db.query.mock.calls[0][0]
       expect(text).toContain('SELECT count(*) FROM active_local_delivery_units')
-      expect(text).toContain('WHERE ldu_code=$1')
-      expect(values).toEqual([lduCode])
+      expect(text).toContain('WHERE ldu_code=$1 AND probation_area_code=$2')
+      expect(values).toEqual([lduCode, probationAreaCode])
     })
 
     test('should return true if ldu is present', async () => {
       db.query.mockReturnValue({ rows: [{ count: 1 }] })
-      const result = await activeLduClient.isLduPresent(lduCode)
+      const result = await activeLduClient.isLduPresent(lduCode, probationAreaCode)
       expect(result).toBe(true)
     })
 


### PR DESCRIPTION
Inserted a new column in active_local_delivery_units table

The new column is probation_area_code.
This is needed to link an LDU to a probation area
Updated the addLdu and isLduPresent functions in the server/data/activeLduClient.js file as the save and search they perform need to include the probation area.