### PR TITLE
DCS-295 Adding delius hdc licences role

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -68,6 +68,8 @@ module.exports = {
       freeSocketTimeout: 30000,
     },
     apiPrefix: get('DELIUS_API_PREFIX', '/api'),
+    // this refers to the 'HDC Digital Update' RBAC which is mapped to LICENCE_RO in the auth server
+    responsibleOfficerRoleId: get('DELIUS_RO_ROLE_ID', 'LHDCBT002'),
   },
 
   probationTeams: {

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ const createNotificationSender = require('./services/notifications/notificationS
 const createRoNotificationSender = require('./services/notifications/roNotificationSender')
 const createCaAndDmNotificationSender = require('./services/notifications/caAndDmNotificationSender')
 const createNotificationService = require('./services/notifications/notificationService')
+const createRoNotificationHandler = require('./services/notifications/roNotificationHandler')
 
 const createRoContactDetailsService = require('./services/roContactDetailsService')
 const createReminderService = require('./services/reminderService')
@@ -84,14 +85,22 @@ const caAndDmNotificationSender = createCaAndDmNotificationSender(
   config
 )
 
-const notificationService = createNotificationService(
+const roNotificationHandler = createRoNotificationHandler(
   roNotificationSender,
-  caAndDmNotificationSender,
   audit,
   licenceService,
   prisonerService,
   roContactDetailsService,
-  warningClient
+  warningClient,
+  deliusClient
+)
+
+const notificationService = createNotificationService(
+  roNotificationSender,
+  caAndDmNotificationSender,
+  audit,
+  prisonerService,
+  roNotificationHandler
 )
 const reminderService = createReminderService(
   roContactDetailsService,

--- a/server/index.js
+++ b/server/index.js
@@ -96,12 +96,13 @@ const roNotificationHandler = createRoNotificationHandler(
 )
 
 const notificationService = createNotificationService(
-  roNotificationSender,
   caAndDmNotificationSender,
   audit,
+  licenceService,
   prisonerService,
   roNotificationHandler
 )
+
 const reminderService = createReminderService(
   roContactDetailsService,
   prisonerService,

--- a/server/services/notifications/notificationService.js
+++ b/server/services/notifications/notificationService.js
@@ -1,37 +1,20 @@
 /**
- * @template T
- * @typedef {import("../../../types/licences").Result<T>} Result
- */
-/**
- * @typedef {import("../../../types/licences").RoContactDetailsService} RoContactDetailsService
- * @typedef {import("../../../types/licences").RoNotificationSender} RoNotificationSender
  * @typedef {import("../../../types/licences").PrisonerService} PrisonerService
- * @typedef {import("../../../types/licences").WarningClient} WarningClient
- * @typedef {import("../../../types/licences").Error} Error
- * @typedef {import("../../../types/licences").ResponsibleOfficerAndContactDetails} ResponsibleOfficerAndContactDetails
  */
 const { sendingUserName } = require('../../utils/userProfile')
-const logger = require('../../../log.js')
-const { isEmpty, unwrapResult } = require('../../utils/functionalHelpers')
-const { STAFF_NOT_LINKED } = require('../serviceErrors')
 
 /**
- * @param {RoContactDetailsService} roContactDetailsService
- * @param {RoNotificationSender} roNotificationSender
  * @param {PrisonerService} prisonerService
- * @param {WarningClient} warningClient
  */
 module.exports = function createNotificationService(
-  roNotificationSender,
   caAndDmNotificationSender,
   audit,
   licenceService,
   prisonerService,
-  roContactDetailsService,
-  warningClient
+  roNotificationHandler
 ) {
   const receiverToSender = {
-    RO: sendRo,
+    RO: roNotificationHandler.sendRo,
     CA: sendCaOrDm,
     DM: sendCaOrDm,
   }
@@ -59,53 +42,6 @@ module.exports = function createNotificationService(
       sendingUserName: sendingUserName(user),
       token,
     })
-  }
-
-  async function sendRo({ transition, bookingId, token, user }) {
-    /** @type {[{premise: string}, Result<ResponsibleOfficerAndContactDetails>]} */
-    const [establishment, result] = await Promise.all([
-      prisonerService.getEstablishmentForPrisoner(bookingId, token),
-      roContactDetailsService.getResponsibleOfficerWithContactDetails(bookingId, token),
-    ])
-
-    const [responsibleOfficer, error] = unwrapResult(result)
-
-    if (error) {
-      logger.error(`Problem retrieving contact details: ${error.message}`)
-      return
-    }
-
-    const { premise: prison } = establishment || {}
-    if (isEmpty(prison)) {
-      logger.error(`Missing prison for bookingId: ${bookingId}`)
-      return
-    }
-
-    if (responsibleOfficer.isUnlinkedAccount) {
-      await raiseUnlinkedAccountWarning(bookingId, responsibleOfficer)
-    }
-
-    await licenceService.markForHandover(bookingId, transition.type)
-
-    auditEvent(user.username, bookingId, transition.type, responsibleOfficer)
-
-    roNotificationSender.sendNotifications({
-      bookingId,
-      responsibleOfficer,
-      prison,
-      notificationType: transition.notificationType,
-      sendingUserName: sendingUserName(user),
-    })
-  }
-
-  /** Need to alert staff to link the records manually otherwise we won't be able to access the RO's email address from their user record and so won't be able to notify them  */
-  async function raiseUnlinkedAccountWarning(bookingId, { deliusId, name, nomsNumber }) {
-    logger.info(`Staff and user records not linked in delius: ${deliusId}`)
-    await warningClient.raiseWarning(
-      bookingId,
-      STAFF_NOT_LINKED,
-      `RO with delius staff code: '${deliusId}' and name: '${name}', responsible for managing: '${nomsNumber}', has unlinked staff record in delius`
-    )
   }
 
   function auditEvent(user, bookingId, transitionType, submissionTarget) {

--- a/server/services/notifications/roNotificationHandler.js
+++ b/server/services/notifications/roNotificationHandler.js
@@ -1,0 +1,101 @@
+/**
+ * @template T
+ * @typedef {import("../../../types/licences").Result<T>} Result
+ */
+/**
+ * @typedef {import("../../../types/licences").RoContactDetailsService} RoContactDetailsService
+ * @typedef {import("../../../types/licences").RoNotificationSender} RoNotificationSender
+ * @typedef {import("../../../types/licences").PrisonerService} PrisonerService
+ * @typedef {import("../../../types/licences").WarningClient} WarningClient
+ * @typedef {import("../../../types/delius").DeliusClient} DeliusClient
+ * @typedef {import("../../../types/licences").Error} Error
+ * @typedef {import("../../../types/licences").ResponsibleOfficerAndContactDetails} ResponsibleOfficerAndContactDetails
+ */
+const { sendingUserName } = require('../../utils/userProfile')
+const logger = require('../../../log.js')
+const { isEmpty, unwrapResult } = require('../../utils/functionalHelpers')
+const { STAFF_NOT_LINKED } = require('../serviceErrors')
+
+/**
+ * @param {RoContactDetailsService} roContactDetailsService
+ * @param {RoNotificationSender} roNotificationSender
+ * @param {PrisonerService} prisonerService
+ * @param {WarningClient} warningClient
+ * @param {DeliusClient} deliusClient
+ */
+module.exports = function createRoNotificationHandler(
+  roNotificationSender,
+  audit,
+  licenceService,
+  prisonerService,
+  roContactDetailsService,
+  warningClient,
+  deliusClient
+) {
+  async function sendRo({ transition, bookingId, token, user }) {
+    /** @type {[{premise: string}, Result<ResponsibleOfficerAndContactDetails>]} */
+    const [establishment, result] = await Promise.all([
+      prisonerService.getEstablishmentForPrisoner(bookingId, token),
+      roContactDetailsService.getResponsibleOfficerWithContactDetails(bookingId, token),
+    ])
+
+    const [responsibleOfficer, error] = unwrapResult(result)
+
+    if (error) {
+      logger.error(`Problem retrieving contact details: ${error.message}`)
+      return
+    }
+
+    const { premise: prison } = establishment || {}
+    if (isEmpty(prison)) {
+      logger.error(`Missing prison for bookingId: ${bookingId}`)
+      return
+    }
+
+    if (responsibleOfficer.isUnlinkedAccount) {
+      await raiseUnlinkedAccountWarning(bookingId, responsibleOfficer)
+    }
+
+    await licenceService.markForHandover(bookingId, transition.type)
+
+    auditEvent(user.username, bookingId, transition.type, responsibleOfficer)
+
+    await roNotificationSender.sendNotifications({
+      bookingId,
+      responsibleOfficer,
+      prison,
+      notificationType: transition.notificationType,
+      sendingUserName: sendingUserName(user),
+    })
+
+    if (responsibleOfficer.username) {
+      /* 
+        We know that the delius RO user handling this case requires the RO role to be able to access licences
+        Attempt the idemptotent operation to add it now. 
+      */
+      await deliusClient.addResponsibleOfficerRole(responsibleOfficer.username)
+    }
+  }
+
+  /** Need to alert staff to link the records manually otherwise we won't be able to access the RO's email address from their user record and so won't be able to notify them  */
+  async function raiseUnlinkedAccountWarning(bookingId, { deliusId, name, nomsNumber }) {
+    logger.info(`Staff and user records not linked in delius: ${deliusId}`)
+    await warningClient.raiseWarning(
+      bookingId,
+      STAFF_NOT_LINKED,
+      `RO with delius staff code: '${deliusId}' and name: '${name}', responsible for managing: '${nomsNumber}', has unlinked staff record in delius`
+    )
+  }
+
+  function auditEvent(user, bookingId, transitionType, submissionTarget) {
+    audit.record('SEND', user, {
+      bookingId,
+      transitionType,
+      submissionTarget,
+    })
+  }
+
+  return {
+    sendRo,
+  }
+}

--- a/test/data/deliusClient.test.js
+++ b/test/data/deliusClient.test.js
@@ -118,4 +118,18 @@ describe('deliusClient', () => {
       ])
     })
   })
+
+  describe('addResponsbileOfficerRole', () => {
+    test('should return data from api', () => {
+      fakeDelius.put(`/users/bobUser/roles/${config.delius.responsibleOfficerRoleId}`).reply(200, {})
+
+      return expect(deliusClient.addResponsibleOfficerRole('bobUser')).resolves.toStrictEqual({})
+    })
+
+    test('should ignore errors', () => {
+      fakeDelius.put(`/users/bobUser/roles/${config.delius.responsibleOfficerRoleId}`).reply(500)
+
+      return expect(deliusClient.addResponsibleOfficerRole('bobUser')).resolves.toStrictEqual(undefined)
+    })
+  })
 })

--- a/test/data/deliusClient.test.js
+++ b/test/data/deliusClient.test.js
@@ -121,7 +121,7 @@ describe('deliusClient', () => {
 
   describe('addResponsbileOfficerRole', () => {
     test('should return data from api', () => {
-      fakeDelius.put(`/users/bobUser/roles/${config.delius.responsibleOfficerRoleId}`).reply(200, {})
+      fakeDelius.put(`/users/bobUser/roles/${config.delius.responsibleOfficerRoleId}`).reply(200)
 
       return expect(deliusClient.addResponsibleOfficerRole('bobUser')).resolves.toStrictEqual({})
     })

--- a/test/services/notifications/roNotificationHandler.test.js
+++ b/test/services/notifications/roNotificationHandler.test.js
@@ -1,0 +1,290 @@
+const createRoNotificationHandler = require('../../../server/services/notifications/roNotificationHandler')
+const transitionForDestinations = require('../../../server/services/notifications/transitionsForDestinations')
+const { STAFF_NOT_LINKED } = require('../../../server/services/serviceErrors')
+
+describe('roNotificationHandler', () => {
+  let roNotificationSender
+  let audit
+  let licenceService
+  let prisonerService
+  let warningClient
+  let deliusClient
+  let roNotificationHandler
+  let roContactDetailsService
+
+  const prisoner = { firstName: 'first', lastName: 'last', dateOfBirth: 'off-dob', offenderNo: 'AB1234A' }
+  const submissionTarget = { premise: 'HMP Blah', agencyId: 'LT1', name: 'Something', deliusId: 'delius' }
+  const bookingId = -1
+  const token = 'token-1'
+  const licence = {}
+  const username = 'bob'
+  const user = { username }
+
+  beforeEach(() => {
+    licenceService = {
+      markForHandover: jest.fn().mockReturnValue(),
+      removeDecision: jest.fn().mockReturnValue({}),
+    }
+
+    roContactDetailsService = {
+      getResponsibleOfficerWithContactDetails: jest.fn(),
+    }
+
+    warningClient = {
+      raiseWarning: jest.fn(),
+    }
+
+    deliusClient = {
+      addResponsibleOfficerRole: jest.fn(),
+    }
+
+    prisonerService = {
+      getEstablishmentForPrisoner: jest.fn().mockReturnValue({ premise: 'HMP Blah', agencyId: 'LT1' }),
+      getOrganisationContactDetails: jest.fn().mockReturnValue(submissionTarget),
+      getPrisonerPersonalDetails: jest.fn().mockReturnValue(prisoner),
+    }
+
+    roNotificationSender = {
+      sendNotifications: jest.fn().mockReturnValue({}),
+    }
+
+    audit = {
+      record: jest.fn(),
+    }
+
+    roNotificationHandler = createRoNotificationHandler(
+      roNotificationSender,
+      audit,
+      licenceService,
+      prisonerService,
+      roContactDetailsService,
+      warningClient,
+      deliusClient
+    )
+  })
+
+  describe('Get send/:destination/:bookingId', () => {
+    test('handles caToRo when addressReview is destination', async () => {
+      const responsibleOfficer = {
+        name: 'Jo Smith',
+        deliusId: 'delius1',
+        email: 'ro@user.com',
+        lduCode: 'code-1',
+        lduDescription: 'lduDescription-1',
+        nomsNumber: 'AAAA12',
+        probationAreaCode: 'prob-code-1',
+        probationAreaDescription: 'prob-desc-1',
+      }
+      roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue(responsibleOfficer)
+
+      await roNotificationHandler.sendRo({
+        transition: transitionForDestinations.addressReview,
+        bookingId,
+        token,
+        licence,
+        prisoner,
+        user,
+      })
+
+      expect(roNotificationSender.sendNotifications).toHaveBeenCalledWith({
+        bookingId,
+        responsibleOfficer,
+        prison: 'HMP Blah',
+        notificationType: 'RO_NEW',
+        sendingUserName: username,
+      })
+      expect(audit.record).toHaveBeenCalledWith('SEND', username, {
+        bookingId,
+        submissionTarget: responsibleOfficer,
+        transitionType: 'caToRo',
+      })
+      expect(licenceService.markForHandover).toHaveBeenCalledWith(bookingId, 'caToRo')
+      expect(licenceService.removeDecision).not.toHaveBeenCalled()
+    })
+
+    test('handles caToRo when bassReview is destination', async () => {
+      const responsibleOfficer = {
+        name: 'Jo Smith',
+        deliusId: 'delius1',
+        email: 'ro@user.com',
+        lduCode: 'code-1',
+        lduDescription: 'lduDescription-1',
+        nomsNumber: 'AAAA12',
+        probationAreaCode: 'prob-code-1',
+        probationAreaDescription: 'prob-desc-1',
+      }
+      roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue(responsibleOfficer)
+
+      await roNotificationHandler.sendRo({
+        transition: transitionForDestinations.bassReview,
+        bookingId,
+        token,
+        licence,
+        prisoner,
+        user,
+      })
+
+      expect(roNotificationSender.sendNotifications).toHaveBeenCalledWith({
+        bookingId,
+        responsibleOfficer,
+        prison: 'HMP Blah',
+        notificationType: 'RO_NEW',
+        sendingUserName: username,
+      })
+      expect(audit.record).toHaveBeenCalledWith('SEND', username, {
+        bookingId,
+        submissionTarget: responsibleOfficer,
+        transitionType: 'caToRo',
+      })
+      expect(licenceService.markForHandover).toHaveBeenCalledWith(bookingId, 'caToRo')
+      expect(licenceService.removeDecision).not.toHaveBeenCalled()
+    })
+
+    test('caToRo when cannot get RO contact details', async () => {
+      roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue({
+        message: 'failed to find RO',
+      })
+
+      await roNotificationHandler.sendRo({
+        transition: transitionForDestinations.bassReview,
+        bookingId,
+        token,
+        licence,
+        prisoner,
+        user,
+      })
+
+      expect(roNotificationSender.sendNotifications).not.toHaveBeenCalled()
+      expect(audit.record).not.toHaveBeenCalled()
+      expect(licenceService.markForHandover).not.toHaveBeenCalled()
+      expect(licenceService.removeDecision).not.toHaveBeenCalled()
+    })
+
+    test('caToRo when cannot get prison', async () => {
+      const responsibleOfficer = {
+        name: 'Jo Smith',
+        deliusId: 'delius1',
+        email: 'ro@user.com',
+        lduCode: 'code-1',
+        lduDescription: 'lduDescription-1',
+        nomsNumber: 'AAAA12',
+        probationAreaCode: 'prob-code-1',
+        probationAreaDescription: 'prob-desc-1',
+      }
+      roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue(responsibleOfficer)
+      prisonerService.getEstablishmentForPrisoner.mockResolvedValue(null)
+
+      await roNotificationHandler.sendRo({
+        transition: transitionForDestinations.bassReview,
+        bookingId,
+        token,
+        licence,
+        prisoner,
+        user,
+      })
+
+      expect(roNotificationSender.sendNotifications).not.toHaveBeenCalled()
+      expect(audit.record).not.toHaveBeenCalled()
+      expect(licenceService.markForHandover).not.toHaveBeenCalled()
+      expect(licenceService.removeDecision).not.toHaveBeenCalled()
+    })
+
+    test('caToRo when delius staff records are not linked to user', async () => {
+      const responsibleOfficer = {
+        name: 'Jo Smith',
+        deliusId: 'STAFF-1',
+        lduCode: 'code-1',
+        lduDescription: 'lduDescription-1',
+        nomsNumber: 'AAAA12',
+        probationAreaCode: 'prob-code-1',
+        probationAreaDescription: 'prob-desc-1',
+        isUnlinkedAccount: true,
+      }
+
+      roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue(responsibleOfficer)
+
+      await roNotificationHandler.sendRo({
+        transition: transitionForDestinations.bassReview,
+        bookingId,
+        token,
+        licence,
+        prisoner,
+        user,
+      })
+
+      expect(warningClient.raiseWarning).toHaveBeenCalledWith(
+        bookingId,
+        STAFF_NOT_LINKED,
+        `RO with delius staff code: 'STAFF-1' and name: 'Jo Smith', responsible for managing: 'AAAA12', has unlinked staff record in delius`
+      )
+
+      expect(roNotificationSender.sendNotifications).toHaveBeenCalledWith({
+        bookingId,
+        responsibleOfficer,
+        prison: 'HMP Blah',
+        notificationType: 'RO_NEW',
+        sendingUserName: username,
+      })
+      expect(audit.record).toHaveBeenCalledWith('SEND', username, {
+        bookingId,
+        submissionTarget: responsibleOfficer,
+        transitionType: 'caToRo',
+      })
+      expect(licenceService.markForHandover).toHaveBeenCalledWith(bookingId, 'caToRo')
+      expect(licenceService.removeDecision).not.toHaveBeenCalled()
+    })
+  })
+
+  test('caToRo adds RO role in delius if have access to delius username', async () => {
+    const responsibleOfficer = {
+      name: 'Jo Smith',
+      deliusId: 'STAFF-1',
+      username: 'userBob',
+      lduCode: 'code-1',
+      lduDescription: 'lduDescription-1',
+      nomsNumber: 'AAAA12',
+      probationAreaCode: 'prob-code-1',
+      probationAreaDescription: 'prob-desc-1',
+      isUnlinkedAccount: true,
+    }
+
+    roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue(responsibleOfficer)
+
+    await roNotificationHandler.sendRo({
+      transition: transitionForDestinations.bassReview,
+      bookingId,
+      token,
+      licence,
+      prisoner,
+      user,
+    })
+
+    expect(deliusClient.addResponsibleOfficerRole).toHaveBeenCalledWith('userBob')
+  })
+
+  test('caToRo does not RO role in delius if delius username is not present', async () => {
+    const responsibleOfficer = {
+      name: 'Jo Smith',
+      deliusId: 'STAFF-1',
+      lduCode: 'code-1',
+      lduDescription: 'lduDescription-1',
+      nomsNumber: 'AAAA12',
+      probationAreaCode: 'prob-code-1',
+      probationAreaDescription: 'prob-desc-1',
+      isUnlinkedAccount: true,
+    }
+
+    roContactDetailsService.getResponsibleOfficerWithContactDetails.mockResolvedValue(responsibleOfficer)
+
+    await roNotificationHandler.sendRo({
+      transition: transitionForDestinations.bassReview,
+      bookingId,
+      token,
+      licence,
+      prisoner,
+      user,
+    })
+
+    expect(deliusClient.addResponsibleOfficerRole).not.toHaveBeenCalled()
+  })
+})

--- a/test/services/roContactDetailService.test.js
+++ b/test/services/roContactDetailService.test.js
@@ -122,6 +122,7 @@ describe('roContactDetailsService', () => {
 
       expect(result).toEqual({
         deliusId: 'delius-1',
+        username: 'user-1',
         email: 'ro@ro.email.com',
         functionalMailbox: 'ro-org@email.com',
         lduDescription: 'Sheffield',
@@ -147,6 +148,7 @@ describe('roContactDetailsService', () => {
 
       expect(result).toEqual({
         deliusId: 'delius-1',
+        username: 'user-1',
         email: 'ro@ro.email.com',
         functionalMailbox: 'ro-org@email.com',
         lduDescription: 'Sheffield',

--- a/types/delius.d.ts
+++ b/types/delius.d.ts
@@ -63,8 +63,8 @@ export interface CommunityOrPrisonOffenderManager {
 }
 
 interface StaffDetails {
-  username: string;
-  email: string;
+  username?: string;
+  email?: string;
   staffCode: string;
   staff: Human;
   teams: Team[];
@@ -87,5 +87,6 @@ export interface DeliusClient {
   getAllOffenderManagers: (offenderNumber: string) =>  Promise<Array<CommunityOrPrisonOffenderManager>>
   getAllProbationAreas: ()=> Promise<Array<ProbationArea>>
   getAllLdusForProbationArea: (probationAreaCode: string)=> Promise<Array<Ldu>>
+  addResponsibleOfficerRole: (username: string) => Promise<void>
 }
 

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -16,7 +16,10 @@ interface ResponsibleOfficer {
 interface ResponsibleOfficerAndContactDetails extends ResponsibleOfficer {
   /** This officer's user and staff record are not linked in delius, false if unknown */
   isUnlinkedAccount: boolean,
+  /** email and delius username, will be null if unlinked account and not stored locally */
   email?: string
+  /** Will be null when contact details are stored locally  */
+  username?: string
   organisation?: string
   functionalMailbox?: string
 }


### PR DESCRIPTION
This role is added when a prison case administrator hands over a case to a responsible officer as we have identified that that delius user should have access to the licence service.

We add a delius role to the user. When that user attempts to access the service with their delius user details, nomis oauth server will map the new delius role to the standard licence responsible officer role.

The add role is an idempotent operation - so there is no problem executing it every time an RO is assigned a case.