### PR TITLE
DCS-328: Ldus reorganised and  duplicates removed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,13 @@
 {
   "extends": ["airbnb-base", "plugin:prettier/recommended"],
   "rules": {
+    "no-unused-vars": [
+      1,
+      {
+        "argsIgnorePattern": "res|next|^err|_",
+        "ignoreRestSiblings": true
+      }
+    ],
     "prettier/prettier": ["error"],
     "no-use-before-define": "off",
     "prefer-destructuring": "warn",

--- a/server/services/lduService.js
+++ b/server/services/lduService.js
@@ -29,23 +29,21 @@ module.exports = function createLduService(deliusClient, activeLduClient) {
 
       const { content: ldus = [] } = await deliusClient.getAllLdusForProbationArea(probationAreaCode)
 
-      const allLdus = ldus
-        .map(ldu => ({
-          code: ldu.code,
-          description: ldu.description,
-          active: activeLdusCodes.includes(ldu.code),
-        }))
-        .sort((a, b) => a.description.localeCompare(b.description, 'en', { ignorePunctuation: true }))
+      const allLdus = ldus.map(ldu => ({
+        code: ldu.code,
+        description: ldu.description,
+        active: activeLdusCodes.includes(ldu.code),
+      }))
 
-      const uniqueLdus = Object.entries(R.groupBy(ldu => ldu.code, allLdus)).map(ldu => ldu[1][0])
+      const uniqueLdus = [...Object.entries(R.groupBy(R.prop('code'), allLdus))]
+        .sort(([lduCode1], [lduCode2]) => lduCode1.localeCompare(lduCode2))
+        .map(([_, ldu]) => ldu.sort((ldu1, ldu2) => ldu1.description.localeCompare(ldu2.description))[0])
 
-      const probationArea = {
+      return {
         code: probationAreaCode,
         description: probationAreaDescription,
         ldus: uniqueLdus,
       }
-
-      return probationArea
     },
 
     async updateActiveLdus(probationAreaCode, activeLdus) {

--- a/server/services/lduService.js
+++ b/server/services/lduService.js
@@ -1,3 +1,4 @@
+const R = require('ramda')
 const logger = require('../../log')
 
 /**
@@ -28,16 +29,20 @@ module.exports = function createLduService(deliusClient, activeLduClient) {
 
       const { content: ldus = [] } = await deliusClient.getAllLdusForProbationArea(probationAreaCode)
 
-      const allLdus = ldus.map(ldu => ({
-        code: ldu.code,
-        description: ldu.description,
-        active: activeLdusCodes.includes(ldu.code),
-      }))
+      const allLdus = ldus
+        .map(ldu => ({
+          code: ldu.code,
+          description: ldu.description,
+          active: activeLdusCodes.includes(ldu.code),
+        }))
+        .sort((a, b) => a.description.localeCompare(b.description, 'en', { ignorePunctuation: true }))
+
+      const uniqueLdus = Object.entries(R.groupBy(ldu => ldu.code, allLdus)).map(ldu => ldu[1][0])
 
       const probationArea = {
         code: probationAreaCode,
         description: probationAreaDescription,
-        ldus: allLdus,
+        ldus: uniqueLdus,
       }
 
       return probationArea

--- a/server/views/admin/locations/ldus.pug
+++ b/server/views/admin/locations/ldus.pug
@@ -24,5 +24,5 @@ block content
               
 
     if probationArea.ldus[0]
-      div.pure-u-1.inlineButtons
+      div.pure-u-1.inlineButtons.largePaddingBottom
         input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Save")

--- a/server/views/admin/locations/probationAreas.pug
+++ b/server/views/admin/locations/probationAreas.pug
@@ -13,4 +13,4 @@ block content
       ul
         each probationArea in probationAreas     
           li 
-            a(href="/admin/locations/probation-areas/"+probationArea.code+"/local-delivery-units") #{probationArea.description}
+            a(href="/admin/locations/probation-areas/"+probationArea.code+"/local-delivery-units") #{probationArea.description} (#{probationArea.code})

--- a/test/services/lduService.test.js
+++ b/test/services/lduService.test.js
@@ -59,8 +59,76 @@ describe('lduService', () => {
         description: 'London',
         ldus: [
           { code: 'ham', description: 'Hampstead', active: true },
-          { code: 'wtl', description: 'Waterloo', active: false },
           { code: 'pic', description: 'Picadilly', active: true },
+          { code: 'wtl', description: 'Waterloo', active: false },
+        ],
+      })
+    })
+
+    it('Should remove duplicate ldus and only show the first description', async () => {
+      deliusClient.getAllLdusForProbationArea.mockResolvedValue({
+        content: [
+          { code: 'ham', description: 'Hampstead' },
+          { code: 'pic', description: 'Picadilly' },
+          { code: 'ham', description: 'Hampstead2' },
+          { code: 'pic', description: 'Picadilly2' },
+          { code: 'wtl', description: 'Waterloo2' },
+          { code: 'pic', description: 'Picadilly' },
+          { code: 'ham', description: 'Hampstead2' },
+          { code: 'pic', description: 'Picadilly2' },
+          { code: 'wtl', description: 'Waterloo' },
+        ],
+      })
+
+      deliusClient.getAllProbationAreas.mockResolvedValue({ content: [{ code: 'Lon', description: 'London' }] })
+      activeLduClient.allActiveLdusInArea.mockResolvedValue([{ code: 'ham' }, { code: 'pic' }])
+
+      const result = await lduService.getProbationArea('Lon')
+
+      expect(result).toEqual({
+        code: 'Lon',
+        description: 'London',
+        ldus: [
+          { code: 'ham', description: 'Hampstead', active: true },
+          { code: 'pic', description: 'Picadilly', active: true },
+          { code: 'wtl', description: 'Waterloo', active: false },
+        ],
+      })
+    })
+
+    it('Should NOT return duplicate ldus', async () => {
+      deliusClient.getAllLdusForProbationArea.mockResolvedValue({
+        content: [
+          { code: 'ham', description: 'Hampstead' },
+          { code: 'wtl', description: 'Waterloo' },
+          { code: 'pic', description: 'Picadilly' },
+          { code: 'ham', description: 'Hampstead2' },
+          { code: 'pic', description: 'Picadilly2' },
+          { code: 'wtl', description: 'Waterloo2' },
+          { code: 'ham', description: 'Hampstead' },
+          { code: 'wtl', description: 'Waterloo' },
+          { code: 'pic', description: 'Picadilly' },
+          { code: 'ham', description: 'Hampstead2' },
+          { code: 'pic', description: 'Picadilly2' },
+          { code: 'wtl', description: 'Waterloo2' },
+        ],
+      })
+
+      deliusClient.getAllProbationAreas.mockResolvedValue({ content: [{ code: 'Lon', description: 'London' }] })
+      activeLduClient.allActiveLdusInArea.mockResolvedValue([{ code: 'ham' }, { code: 'pic' }])
+
+      const result = await lduService.getProbationArea('Lon')
+
+      expect(result).not.toEqual({
+        code: 'Lon',
+        description: 'London',
+        ldus: [
+          { code: 'ham', description: 'Hampstead' },
+          { code: 'wtl', description: 'Waterloo' },
+          { code: 'pic', description: 'Picadilly' },
+          { code: 'ham', description: 'Hampstead2', active: true },
+          { code: 'pic', description: 'Picadilly2', active: true },
+          { code: 'wtl', description: 'Waterloo2', active: false },
         ],
       })
     })

--- a/test/services/lduService.test.js
+++ b/test/services/lduService.test.js
@@ -95,43 +95,6 @@ describe('lduService', () => {
         ],
       })
     })
-
-    it('Should NOT return duplicate ldus', async () => {
-      deliusClient.getAllLdusForProbationArea.mockResolvedValue({
-        content: [
-          { code: 'ham', description: 'Hampstead' },
-          { code: 'wtl', description: 'Waterloo' },
-          { code: 'pic', description: 'Picadilly' },
-          { code: 'ham', description: 'Hampstead2' },
-          { code: 'pic', description: 'Picadilly2' },
-          { code: 'wtl', description: 'Waterloo2' },
-          { code: 'ham', description: 'Hampstead' },
-          { code: 'wtl', description: 'Waterloo' },
-          { code: 'pic', description: 'Picadilly' },
-          { code: 'ham', description: 'Hampstead2' },
-          { code: 'pic', description: 'Picadilly2' },
-          { code: 'wtl', description: 'Waterloo2' },
-        ],
-      })
-
-      deliusClient.getAllProbationAreas.mockResolvedValue({ content: [{ code: 'Lon', description: 'London' }] })
-      activeLduClient.allActiveLdusInArea.mockResolvedValue([{ code: 'ham' }, { code: 'pic' }])
-
-      const result = await lduService.getProbationArea('Lon')
-
-      expect(result).not.toEqual({
-        code: 'Lon',
-        description: 'London',
-        ldus: [
-          { code: 'ham', description: 'Hampstead' },
-          { code: 'wtl', description: 'Waterloo' },
-          { code: 'pic', description: 'Picadilly' },
-          { code: 'ham', description: 'Hampstead2', active: true },
-          { code: 'pic', description: 'Picadilly2', active: true },
-          { code: 'wtl', description: 'Waterloo2', active: false },
-        ],
-      })
-    })
   })
 
   describe('updateActiveLdus', () => {


### PR DESCRIPTION
http://localhost:3000/admin/locations/probation-areas
Probation area code appended to name

http://localhost:3000/admin/locations/probation-areas/:code/local-delivery-units
Ldus filtered by code to remove any duplicates. Displayed only first description where the same ldu may have more than one description

Extra padding to bottom of save button