### PR TITLE
DCS-304 Updating with new content and only ever block CA with at most one reason

### DIFF
--- a/server/routes/taskList.js
+++ b/server/routes/taskList.js
@@ -54,12 +54,12 @@ module.exports = ({ prisonerService, licenceService, audit, caService }) => rout
         licenceStatus.stage === 'ELIGIBILITY' &&
         licenceStatus.tasks.eligibility === 'DONE'
       ) {
-        const errorCodes = await caService.getReasonForNotContinuing(bookingId, res.locals.token)
+        const errorCode = await caService.getReasonForNotContinuing(bookingId, res.locals.token)
 
-        if (errorCodes.length > 0) {
+        if (errorCode) {
           return res.render('taskList/taskListBuilder', {
             ...model,
-            taskListModel: getTasksForBlocked(errorCodes),
+            taskListModel: getTasksForBlocked(errorCode),
             errors: [],
           })
         }

--- a/server/routes/viewModels/taskLists/caTasks.js
+++ b/server/routes/viewModels/taskLists/caTasks.js
@@ -17,7 +17,7 @@ const createLicence = require('./tasks/createLicence')
 const finalChecks = require('./tasks/finalChecks')
 
 module.exports = {
-  getTasksForBlocked: errorCodes => [
+  getTasksForBlocked: errorCode => [
     {
       task: 'eligibilityTask',
     },
@@ -32,7 +32,7 @@ module.exports = {
     },
     {
       task: 'caBlockedTask',
-      errorCodes,
+      errorCode,
     },
   ],
 

--- a/server/views/taskList/tasks/caBlockedTask.pug
+++ b/server/views/taskList/tasks/caBlockedTask.pug
@@ -1,41 +1,40 @@
 
 mixin caBlockedTask(task)
-        each code in task.errorCodes
-            div.largeMarginBottom
-            case code
-                when 'NO_OFFENDER_NUMBER'
-                    + noOffenderNumber()
-                when 'LDU_INACTIVE'
-                    + lduInactive()
-                when 'COM_NOT_ALLOCATED'
-                    + comNotAllocated()
-                default
-                    p.error An unknown Error occurred
+    div.largeMarginBottom
+    case task.errorCode
+        when 'NO_OFFENDER_NUMBER'
+            + noOffenderNumber()
+        when 'LDU_INACTIVE'
+            + lduInactive()
+        when 'COM_NOT_ALLOCATED'
+            + comNotAllocated()
+        default
+            p.error An unknown Error occurred
 
 
 mixin noOffenderNumber()
-    h2.heading-medium No responsible officer is assigned to this case.
+    h2.heading-medium You cannot submit this case
     div.pure-g
         div.pure-u-1.pure-u-md-3-4
-            p This is because there is no offender number recorded in Delius.
+            p This is because there is no offender number recorded in Delius
             h3.heading-small What you need to do
-            p Ask a Delius user to enter the offender number. 
-            p The relationship will then show in the HDC service.
+            p Ask a Delius user to enter the offender number
+            p The relationship will then show in the HDC service
 
 mixin lduInactive()
-    h2.heading-medium The case cannot be processed in this system.
+    h2.heading-medium You cannot submit this case
     div.pure-g
         div.pure-u-1.pure-u-md-3-4
-            p This is because the assigned Responsible officer is in an area not covered by the HDC pilot.
+            p This is because the assigned Responsible officer is in an area not covered by the HDC roll out
             h3.heading-small What you need to do
             p Process the case in NOMIS instead
 
 mixin comNotAllocated()
-    h2.heading-medium No responsible officer is assigned to this case.
+    h2.heading-medium You cannot submit this case
     div.pure-g
         div.pure-u-1.pure-u-md-3-4
-            p This is because there is no Community Offender Manager showing in Delius.
+            p This is because there is no Community Offender Manager showing in Delius
             h3.heading-small What you need to do
-            p Ask a Delius user to assign a Community Offender Manager.  
-            p The relationship will then show in the HDC service.
+            p Ask a Delius user to assign a Community Offender Manager  
+            p The relationship will then show in the HDC service
 

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -116,7 +116,7 @@ describe('GET /taskList/:prisonNumber', () => {
         stage: 'ELIGIBILITY',
         licence: licenceWithEligibilityComplete,
       })
-      caService.getReasonForNotContinuing.mockResolvedValue(['NO_OFFENDER_NUMBER'])
+      caService.getReasonForNotContinuing.mockResolvedValue('NO_OFFENDER_NUMBER')
 
       const app = createApp({
         licenceServiceStub: licenceService,
@@ -129,14 +129,13 @@ describe('GET /taskList/:prisonNumber', () => {
         .expect(200)
         .expect('Content-Type', /html/)
         .expect(res => {
-          expect(res.text).toContain('This is because there is no offender number recorded in Delius.')
+          expect(res.text).toContain('This is because there is no offender number recorded in Delius')
         })
     })
 
-    test('should return error messages for LDU_INACTIVE plus COM_NOT_ALLOCATED', async () => {
+    test('should return error messages for LDU_INACTIVE', async () => {
       licenceService.getLicence.mockResolvedValue({ stage: 'ELIGIBILITY', licence: licenceWithEligibilityComplete })
-      const errors = ['LDU_INACTIVE', 'COM_NOT_ALLOCATED']
-      caService.getReasonForNotContinuing.mockResolvedValue(errors)
+      caService.getReasonForNotContinuing.mockResolvedValue('LDU_INACTIVE')
 
       const app = createApp({
         licenceServiceStub: licenceService,
@@ -150,9 +149,27 @@ describe('GET /taskList/:prisonNumber', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).toContain(
-            'This is because the assigned Responsible officer is in an area not covered by the HDC pilot.'
+            'This is because the assigned Responsible officer is in an area not covered by the HDC roll out'
           )
-          expect(res.text).toContain('This is because there is no Community Offender Manager showing in Delius.')
+        })
+    })
+
+    test('should return error messages for COM_NOT_ALLOCATED', async () => {
+      licenceService.getLicence.mockResolvedValue({ stage: 'ELIGIBILITY', licence: licenceWithEligibilityComplete })
+      caService.getReasonForNotContinuing.mockResolvedValue('COM_NOT_ALLOCATED')
+
+      const app = createApp({
+        licenceServiceStub: licenceService,
+        prisonerServiceStub: prisonerService,
+        caServiceStub: caService,
+      })
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('This is because there is no Community Offender Manager showing in Delius')
         })
     })
 

--- a/test/services/caService.test.js
+++ b/test/services/caService.test.js
@@ -17,7 +17,7 @@ describe('caService', () => {
       it('Should return []', async () => {
         lduActiveClient.isLduPresent.mockResolvedValue(true)
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).toEqual([])
+        expect(result).toEqual(null)
       })
     })
   })
@@ -33,13 +33,13 @@ describe('caService', () => {
         lduActiveClient.isLduPresent.mockResolvedValue(true)
 
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).toEqual([])
+        expect(result).toEqual(null)
       })
 
       it('should return LDU_INACTIVE', async () => {
         lduActiveClient.isLduPresent.mockResolvedValue(false)
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).toEqual(['LDU_INACTIVE'])
+        expect(result).toEqual('LDU_INACTIVE')
       })
 
       it('should return COM_NOT_ALLOCATED', async () => {
@@ -47,16 +47,16 @@ describe('caService', () => {
         responsibleOfficer.isAllocated = false
 
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).toEqual(['COM_NOT_ALLOCATED'])
+        expect(result).toEqual('COM_NOT_ALLOCATED')
       })
 
-      it('should return LDU_INACTIVE and COM_NOT_ALLOCATED', async () => {
+      it('should only return LDU_INACTIVE when LDU_INACTIVE and COM_NOT_ALLOCATED', async () => {
         lduActiveClient.isLduPresent.mockResolvedValue(false)
         responsibleOfficer.isAllocated = false
         roService = { findResponsibleOfficer: jest.fn().mockResolvedValue(responsibleOfficer) }
 
         const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-        expect(result).toEqual(['LDU_INACTIVE', 'COM_NOT_ALLOCATED'])
+        expect(result).toEqual('LDU_INACTIVE')
       })
     })
   })
@@ -75,13 +75,13 @@ describe('caService', () => {
     })
     it('should return NO_OFFENDER_NUMBER because no offender number on nomis for bookingId', async () => {
       const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-      expect(result).toEqual(['NO_OFFENDER_NUMBER'])
+      expect(result).toEqual('NO_OFFENDER_NUMBER')
     })
 
     it('should return NO_COM_ASSIGNED', async () => {
       error.code = 'NO_COM_ASSIGNED'
       const result = await caService.getReasonForNotContinuing('bookingId-1', 'token-1')
-      expect(result).toEqual(['COM_NOT_ALLOCATED'])
+      expect(result).toEqual('COM_NOT_ALLOCATED')
     })
   })
 })

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -75,7 +75,7 @@ export interface PrisonerService {
 } 
 
 export interface CaService {
-  getReasonForNotContinuing: (bookingId: number, token: string) => Promise<Array<string> | undefined>
+  getReasonForNotContinuing: (bookingId: number, token: string) => Promise<string | undefined>
 }
 
 export interface Warning {


### PR DESCRIPTION
We've decided that we shouldn't need to worry the user if there is no COM assigned if the COM would have been in an area outside the HDC rollout
So we'll always priorities the inactive LDU message if present.