### PR TITLE
DCS-332 Adding in history view into the admin licences screen

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -365,7 +365,7 @@ module.exports = function createApp({
   app.use('/admin/warnings/', secureRoute(warningsRouter(warningClient), { auditKey: 'WARNINGS' }))
   app.use('/admin/locations/', secureRoute(locationsRouter(lduService), { auditKey: 'WARNINGS' }))
   app.use('/admin/licenceSearch/', secureRoute(licenceSearchRouter(licenceSearchService)))
-  app.use('/admin/licences/', secureRoute(licenceRouter(licenceService, signInService, prisonerService)))
+  app.use('/admin/licences/', secureRoute(licenceRouter(licenceService, signInService, prisonerService, audit)))
 
   app.use('/hdc/contact/', secureRoute(contactRouter(userAdminService, roService)))
   app.use('/hdc/pdf/', secureRoute(pdfRouter({ pdfService, prisonerService }), { auditKey: 'CREATE_PDF' }))

--- a/server/data/audit.js
+++ b/server/data/audit.js
@@ -39,6 +39,9 @@ module.exports = {
     const { rows } = await db.query(query)
     return rows
   },
+
+  getEvent,
+  getEventsForBooking,
 }
 
 function addItem(key, user, data) {
@@ -48,6 +51,22 @@ function addItem(key, user, data) {
   }
 
   return db.query(query)
+}
+
+async function getEventsForBooking(bookingId) {
+  const { rows } = await db.query({
+    text: `select id, "timestamp", "user", action, details from audit where details::jsonb ->> 'bookingId' = $1 order by timestamp desc;`,
+    values: [bookingId],
+  })
+  return rows
+}
+
+async function getEvent(eventId) {
+  const { rows } = await db.query({
+    text: `select id, "timestamp", "user", action, details from audit where id = $1;`,
+    values: [eventId],
+  })
+  return rows[0]
 }
 
 function getEventQuery(action, filters, optionalQueries) {

--- a/server/routes/admin/licence.js
+++ b/server/routes/admin/licence.js
@@ -1,16 +1,39 @@
+const moment = require('moment')
+const setCase = require('case')
+
 const { asyncMiddleware, authorisationMiddleware } = require('../../utils/middleware')
 
-module.exports = (licenceService, signInService, prisonerService) => router => {
+module.exports = (licenceService, signInService, prisonerService, audit) => router => {
   router.use(authorisationMiddleware)
 
+  const formatEvent = event => ({
+    id: event.id,
+    user: event.user,
+    action: setCase.sentence(event.action),
+    type: event.action,
+    timestamp: moment(event.timestamp).format('dddd Do MMMM HH:mm:ss'),
+    details: event.details,
+    detailsJson: JSON.stringify(event.details, null, 4),
+  })
+
   router.get(
-    '/:bookingId',
+    '/:abookingId',
     asyncMiddleware(async (req, res) => {
-      const { bookingId } = req.params
+      const { abookingId: bookingId } = req.params
       const licence = await licenceService.getLicence(bookingId)
       const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
       const prisonerInfo = await prisonerService.getPrisonerDetails(bookingId, systemToken.token)
-      return res.render('admin/licences/view', { bookingId, licence, prisonerInfo })
+      const events = await audit.getEventsForBooking(bookingId)
+      return res.render('admin/licences/view', { bookingId, licence, prisonerInfo, events: events.map(formatEvent) })
+    })
+  )
+
+  router.get(
+    '/events/:eventId/raw',
+    asyncMiddleware(async (req, res) => {
+      const { eventId } = req.params
+      const event = await audit.getEvent(eventId)
+      return res.render('admin/licences/event', { event: formatEvent(event) })
     })
   )
 

--- a/server/routes/admin/licenceSearch.js
+++ b/server/routes/admin/licenceSearch.js
@@ -29,7 +29,7 @@ module.exports = licenceSearchService => (router, audited) => {
       if (licenceId) {
         return res.redirect(`/admin/licences/${licenceId}`)
       }
-      req.flash('errors', { id: `Could not find licences with identifier: '${id || ''}'` })
+      req.flash('errors', { id: `Could not find licence with identifier: '${id || ''}'` })
       return res.redirect('/admin/licenceSearch')
     })
   )

--- a/server/views/admin/licences/activity.pug
+++ b/server/views/admin/licences/activity.pug
@@ -1,0 +1,79 @@
+mixin detail(type, details)
+  case type
+    when 'SEND'
+        + send(details)
+    when 'UPDATE_SECTION'
+        + updateSection(details)
+    when 'NOTIFY'
+        + notify(details)
+    default
+        | &nbsp;   
+
+mixin defaultType(type, details)
+    | #{type} #{details}
+
+
+mixin send(details)
+    case details.transitionType
+      when 'caToRo'
+          | Sent from CA → RO
+      when 'roToCa'
+          | Sent from RO → CA
+      when 'caToDm'
+          | Sent from CA → DM
+      when 'dmToCa'
+          | Sent from DM → CA
+      default
+          | #{transitionType}
+
+mixin updateSection(details)
+    | Provided details for '#{details.path.replace(/\/hdc\/(.*?)\/[\d]+/, "$1")}'
+
+mixin notify(details)
+    | #{details.notifications.length} notifications sent of type: '#{details.notificationType}'
+
+mixin assignedTo(val)
+  case val
+    when 'PROCESSING_RO'
+    when 'VARY'
+       | Responsible Officer
+    when 'APPROVAL'
+    when 'MODIFIED_APPROVAL'
+       | Decision Maker
+    default
+       | Prison Case Admin 
+
+div.borderBottom.paddingBottom
+  
+  h2.heading-medium Activity
+
+  p
+    span.bold Current stage:&nbsp;
+    span #{licence.stage}
+  p
+    span.bold Currently Assigned to:&nbsp;
+    span 
+      + assignedTo(licence.stage)
+    
+    
+  table.largeMarginBottom
+    thead
+        tr
+        th Timestamp
+        th User
+        th Action
+        th Details
+    tbody
+        each event in events
+          tr.hdcEligible
+          td.link
+              a(id='event-'+ event.id  href='/admin/licences/events/' + event.id + '/raw') #{event.timestamp}
+          td.user
+              | #{event.user}
+          td.action
+              | #{event.action}
+          td.details
+              + detail(event.type, event.details)
+
+
+

--- a/server/views/admin/licences/event.pug
+++ b/server/views/admin/licences/event.pug
@@ -1,0 +1,33 @@
+//- Read only licence view eg from caselist when case is with a different role
+extends ../../layout
+
+block content
+
+  include ../../includes/back
+
+  h1.heading-large Event details
+  
+  div.pure-g.paddingBottom
+    div.pure-u-1.pure-u-md-3-24.padRight15
+      div.midMarginBottom
+        span.bold Id
+        span.block #{event.id}
+    div.pure-u-1.pure-u-md-8-24.padRight15
+      div.midMarginBottom
+        span.bold Timestamp
+        span.block #{event.timestamp}
+    div.pure-u-1.pure-u-md-5-24.padRight15
+      div.midMarginBottom
+        span.bold User
+        span.block #{event.user}    
+    div.pure-u-1.pure-u-md-5-24.padRight15
+      div.midMarginBottom
+        span.bold Action
+        span.block #{event.action}    
+
+  div.pure-g.paddingBottom
+    div.pure-u-1
+      div.midMarginBottom
+        span.bold Details:
+        pre.paddingTop
+          code !{event.detailsJson}

--- a/server/views/admin/licences/search.pug
+++ b/server/views/admin/licences/search.pug
@@ -18,7 +18,7 @@ block content
         div.pure-u-2-3.midPaddingBottom
           div.pure-g.u-paddingBottom
             div.pure-u-1
-              label.form-label(for="id") Offender Identifier (Offender number or Booking ID)
+              label.form-label(for="id") Offender number or Booking ID
             div.pure-u-sm-5-12
               input.form-control(id="id" type="text" name="id")
             div.pure-u-sm-1-6.sm-PadLeftRight15

--- a/server/views/admin/licences/view.pug
+++ b/server/views/admin/licences/view.pug
@@ -7,3 +7,4 @@ block content
 
   h1.heading-large Licence details
   include ../../taskList/prisonerDetails
+  include ./activity

--- a/server/views/admin/locations/ldus.pug
+++ b/server/views/admin/locations/ldus.pug
@@ -20,7 +20,7 @@ block content
           each ldu, index in probationArea.ldus
             div.multiple-choice
               input(id=ldu.code type="checkbox" name=`activeLdus[${index}]` checked=ldu.active value=ldu.code)
-              label(for=ldu.code) #{ldu.description}
+              label(for=ldu.code) #{ldu.description} (#{ldu.code})
               
 
     if probationArea.ldus[0]

--- a/test/data/audit.test.js
+++ b/test/data/audit.test.js
@@ -34,6 +34,38 @@ describe('Audit', () => {
     })
   })
 
+  describe('getEventForBooking', () => {
+    beforeEach(() => {
+      db.query.mockResolvedValue({ rows: [{ id: 1 }] })
+    })
+
+    test('should make the query', async () => {
+      const result = await audit.getEventsForBooking(1)
+      expect(result).toEqual([{ id: 1 }])
+
+      const { values, text } = db.query.mock.calls[0][0]
+      expect(values).toEqual([1])
+      expect(text).toEqual(
+        `select id, "timestamp", "user", action, details from audit where details::jsonb ->> 'bookingId' = $1 order by timestamp desc;`
+      )
+    })
+  })
+
+  describe('getEvent', () => {
+    beforeEach(() => {
+      db.query.mockResolvedValue({ rows: [{ id: 1 }] })
+    })
+
+    test('should make the query', async () => {
+      const result = await audit.getEvent(1)
+      expect(result).toEqual({ id: 1 })
+
+      const { values, text } = db.query.mock.calls[0][0]
+      expect(values).toEqual([1])
+      expect(text).toEqual(`select id, "timestamp", "user", action, details from audit where id = $1;`)
+    })
+  })
+
   describe('getEvents', () => {
     beforeEach(() => {
       db.query.mockReturnValue([])

--- a/test/supertestSetup.js
+++ b/test/supertestSetup.js
@@ -217,7 +217,6 @@ const setup = {
     app.use(bodyParser.json())
     app.use(bodyParser.urlencoded({ extended: false }))
     app.use(prefix, route)
-
     return app
   },
 }


### PR DESCRIPTION
Adding new screen to allow admin staff to view the audit history of a licence
<kbd>
![Screenshot 2020-01-27 at 15 12 24](https://user-images.githubusercontent.com/1517745/73186339-73bc6080-4117-11ea-8805-2109ae97458c.png)
</kbd>
Clicking on timestamp also allows viewing raw audit events:
<kbd>![Screenshot 2020-01-27 at 15 13 47](https://user-images.githubusercontent.com/1517745/73186442-a23a3b80-4117-11ea-9b48-eb38bda02f01.png)
</kbd>