### PR TITLE
DCS-302 prevent looking up contact details, if active LDU check feature is disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10249,9 +10249,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,6 @@
     "pdf-parse": "^1.1.1",
     "prettier": "1.16.4",
     "supertest": "^3.4.2",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.4"
   }
 }

--- a/server/config.js
+++ b/server/config.js
@@ -161,6 +161,5 @@ module.exports = {
     autostart: get('SCHEDULED_JOBS_AUTOSTART', 'no') === 'yes',
     overlapTimeout: get('SCHEDULED_JOBS_OVERLAP', 5000),
   },
-
-  continueCaToRoFeatureFlag: get('CONTINUE_CA_TO_RO_FEATURE_FLAG', 'no') === 'yes',
+  preventCaToRoHandoverOnInactiveLdusFlag: get('CONTINUE_CA_TO_RO_FEATURE_FLAG', 'no') === 'yes',
 }

--- a/server/index.js
+++ b/server/index.js
@@ -49,7 +49,7 @@ const deliusClient = createDeliusClient(signInService)
 const probationTeamsClient = createProbationTeamsClient(signInService)
 
 const roService = createRoService(deliusClient, nomisClientBuilder)
-const caService = createCaService(roService, lduActiveClient, config)
+const caService = createCaService(roService, lduActiveClient, config.preventCaToRoHandoverOnInactiveLdusFlag)
 const prisonerService = createPrisonerService(nomisClientBuilder, roService)
 const caseListFormatter = createCaseListFormatter(logger, licenceClient)
 const caseListService = createCaseListService(nomisClientBuilder, roService, licenceClient, caseListFormatter)
@@ -65,7 +65,12 @@ const userAdminService = createUserAdminService(
 )
 const userService = createUserService(nomisClientBuilder)
 const deadlineService = createDeadlineService(licenceClient)
-const roContactDetailsService = createRoContactDetailsService(userAdminService, roService, probationTeamsClient)
+const roContactDetailsService = createRoContactDetailsService(
+  userAdminService,
+  roService,
+  probationTeamsClient,
+  config.preventCaToRoHandoverOnInactiveLdusFlag
+)
 
 const notificationSender = createNotificationSender(notifyClient, audit, config)
 const roNotificationSender = createRoNotificationSender(notificationSender, config)

--- a/server/services/caService.js
+++ b/server/services/caService.js
@@ -6,6 +6,7 @@
  * @typedef {import("../../types/licences").Error} Error
  * @typedef {import("../../types/licences").CaService} CaService
  * @typedef {import("../../types/licences").RoService} RoService
+ *  @typedef {import("../data/activeLduClient")} ActiveLduClient
  */
 
 const logger = require('../../log.js')
@@ -14,12 +15,14 @@ const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, LDU_INACTIVE, COM_NOT_ALLOCATED } =
 
 /**
  * @param {RoService} roService
+ * @param {ActiveLduClient} activeLduClient
+ * @param {boolean} preventCaToRoHandoverOnInactiveLdusFlag
  * @returns {CaService} caService
  */
-module.exports = function createCaService(roService, lduActiveClient, { continueCaToRoFeatureFlag }) {
+module.exports = function createCaService(roService, activeLduClient, preventCaToRoHandoverOnInactiveLdusFlag) {
   return {
     async getReasonForNotContinuing(bookingId, token) {
-      if (!continueCaToRoFeatureFlag) {
+      if (!preventCaToRoHandoverOnInactiveLdusFlag) {
         return []
         // When this feature is disabled, we never block the CA from continuing the case
       }
@@ -42,7 +45,7 @@ module.exports = function createCaService(roService, lduActiveClient, { continue
 
       const { lduCode, isAllocated, probationAreaCode } = ro
 
-      const isLduActive = await lduActiveClient.isLduPresent(lduCode, probationAreaCode)
+      const isLduActive = await activeLduClient.isLduPresent(lduCode, probationAreaCode)
 
       if (!isLduActive || !isAllocated) {
         return [...(!isLduActive ? [LDU_INACTIVE] : []), ...(!isAllocated ? [COM_NOT_ALLOCATED] : [])]

--- a/test/services/caService.test.js
+++ b/test/services/caService.test.js
@@ -11,8 +11,7 @@ roService = { findResponsibleOfficer: jest.fn().mockResolvedValue(responsibleOff
 
 describe('caService', () => {
   describe('Allow CA to proceed to RO', () => {
-    const config = { continueCaToRoFeatureFlag: false }
-    caService = createCaService(roService, lduActiveClient, config)
+    caService = createCaService(roService, lduActiveClient, false)
 
     describe('getReasonForNotContinuing', () => {
       it('Should return []', async () => {
@@ -25,7 +24,7 @@ describe('caService', () => {
 
   describe('Prevent CA from proceeding to RO', () => {
     beforeEach(() => {
-      const config = { continueCaToRoFeatureFlag: true }
+      const config = { preventCaToRoHandoverOnInactiveLdusFlag: true }
       caService = createCaService(roService, lduActiveClient, config)
     })
 
@@ -72,9 +71,7 @@ describe('caService', () => {
         findResponsibleOfficer: jest.fn().mockResolvedValue(error),
       }
 
-      const config = { continueCaToRoFeatureFlag: true }
-
-      caService = createCaService(roService, lduActiveClient, config)
+      caService = createCaService(roService, lduActiveClient, true)
     })
     it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
       const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')

--- a/test/services/roContactDetailService.test.js
+++ b/test/services/roContactDetailService.test.js
@@ -12,13 +12,17 @@ describe('roContactDetailsService', () => {
     }
     roService = {
       getStaffByCode: jest.fn(),
-      findResponsibleOfficer: jest.fn(),
+      findResponsibleOfficer: jest.fn().mockResolvedValue({
+        deliusId: 'delius-1',
+        lduDescription: 'Sheffield',
+        lduCode: 'SHF-1',
+      }),
     }
     probationTeamsService = {
       getFunctionalMailbox: jest.fn(),
     }
 
-    service = createRoContactDetailsService(userAdminService, roService, probationTeamsService)
+    service = createRoContactDetailsService(userAdminService, roService, probationTeamsService, true)
   })
 
   describe('getFunctionalMailBox', () => {
@@ -30,7 +34,6 @@ describe('roContactDetailsService', () => {
       }
 
       userAdminService.getRoUserByDeliusId = jest.fn().mockReturnValue(fullContactInfo)
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
 
       const result = await service.getFunctionalMailBox('delius-1')
 
@@ -39,9 +42,8 @@ describe('roContactDetailsService', () => {
       expect(roService.getStaffByCode).not.toHaveBeenCalled()
     })
 
-    test('local data not stored, retrieve from external service', async () => {
-      userAdminService.getRoUserByDeliusId = jest.fn().mockReturnValue(null)
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
+    test('local data not stored, retrieve from external service is enabled', async () => {
+      userAdminService.getRoUserByDeliusId.mockReturnValue(null)
       probationTeamsService.getFunctionalMailbox.mockResolvedValue('ro-org@email.com')
       roService.getStaffByCode.mockResolvedValue({ email: 'ro@email.com' })
 
@@ -50,6 +52,19 @@ describe('roContactDetailsService', () => {
       expect(result).toBe('ro-org@email.com')
       expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalledWith('delius-1')
       expect(roService.getStaffByCode).toHaveBeenCalledWith('delius-1')
+    })
+
+    test('local data not stored, retrieve from external service is disabled', async () => {
+      service = createRoContactDetailsService(userAdminService, roService, probationTeamsService, false)
+
+      userAdminService.getRoUserByDeliusId = jest.fn().mockReturnValue(null)
+
+      const result = await service.getFunctionalMailBox('delius-1')
+
+      expect(result).toBe(undefined)
+      expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalledWith('delius-1')
+      expect(probationTeamsService.getFunctionalMailbox).not.toHaveBeenCalled()
+      expect(roService.getStaffByCode).not.toHaveBeenCalled()
     })
   })
 
@@ -61,7 +76,6 @@ describe('roContactDetailsService', () => {
         organisation: 'NPS Dewsbury (Kirklees and Wakefield)',
       }
 
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
       userAdminService.getRoUserByDeliusId = jest.fn().mockReturnValue(fullContactInfo)
 
       const result = await service.getResponsibleOfficerWithContactDetails(1, 'token-1')
@@ -72,6 +86,8 @@ describe('roContactDetailsService', () => {
         functionalMailbox: 'admin@ro.email',
         organisation: 'NPS Dewsbury (Kirklees and Wakefield)',
         isUnlinkedAccount: false,
+        lduCode: 'SHF-1',
+        lduDescription: 'Sheffield',
       })
       expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalledWith('delius-1')
       expect(roService.getStaffByCode).not.toHaveBeenCalledWith('delius-1')
@@ -88,15 +104,8 @@ describe('roContactDetailsService', () => {
     })
 
     test('no staff record local, found in delius', async () => {
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
-
       userAdminService.getRoUserByDeliusId.mockResolvedValue(null)
 
-      roService.findResponsibleOfficer.mockResolvedValue({
-        deliusId: 'delius-1',
-        lduDescription: 'Sheffield',
-        lduCode: 'SHF-1',
-      })
       probationTeamsService.getFunctionalMailbox.mockResolvedValue('ro-org@email.com')
       roService.getStaffByCode.mockResolvedValue({ email: 'ro@ro.email.com', username: 'user-1' })
 
@@ -116,15 +125,8 @@ describe('roContactDetailsService', () => {
     })
 
     test('no staff record local, linked user found in delius', async () => {
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
-
       userAdminService.getRoUserByDeliusId.mockResolvedValue(null)
 
-      roService.findResponsibleOfficer.mockResolvedValue({
-        deliusId: 'delius-1',
-        lduDescription: 'Sheffield',
-        lduCode: 'SHF-1',
-      })
       probationTeamsService.getFunctionalMailbox.mockResolvedValue('ro-org@email.com')
       roService.getStaffByCode.mockResolvedValue({ email: 'ro@ro.email.com', username: 'user-1' })
 
@@ -143,9 +145,28 @@ describe('roContactDetailsService', () => {
       expect(roService.getStaffByCode).toHaveBeenCalledWith('delius-1')
     })
 
-    it('no staff record local, un-linked user found in delius', async () => {
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
+    it('no staff record local, looking up details in delius is disabled', async () => {
+      service = createRoContactDetailsService(userAdminService, roService, probationTeamsService, false)
 
+      userAdminService.getRoUserByDeliusId.mockResolvedValue(null)
+      probationTeamsService.getFunctionalMailbox.mockResolvedValue('ro-org@email.com')
+      roService.getStaffByCode.mockResolvedValue({})
+
+      const result = await service.getResponsibleOfficerWithContactDetails(1, 'token-1')
+
+      expect(result).toEqual({
+        deliusId: 'delius-1',
+        email: undefined,
+        functionalMailbox: undefined,
+        lduDescription: 'Sheffield',
+        isUnlinkedAccount: false,
+        lduCode: 'SHF-1',
+        organisation: 'Sheffield (SHF-1)',
+      })
+      expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalledWith('delius-1')
+      expect(roService.getStaffByCode).not.toHaveBeenCalled()
+    })
+    it('no staff record local, un-linked user found in delius', async () => {
       userAdminService.getRoUserByDeliusId.mockResolvedValue(null)
 
       roService.findResponsibleOfficer.mockResolvedValue({
@@ -172,8 +193,6 @@ describe('roContactDetailsService', () => {
     })
 
     test('no staff record local, found in delius but not linked user', async () => {
-      roService.findResponsibleOfficer.mockResolvedValue({ deliusId: 'delius-1' })
-
       userAdminService.getRoUserByDeliusId.mockResolvedValue(null)
       roService.getStaffByCode.mockResolvedValue({
         message: 'Staff and user not linked in delius: delius-1',


### PR DESCRIPTION
Previously we wouldn't have sent emails to ROs that didn't appear in the local staff ids table.
Now if we don't find the details in the local staff_ids table we will look in delius.

This has the negative side effect, that if a CA incorrectly processes a case when an offenders RO is in an area which isn't part of digital HDC and we find their details in delius - we will end up telling them that they need to process the case, even though they will have never seen the digital HDC service.

We have a new feature which will prevent a CA from processing a case if the RO is not part of the digital HDC service, this change will prevent the delius look up if this new feature is disabled