### PR TITLE
Re-enabling SSL for postgres connections

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -58,7 +58,7 @@ const victimRouter = require('./routes/victim')
 const varyRouter = require('./routes/vary')
 
 const version = moment.now().toString()
-const production = process.env.NODE_ENV === 'production'
+const { production } = config
 
 module.exports = function createApp({
   signInService,

--- a/server/config.js
+++ b/server/config.js
@@ -16,6 +16,8 @@ function get(name, fallback, options = {}) {
 module.exports = {
   version: 0.1,
 
+  production,
+
   enableTestUtils: get('ENABLE_TEST_UTILS', false),
 
   db: {


### PR DESCRIPTION
Was relying on a non-existent 'production' property to help determine whether to use ssl.
Adding the property in