### PR TITLE
DCS-312 Fix issue around retrieving conditions 

### DIFF
--- a/licences-specs/src/test/resources/GebConfig.groovy
+++ b/licences-specs/src/test/resources/GebConfig.groovy
@@ -26,8 +26,8 @@ driver = {
   // System.setProperty('webdriver.chrome.driver', '/Applications/chromedriver')
   // System.setProperty('webdriver.chrome.driver', '/usr/local/bin/chromedriver')
   ChromeOptions options = new ChromeOptions()
-//  options.addArguments('headless')
-  options.addArguments('chrome')
+  options.addArguments('headless')
+//  options.addArguments('chrome')
   new ChromeDriver(options)
 }
 

--- a/licences-specs/src/test/resources/GebConfig.groovy
+++ b/licences-specs/src/test/resources/GebConfig.groovy
@@ -26,8 +26,8 @@ driver = {
   // System.setProperty('webdriver.chrome.driver', '/Applications/chromedriver')
   // System.setProperty('webdriver.chrome.driver', '/usr/local/bin/chromedriver')
   ChromeOptions options = new ChromeOptions()
-  options.addArguments('headless')
-//  options.addArguments('chrome')
+//  options.addArguments('headless')
+  options.addArguments('chrome')
   new ChromeDriver(options)
 }
 

--- a/server/services/conditionsService.js
+++ b/server/services/conditionsService.js
@@ -72,11 +72,7 @@ module.exports = function createConditionsService({ use2019Conditions }) {
   function populateLicenceWithConditions(licence, errors = {}, approvedOnly = false) {
     // could be undefined, 'No' or 'Yes'
     if (getIn(licence, ['licenceConditions', 'standard', 'additionalConditionsRequired']) !== 'Yes') {
-      return {
-        ...licence,
-        licenceConditions: [],
-        additionalConditionsJustification: '',
-      }
+      return licence
     }
 
     const licenceAdditionalConditions = getIn(licence, ['licenceConditions', 'additional'])
@@ -84,11 +80,7 @@ module.exports = function createConditionsService({ use2019Conditions }) {
     const conditionsOnLicence = !isEmpty(licenceAdditionalConditions) || bespokeConditions.length > 0
 
     if (!conditionsOnLicence) {
-      return {
-        ...licence,
-        licenceConditions: [],
-        additionalConditionsJustification: '',
-      }
+      return licence
     }
 
     const conditionIdsSelected = Object.keys(licenceAdditionalConditions)

--- a/test/services/conditionsService.test.js
+++ b/test/services/conditionsService.test.js
@@ -56,20 +56,25 @@ describe('conditionsService', () => {
         },
       }
 
-      return expect(service.populateLicenceWithConditions(licence)).toEqual(licence)
+      return expect(service.populateLicenceWithConditions(licence)).toEqual({
+        additionalConditionsJustification: '',
+        licenceConditions: [],
+      })
     })
 
     test('should return licence if no additional conditions', () => {
       const licence = { licenceConditions: {} }
 
       return expect(service.populateLicenceWithConditions(licence)).toEqual({
-        licenceConditions: {},
+        additionalConditionsJustification: '',
+        licenceConditions: [],
       })
     })
 
     test('should return licence with additional conditions', () => {
       const licence = {
         licenceConditions: {
+          standard: { additionalConditionsRequired: 'Yes' },
           additional: { ATTENDDEPENDENCY: { appointmentDate: '12/03/1985' } },
           conditionsSummary: { additionalConditionsJustification: 'Justification of additional conditions' },
         },
@@ -102,6 +107,7 @@ describe('conditionsService', () => {
     test('should return licence with bespoke conditions', () => {
       const licence = {
         licenceConditions: {
+          standard: { additionalConditionsRequired: 'Yes' },
           additional: {},
           bespoke: [{ text: 'approved text', approved: 'Yes' }, { text: 'unapproved text', approved: 'No' }],
         },
@@ -141,6 +147,7 @@ describe('conditionsService', () => {
     test('should return licence with only approved bespoke conditions', () => {
       const licence = {
         licenceConditions: {
+          standard: { additionalConditionsRequired: 'Yes' },
           additional: {},
           bespoke: [
             { text: 'approved text', approved: 'Yes' },
@@ -1090,7 +1097,9 @@ describe('conditionsService', () => {
 
     test('should always return standard conditions even for empty licence', () => {
       const licence = {
-        licenceConditions: {},
+        licenceConditions: {
+          standard: {},
+        },
       }
 
       return expect(service.getFullTextForApprovedConditions(licence)).toEqual({
@@ -1113,6 +1122,7 @@ describe('conditionsService', () => {
     test('should return additional conditions as text', () => {
       const licence = {
         licenceConditions: {
+          standard: { additionalConditionsRequired: 'Yes' },
           additional: { ATTENDDEPENDENCY: { appointmentDate: '12/03/1985' } },
         },
       }
@@ -1128,6 +1138,7 @@ describe('conditionsService', () => {
     test('should return only approved bespoke conditions', () => {
       const licence = {
         licenceConditions: {
+          standard: { additionalConditionsRequired: 'Yes' },
           additional: {},
           bespoke: [
             { text: 'approved text', approved: 'Yes' },

--- a/test/services/conditionsService.test.js
+++ b/test/services/conditionsService.test.js
@@ -56,19 +56,13 @@ describe('conditionsService', () => {
         },
       }
 
-      return expect(service.populateLicenceWithConditions(licence)).toEqual({
-        additionalConditionsJustification: '',
-        licenceConditions: [],
-      })
+      return expect(service.populateLicenceWithConditions(licence)).toEqual(licence)
     })
 
     test('should return licence if no additional conditions', () => {
       const licence = { licenceConditions: {} }
 
-      return expect(service.populateLicenceWithConditions(licence)).toEqual({
-        additionalConditionsJustification: '',
-        licenceConditions: [],
-      })
+      return expect(service.populateLicenceWithConditions(licence)).toEqual(licence)
     })
 
     test('should return licence with additional conditions', () => {


### PR DESCRIPTION
This bug occurs when attempting to create the Curfew Address Check Form (one of the tasks in the RO tasklist).
If, for example, a Proposed Curfew Address is rejected, then this bug occurs.