### PR TITLE
Add admin "search for licence" page 

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -33,7 +33,9 @@ const jobsAdminRouter = require('../server/routes/admin/jobs')
 const deliusAdminRouter = require('../server/routes/admin/delius')
 const locationsRouter = require('../server/routes/admin/locations')
 const warningsRouter = require('../server/routes/admin/warnings')
+const licenceSearchRouter = require('../server/routes/admin/licenceSearch')
 const apiRouter = require('../server/routes/api')
+
 const caseListRouter = require('../server/routes/caseList')
 const contactRouter = require('../server/routes/contact')
 const pdfRouter = require('../server/routes/pdf')
@@ -69,6 +71,7 @@ module.exports = function createApp({
   caseListService,
   pdfService,
   formService,
+  licenceSearchService,
   userAdminService,
   reportingService,
   notificationService,
@@ -360,6 +363,7 @@ module.exports = function createApp({
   app.use('/admin/delius/', secureRoute(deliusAdminRouter(roService)))
   app.use('/admin/warnings/', secureRoute(warningsRouter(warningClient), { auditKey: 'WARNINGS' }))
   app.use('/admin/locations/', secureRoute(locationsRouter(lduService), { auditKey: 'WARNINGS' }))
+  app.use('/admin/licenceSearch/', secureRoute(licenceSearchRouter(licenceSearchService)))
 
   app.use('/hdc/contact/', secureRoute(contactRouter(userAdminService, roService)))
   app.use('/hdc/pdf/', secureRoute(pdfRouter({ pdfService, prisonerService }), { auditKey: 'CREATE_PDF' }))

--- a/server/app.js
+++ b/server/app.js
@@ -34,6 +34,7 @@ const deliusAdminRouter = require('../server/routes/admin/delius')
 const locationsRouter = require('../server/routes/admin/locations')
 const warningsRouter = require('../server/routes/admin/warnings')
 const licenceSearchRouter = require('../server/routes/admin/licenceSearch')
+const licenceRouter = require('../server/routes/admin/licence')
 const apiRouter = require('../server/routes/api')
 
 const caseListRouter = require('../server/routes/caseList')
@@ -364,6 +365,7 @@ module.exports = function createApp({
   app.use('/admin/warnings/', secureRoute(warningsRouter(warningClient), { auditKey: 'WARNINGS' }))
   app.use('/admin/locations/', secureRoute(locationsRouter(lduService), { auditKey: 'WARNINGS' }))
   app.use('/admin/licenceSearch/', secureRoute(licenceSearchRouter(licenceSearchService)))
+  app.use('/admin/licences/', secureRoute(licenceRouter(licenceService, signInService, prisonerService)))
 
   app.use('/hdc/contact/', secureRoute(contactRouter(userAdminService, roService)))
   app.use('/hdc/pdf/', secureRoute(pdfRouter({ pdfService, prisonerService }), { auditKey: 'CREATE_PDF' }))

--- a/server/data/nomisClientBuilder.js
+++ b/server/data/nomisClientBuilder.js
@@ -47,6 +47,11 @@ module.exports = token => {
       return nomisGet({ path })
     },
 
+    getBookingByOffenderNumber(offenderNo) {
+      const path = `${apiUrl}/bookings/offenderNo/${offenderNo}`
+      return nomisGet({ path })
+    },
+
     getAliases(bookingId) {
       const path = `${apiUrl}/bookings/${bookingId}/aliases`
       return nomisGet({ path })

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,7 @@ const createProbationTeamsClient = require('./data/probationTeamsClient')
 const createRoService = require('./services/roService')
 const createCaService = require('./services/caService')
 const createLduService = require('./services/lduService')
+const createLicenceSearchService = require('./services/licenceSearchService')
 
 const signInService = createSignInService()
 const licenceService = createLicenceService(licenceClient)
@@ -107,6 +108,7 @@ const nomisPushService = createNomisPushService(nomisClientBuilder, signInServic
 const notificationJobs = createNotificationJobs(reminderService, signInService)
 const jobSchedulerService = createJobSchedulerService(dbLockingClient, configClient, notificationJobs)
 const lduService = createLduService(deliusClient, activeLduClient)
+const licenceSearchService = createLicenceSearchService(licenceClient, signInService, nomisClientBuilder)
 
 const app = createApp({
   signInService,
@@ -123,6 +125,7 @@ const app = createApp({
   nomisPushService,
   configClient,
   jobSchedulerService,
+  licenceSearchService,
   roService,
   audit,
   caService,

--- a/server/routes/admin/licence.js
+++ b/server/routes/admin/licence.js
@@ -1,0 +1,18 @@
+const { asyncMiddleware, authorisationMiddleware } = require('../../utils/middleware')
+
+module.exports = (licenceService, signInService, prisonerService) => router => {
+  router.use(authorisationMiddleware)
+
+  router.get(
+    '/:bookingId',
+    asyncMiddleware(async (req, res) => {
+      const { bookingId } = req.params
+      const licence = await licenceService.getLicence(bookingId)
+      const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
+      const prisonerInfo = await prisonerService.getPrisonerDetails(bookingId, systemToken.token)
+      return res.render('admin/licences/view', { bookingId, licence, prisonerInfo })
+    })
+  )
+
+  return router
+}

--- a/server/routes/admin/licenceSearch.js
+++ b/server/routes/admin/licenceSearch.js
@@ -15,7 +15,7 @@ module.exports = licenceSearchService => (router, audited) => {
     '/',
     asyncMiddleware(async (req, res) => {
       const errors = firstItem(req.flash('errors')) || {}
-      return res.render('admin/licenceSearch', { errors })
+      return res.render('admin/licences/search', { errors })
     })
   )
 

--- a/server/routes/admin/licenceSearch.js
+++ b/server/routes/admin/licenceSearch.js
@@ -1,0 +1,38 @@
+/**
+ * @typedef {import("../../../types/licences").LicenceSearchService} LicenceSearchService
+ */
+const { asyncMiddleware, authorisationMiddleware } = require('../../utils/middleware')
+const logger = require('../../../log')
+const { firstItem } = require('../../utils/functionalHelpers')
+
+/**
+ *  @param {LicenceSearchService} licenceSearchService
+ */
+module.exports = licenceSearchService => (router, audited) => {
+  router.use(authorisationMiddleware)
+
+  router.get(
+    '/',
+    asyncMiddleware(async (req, res) => {
+      const errors = firstItem(req.flash('errors')) || {}
+      return res.render('admin/licenceSearch', { errors })
+    })
+  )
+
+  router.post(
+    '/',
+    audited,
+    asyncMiddleware(async (req, res) => {
+      const { id } = req.body
+      logger.info(`Searching for licence with identifier: [${id}]`)
+      const licenceId = await licenceSearchService.findForId(req.user.username, id)
+      if (licenceId) {
+        return res.redirect(`/admin/licences/${licenceId}`)
+      }
+      req.flash('errors', { id: `Could not find licences with identifier: '${id || ''}'` })
+      return res.redirect('/admin/licenceSearch')
+    })
+  )
+
+  return router
+}

--- a/server/services/licenceSearchService.js
+++ b/server/services/licenceSearchService.js
@@ -1,0 +1,43 @@
+/**
+ * @typedef {import("../../types/licences").LicenceSearchService} LicenceSearchService
+ */
+
+/**
+ * @return {LicenceSearchService} LicenceSearchService
+ */
+module.exports = function createLicenceSearchService(licenceClient, signInService, nomisClientBuilder) {
+  const bookingIdForExistingLicence = async bookingId => {
+    const licence = await licenceClient.getLicence(bookingId)
+    return licence ? licence.booking_id : null
+  }
+
+  const findByBookingId = async offenderIdentifier => {
+    const parsedBookingId = parseInt(offenderIdentifier.trim(), 10)
+    return parsedBookingId && bookingIdForExistingLicence(parsedBookingId)
+  }
+
+  const findByOffenderNumber = async (username, offenderIdentifier) => {
+    const systemToken = await signInService.getClientCredentialsTokens(username)
+    const client = nomisClientBuilder(systemToken)
+
+    try {
+      const { bookingId } = await client.getBookingByOffenderNumber(offenderIdentifier)
+      return bookingId && bookingIdForExistingLicence(bookingId)
+    } catch (error) {
+      if (error.status === 404) {
+        return null
+      }
+      throw error
+    }
+  }
+
+  return {
+    async findForId(username, offenderIdentifier) {
+      const bookingId = await findByBookingId(offenderIdentifier)
+      if (bookingId) {
+        return bookingId
+      }
+      return findByOffenderNumber(username, offenderIdentifier)
+    },
+  }
+}

--- a/server/services/licenceSearchService.js
+++ b/server/services/licenceSearchService.js
@@ -18,7 +18,7 @@ module.exports = function createLicenceSearchService(licenceClient, signInServic
 
   const findByOffenderNumber = async (username, offenderIdentifier) => {
     const systemToken = await signInService.getClientCredentialsTokens(username)
-    const client = nomisClientBuilder(systemToken)
+    const client = nomisClientBuilder(systemToken.token)
 
     try {
       const { bookingId } = await client.getBookingByOffenderNumber(offenderIdentifier)

--- a/server/utils/licenceStatus.js
+++ b/server/utils/licenceStatus.js
@@ -752,14 +752,14 @@ function getBassAreaCheckState(bassAreaSuitableAnswer, bassAreaReason) {
 
 function getBassState(licence) {
   const bassAccepted = getIn(licence, ['bassReferral', 'bassOffer', 'bassAccepted'])
-  const bassOffer = getBassOfferState(licence, bassAccepted)
+  const bassOffer = getBassOfferState(bassAccepted)
   const { bassWithdrawn, bassWithdrawalReason } = getBassWithdrawalState(licence)
   const bassAddress = getBassAddressState(licence)
 
   return { bassAccepted, bassOffer, bassWithdrawn, bassWithdrawalReason, bassAddress }
 }
 
-function getBassOfferState(licence, bassAccepted) {
+function getBassOfferState(bassAccepted) {
   if (!bassAccepted) {
     return taskStates.UNSTARTED
   }

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -17,3 +17,5 @@ block content
         a(href='/admin/warnings/outstanding') View Warnings
       div
         a(href='/admin/locations/probation-areas') Manage locations
+      div
+        a(href='/admin/licenceSearch') Search for licence

--- a/server/views/admin/licenceSearch.pug
+++ b/server/views/admin/licenceSearch.pug
@@ -1,0 +1,26 @@
+extends ../layout
+include ../includes/errorBannerWithDetail
+
+block content
+
+  div.back-link-container.smallPaddingTop
+    a#back.link-back(href="/admin/") Back
+
+    +errorBannerWithDetail(errors, [{ field: 'id' }])
+
+  div.pure-g
+    div.pure-u-1.largeMarginTop
+      h2.heading-medium Search for licence
+
+      form(method='POST' action='/admin/licenceSearch')
+        input(type="hidden" name="_csrf" value=csrfToken)
+
+        div.pure-u-2-3.midPaddingBottom
+          div.pure-g.u-paddingBottom
+            div.pure-u-1
+              label.form-label(for="id") Offender Identifier (Offender number or Booking ID)
+            div.pure-u-sm-5-12
+              input.form-control(id="id" type="text" name="id")
+            div.pure-u-sm-1-6.sm-PadLeftRight15
+              input.requiredButton.button(type="submit" value="Search")
+            div.pure-u-sm-5-12

--- a/server/views/admin/licences/search.pug
+++ b/server/views/admin/licences/search.pug
@@ -1,5 +1,5 @@
-extends ../layout
-include ../includes/errorBannerWithDetail
+extends ../../layout
+include ../../includes/errorBannerWithDetail
 
 block content
 

--- a/server/views/admin/licences/view.pug
+++ b/server/views/admin/licences/view.pug
@@ -1,0 +1,9 @@
+//- Read only licence view eg from caselist when case is with a different role
+extends ../../layout
+
+block content
+
+  include ../../includes/back
+
+  h1.heading-large Licence details
+  include ../../taskList/prisonerDetails

--- a/test/data/nomisClient.test.js
+++ b/test/data/nomisClient.test.js
@@ -52,6 +52,25 @@ describe('nomisClient', () => {
     })
   })
 
+  describe('getBookingByOffenderNumber', () => {
+    test('should return data from api', () => {
+      fakeNomis.get(`/bookings/offenderNo/ABC123D`).reply(200, { key: 'value' })
+
+      return expect(nomisClient.getBookingByOffenderNumber('ABC123D')).resolves.toEqual({ key: 'value' })
+    })
+
+    test('should reject if api fails', () => {
+      fakeNomis
+        .get(`/bookings/offenderNo/ABC123D`)
+        .thrice()
+        .reply(500)
+
+      return expect(nomisClient.getBookingByOffenderNumber('ABC123D')).rejects.toStrictEqual(
+        Error('Internal Server Error')
+      )
+    })
+  })
+
   describe('getImageInfo', () => {
     test('should return data from api', () => {
       fakeNomis.get(`/images/1`).reply(200, { key: 'value' })

--- a/test/routes/admin/licence.test.js
+++ b/test/routes/admin/licence.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest')
+
+const {
+  auditStub,
+  createPrisonerServiceStub,
+  createLicenceServiceStub,
+  appSetup,
+  createSignInServiceStub,
+} = require('../../supertestSetup')
+
+const standardRouter = require('../../../server/routes/routeWorkers/standardRouter')
+const createAdminRoute = require('../../../server/routes/admin/licence')
+
+describe('/licences/', () => {
+  describe('GET licence', () => {
+    test('Renders HTML output', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/licences/1')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Licence details')
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app)
+        .get('/admin/licences/1')
+        .expect(403)
+    })
+  })
+
+  function createApp(user) {
+    const prisonerService = createPrisonerServiceStub()
+    const licenceService = createLicenceServiceStub()
+    const signInService = createSignInServiceStub()
+    const baseRouter = standardRouter({ licenceService, prisonerService, audit: auditStub, signInService })
+    const route = baseRouter(createAdminRoute(licenceService, signInService, prisonerService))
+    return appSetup(route, user, '/admin/licences')
+  }
+})

--- a/test/routes/admin/licenceSearch.test.js
+++ b/test/routes/admin/licenceSearch.test.js
@@ -1,0 +1,86 @@
+const request = require('supertest')
+
+const {
+  auditStub,
+  createPrisonerServiceStub,
+  createLicenceServiceStub,
+  appSetup,
+  createSignInServiceStub,
+} = require('../../supertestSetup')
+
+const standardRouter = require('../../../server/routes/routeWorkers/standardRouter')
+const createAdminRoute = require('../../../server/routes/admin/licenceSearch')
+
+describe('/licenceSearch/', () => {
+  let licenceSearchService
+
+  beforeEach(() => {
+    licenceSearchService = {
+      findForId: jest.fn(),
+    }
+  })
+
+  describe('GET search', () => {
+    test('Renders HTML output', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/licenceSearch')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Search for licence')
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app)
+        .get('/admin/licenceSearch')
+        .expect(403)
+    })
+  })
+
+  describe('POST search', () => {
+    test('calls search service, finds licence and redirects to licence page', () => {
+      licenceSearchService.findForId.mockReturnValue(1)
+      const app = createApp('batchUser')
+      return request(app)
+        .post('/admin/licenceSearch')
+        .send('id=123')
+        .expect(302)
+        .expect('Location', '/admin/licences/1')
+        .expect(() => {
+          expect(licenceSearchService.findForId).toHaveBeenCalledWith('NOMIS_BATCHLOAD', '123')
+        })
+    })
+
+    test('calls search service, fails to find licence and shows warning message', () => {
+      licenceSearchService.findForId.mockReturnValue(null)
+      const app = createApp('batchUser')
+      return request(app)
+        .post('/admin/licenceSearch')
+        .send('id=123')
+        .expect(302)
+        .expect('Location', '/admin/licenceSearch')
+        .expect(() => {
+          expect(licenceSearchService.findForId).toHaveBeenCalledWith('NOMIS_BATCHLOAD', '123')
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app)
+        .get('/admin/licenceSearch')
+        .expect(403)
+    })
+  })
+
+  function createApp(user) {
+    const prisonerService = createPrisonerServiceStub()
+    const licenceService = createLicenceServiceStub()
+    const signInService = createSignInServiceStub()
+    const baseRouter = standardRouter({ licenceService, prisonerService, audit: auditStub, signInService })
+    const route = baseRouter(createAdminRoute(licenceSearchService))
+    return appSetup(route, user, '/admin/licenceSearch')
+  }
+})

--- a/test/routes/admin/userAdmin.test.js
+++ b/test/routes/admin/userAdmin.test.js
@@ -7,10 +7,10 @@ const {
   createLicenceServiceStub,
   appSetup,
   createSignInServiceStub,
-} = require('../supertestSetup')
+} = require('../../supertestSetup')
 
-const standardRouter = require('../../server/routes/routeWorkers/standardRouter')
-const createAdminRoute = require('../../server/routes/admin/users')
+const standardRouter = require('../../../server/routes/routeWorkers/standardRouter')
+const createAdminRoute = require('../../../server/routes/admin/users')
 
 const user1 = {
   nomisId: 'user1',

--- a/test/services/licenceSearchService.test.js
+++ b/test/services/licenceSearchService.test.js
@@ -1,0 +1,74 @@
+const createLicenceSearchService = require('../../server/services/licenceSearchService')
+
+const licenceClient = {
+  getLicence: jest.fn(),
+}
+
+const signInService = {
+  getClientCredentialsTokens: jest.fn().mockReturnValue('a token'),
+}
+
+const nomisClient = {
+  getBookingByOffenderNumber: jest.fn().mockReturnValue({ bookingId: 1 }),
+}
+
+const nomisClientBuilder = jest.fn().mockReturnValue(nomisClient)
+
+let licenceSearchService
+
+describe('licenceSearchService', () => {
+  beforeEach(async () => {
+    licenceSearchService = await createLicenceSearchService(licenceClient, signInService, nomisClientBuilder)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('findLicenceFor', () => {
+    it('Should find when searching by booking id', async () => {
+      licenceClient.getLicence.mockReturnValue({ booking_id: 1234 })
+
+      const bookingId = await licenceSearchService.findForId('user-1', '1234')
+
+      expect(bookingId).toBe(1234)
+    })
+
+    it('Should trim input when searching by booking id', async () => {
+      licenceClient.getLicence.mockReturnValue({ booking_id: 1234 })
+
+      const bookingId = await licenceSearchService.findForId('user-1', '  1234   ')
+
+      expect(bookingId).toBe(1234)
+    })
+
+    it('Should find when searching by offender number', async () => {
+      nomisClient.getBookingByOffenderNumber.mockReturnValue({ bookingId: 1234 })
+      licenceClient.getLicence.mockReturnValueOnce({ booking_id: 1234 })
+
+      const bookingId = await licenceSearchService.findForId('user-1', 'ABC1234')
+
+      expect(bookingId).toBe(1234)
+      expect(signInService.getClientCredentialsTokens).toHaveBeenCalledWith('user-1')
+      expect(nomisClient.getBookingByOffenderNumber).toHaveBeenCalledWith('ABC1234')
+    })
+
+    it('Can cope with 404 when searching by offender number', async () => {
+      licenceClient.getLicence.mockReturnValue(null)
+      nomisClient.getBookingByOffenderNumber.mockRejectedValue({ status: 404 })
+
+      const bookingId = await licenceSearchService.findForId('user-1', 'ABC1234')
+
+      expect(bookingId).toBe(null)
+      expect(signInService.getClientCredentialsTokens).toHaveBeenCalledWith('user-1')
+      expect(nomisClient.getBookingByOffenderNumber).toHaveBeenCalledWith('ABC1234')
+    })
+
+    it('propagates other http errors when searching by offender number', async () => {
+      licenceClient.getLicence.mockReturnValue(null)
+      nomisClient.getBookingByOffenderNumber.mockRejectedValue({ status: 500 })
+
+      return expect(licenceSearchService.findForId('user-1', 'ABC1234')).rejects.toStrictEqual({ status: 500 })
+    })
+  })
+})

--- a/types/licences.d.ts
+++ b/types/licences.d.ts
@@ -119,6 +119,12 @@ export interface LduService {
   updateActiveLdus: (probationAreaCode: string, activeLdus: string[]) => Promise<void>
 }
 
+
+export interface LicenceSearchService {
+  findForId: (username: string, id: string) => Promise<number | undefined>
+}
+
+
 export interface ActiveLduClient {
   isLduPresent: (lduCode: string, probationAreaCode: string)=> Promise<boolean>
   allActiveLdusInArea: (probationAreaCode: string)=> Promise<ActiveLdu[]>


### PR DESCRIPTION
We want to add the ability for admin staff to be able to view additional information about a licence.

This allows searching for a licence based on offender number or booking id and currently just shows limited info about the offender, assigned RO and some key dates. 

In future tickets we will add additional info/actions to this page, for instance, we want to expose audit history for a licence to reduce the amount of time we need to spend when investigating support requests. 
