### PR TITLE
DCS-304 Merging unallocated and not present reasons for blocking case progression

### DIFF
--- a/server/routes/config/taskListErrors.js
+++ b/server/routes/config/taskListErrors.js
@@ -1,6 +1,5 @@
 module.exports = {
   NO_OFFENDER_NUMBER: 'Offender number required but it is not entered in Delius',
-  NO_COM_ASSIGNED: 'A Community Offender Manager has not been assigned. Please contact the Delius team',
   LDU_INACTIVE: 'The Local Delivery Unit is in a geographical area that is currently inactive. Please refer via Nomis',
   COM_NOT_ALLOCATED:
     'The Community Offender Manager (COM) assigned is a pseudo. Please arrange for an actual COM to be assigned',

--- a/server/services/caService.js
+++ b/server/services/caService.js
@@ -11,7 +11,7 @@
 
 const logger = require('../../log.js')
 const { unwrapResult } = require('../utils/functionalHelpers')
-const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, LDU_INACTIVE, COM_NOT_ALLOCATED } = require('./serviceErrors')
+const { NO_OFFENDER_NUMBER, LDU_INACTIVE, NO_COM_ASSIGNED, COM_NOT_ALLOCATED } = require('./serviceErrors')
 
 /**
  * @param {RoService} roService
@@ -34,10 +34,11 @@ module.exports = function createCaService(roService, activeLduClient, preventCaT
           `Found reason for not continuing processing booking: ${bookingId}, error: ${error.code}:${error.message}`
         )
         switch (error.code) {
-          case 'NO_OFFENDER_NUMBER':
+          case NO_OFFENDER_NUMBER:
             return [NO_OFFENDER_NUMBER]
-          case 'NO_COM_ASSIGNED':
-            return [NO_COM_ASSIGNED]
+          case NO_COM_ASSIGNED:
+            // Handle NO_COM_ASSIGNED and COM_NOT_ALLOCATED in the same way
+            return [COM_NOT_ALLOCATED]
           default:
             throw new Error(`Unexpected error received: ${error.code}: ${error.message}`)
         }
@@ -51,7 +52,6 @@ module.exports = function createCaService(roService, activeLduClient, preventCaT
         return [...(!isLduActive ? [LDU_INACTIVE] : []), ...(!isAllocated ? [COM_NOT_ALLOCATED] : [])]
       }
       // TODO: Do we need to warn if the com isn't the current responsible officer for the offender?
-      // returning null means there is no reason preventing CA from continuing referral to RO
       return []
     },
   }

--- a/server/services/notifications/notificationService.js
+++ b/server/services/notifications/notificationService.js
@@ -82,7 +82,7 @@ module.exports = function createNotificationService(
     }
 
     if (responsibleOfficer.isUnlinkedAccount) {
-      await raiseUnlinkedAccountWarning(bookingId, responsibleOfficer.deliusId)
+      await raiseUnlinkedAccountWarning(bookingId, responsibleOfficer)
     }
 
     await licenceService.markForHandover(bookingId, transition.type)
@@ -98,9 +98,14 @@ module.exports = function createNotificationService(
     })
   }
 
-  async function raiseUnlinkedAccountWarning(bookingId, deliusId) {
-    logger.info(`Staff and user not linked in delius: ${deliusId}`)
-    await warningClient.raiseWarning(bookingId, STAFF_NOT_LINKED, `Staff and user not linked in delius: ${deliusId}`)
+  /** Need to alert staff to link the records manually otherwise we won't be able to access the RO's email address from their user record and so won't be able to notify them  */
+  async function raiseUnlinkedAccountWarning(bookingId, { deliusId, name, nomsNumber }) {
+    logger.info(`Staff and user records not linked in delius: ${deliusId}`)
+    await warningClient.raiseWarning(
+      bookingId,
+      STAFF_NOT_LINKED,
+      `RO with delius staff code: '${deliusId}' and name: '${name}', responsible for managing: '${nomsNumber}', has unlinked staff record in delius`
+    )
   }
 
   function auditEvent(user, bookingId, transitionType, submissionTarget) {

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -82,25 +82,6 @@ describe('GET /taskList/:prisonNumber', () => {
         })
     })
 
-    test('should return error message for NO_COM_ASSIGNED', async () => {
-      licenceService.getLicence.mockResolvedValue({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
-      caService.getReasonForNotContinuing.mockResolvedValue(['NO_COM_ASSIGNED'])
-
-      const app = createApp({
-        licenceServiceStub: licenceService,
-        prisonerServiceStub: prisonerService,
-        caServiceStub: caService,
-      })
-
-      return request(app)
-        .get('/taskList/123')
-        .expect(200)
-        .expect('Content-Type', /html/)
-        .expect(res => {
-          expect(res.text).toContain('A Community Offender Manager has not been assigned')
-        })
-    })
-
     test('should return error messages for LDU_INACTIVE plus COM_NOT_ALLOCATED', async () => {
       licenceService.getLicence.mockResolvedValue({ stage: 'ELIGIBILITY', licence: { anyKey: 1 } })
       const errors = ['LDU_INACTIVE', 'COM_NOT_ALLOCATED']

--- a/test/services/caService.test.js
+++ b/test/services/caService.test.js
@@ -81,7 +81,7 @@ describe('caService', () => {
     it('should return NO_COM_ASSIGNED', async () => {
       error.code = 'NO_COM_ASSIGNED'
       const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-      expect(result).toEqual(['NO_COM_ASSIGNED'])
+      expect(result).toEqual(['COM_NOT_ALLOCATED'])
     })
   })
 })

--- a/test/services/notifications/notificationService.test.js
+++ b/test/services/notifications/notificationService.test.js
@@ -215,7 +215,7 @@ describe('NotificationService', () => {
       expect(warningClient.raiseWarning).toHaveBeenCalledWith(
         bookingId,
         STAFF_NOT_LINKED,
-        'Staff and user not linked in delius: STAFF-1'
+        `RO with delius staff code: 'STAFF-1' and name: 'Jo Smith', responsible for managing: 'AAAA12', has unlinked staff record in delius`
       )
 
       expect(roNotificationSender.sendNotifications).toHaveBeenCalledWith({


### PR DESCRIPTION

We want to handle not being allocated an RO and being allocated the dummy 'Unallocated RO' user the same
as in both cases we will request that the user talks to a delius user and gets them to fix the data in delius

Also adding more context to warnings when a case is handed over to an unlinked user