### PR TITLE
DCS-339 Fixing issue where you could not change roles if you were an RO

### DIFF
--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -7,7 +7,7 @@ module.exports = ({ userService }) => router => {
     '/',
     asyncMiddleware(async (req, res) => {
       const [allRoles, allCaseLoads] = await Promise.all([
-        userService.getAllRoles(res.locals.token),
+        userService.getAllRoles(req.user.token),
         userService.getAllCaseLoads(req.user, res.locals.token),
       ])
 


### PR DESCRIPTION
RO has system credentials and so associated set of roles assigned to res.locals in auth.js.
The role switcher only sees the RO role, and no other roles which the user could change to so it disappears.

This change ensures that the roles that are considered belong to the user token rather than the system token.

The whole auth/role handling area could do with being rewritten