### PR TITLE
DCS-331 Adding ability for staff to trigger notifying an RO

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -85,6 +85,7 @@ module.exports = function createApp({
   caService,
   warningClient,
   lduService,
+  roNotificationHandler,
 }) {
   const app = express()
 
@@ -368,7 +369,10 @@ module.exports = function createApp({
     '/admin/licenceSearch/',
     secureRoute(licenceSearchRouter(licenceSearchService), { auditKey: 'LICENCE_SEARCH' })
   )
-  app.use('/admin/licences/', secureRoute(licenceRouter(licenceService, signInService, prisonerService, audit)))
+  app.use(
+    '/admin/licences/',
+    secureRoute(licenceRouter(licenceService, signInService, prisonerService, audit, roNotificationHandler))
+  )
 
   app.use('/hdc/contact/', secureRoute(contactRouter(userAdminService, roService)))
   app.use('/hdc/pdf/', secureRoute(pdfRouter({ pdfService, prisonerService }), { auditKey: 'CREATE_PDF' }))

--- a/server/index.js
+++ b/server/index.js
@@ -131,6 +131,7 @@ const app = createApp({
   caService,
   warningClient,
   lduService,
+  roNotificationHandler,
 })
 
 module.exports = app

--- a/server/routes/admin/licence.js
+++ b/server/routes/admin/licence.js
@@ -1,9 +1,11 @@
 const moment = require('moment')
 const setCase = require('case')
+const { unwrapResult, firstItem } = require('../../utils/functionalHelpers')
+const transitionsForDestinations = require('../../services/notifications/transitionsForDestinations')
 
 const { asyncMiddleware, authorisationMiddleware } = require('../../utils/middleware')
 
-module.exports = (licenceService, signInService, prisonerService, audit) => router => {
+module.exports = (licenceService, signInService, prisonerService, audit, roNotificationHandler) => router => {
   router.use(authorisationMiddleware)
 
   const formatEvent = event => ({
@@ -24,7 +26,14 @@ module.exports = (licenceService, signInService, prisonerService, audit) => rout
       const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
       const prisonerInfo = await prisonerService.getPrisonerDetails(bookingId, systemToken.token)
       const events = await audit.getEventsForBooking(bookingId)
-      return res.render('admin/licences/view', { bookingId, licence, prisonerInfo, events: events.map(formatEvent) })
+      const errors = firstItem(req.flash('errors')) || {}
+      return res.render('admin/licences/view', {
+        bookingId,
+        licence: licence || {},
+        prisonerInfo,
+        events: events.map(formatEvent),
+        errors,
+      })
     })
   )
 
@@ -34,6 +43,38 @@ module.exports = (licenceService, signInService, prisonerService, audit) => rout
       const { eventId } = req.params
       const event = await audit.getEvent(eventId)
       return res.render('admin/licences/event', { event: formatEvent(event) })
+    })
+  )
+
+  router.get(
+    '/:abookingId/notifyRo',
+    asyncMiddleware(async (req, res) => {
+      const { abookingId: bookingId } = req.params
+      const licence = await licenceService.getLicence(bookingId)
+      const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
+      const prisonerInfo = await prisonerService.getPrisonerDetails(bookingId, systemToken.token)
+      return res.render('admin/licences/notify', { bookingId, licence, prisonerInfo })
+    })
+  )
+
+  router.post(
+    '/:abookingId/notifyRo',
+    asyncMiddleware(async (req, res) => {
+      const { abookingId: bookingId } = req.params
+      const systemToken = await signInService.getClientCredentialsTokens(req.user.username)
+      const [_, error] = unwrapResult(
+        await roNotificationHandler.sendRoEmail({
+          transition: transitionsForDestinations.addressReview,
+          bookingId,
+          token: systemToken.token,
+          user: req.user,
+        })
+      )
+
+      if (error) {
+        req.flash('errors', { notifyError: error.message })
+      }
+      return res.redirect(`/admin/licences/${bookingId}`)
     })
   )
 

--- a/server/views/admin/licences/activity.pug
+++ b/server/views/admin/licences/activity.pug
@@ -54,16 +54,20 @@ mixin assignedTo(val)
 div.borderBottom.paddingBottom
   
   h2.heading-medium Activity
+  div.pure-g
+    div.pure-u-1.pure-u-md-1-2
+      p
+        span.bold Current stage:&nbsp;
+        span #{licence.stage}
+      p
+        span.bold Currently Assigned to:&nbsp;
+        span 
+          + assignedTo(licence.stage)
+    if licence && licence.stage === 'PROCESSING_RO'      
+      div.pure-u-1.pure-u-md-1-2
+        div.alignRight
+          a.button(href='/admin/licences/' + bookingId + '/notifyRo') Notify RO of case handover
 
-  p
-    span.bold Current stage:&nbsp;
-    span #{licence.stage}
-  p
-    span.bold Currently Assigned to:&nbsp;
-    span 
-      + assignedTo(licence.stage)
-    
-    
   table.largeMarginBottom
     thead
         tr

--- a/server/views/admin/licences/notify.pug
+++ b/server/views/admin/licences/notify.pug
@@ -1,0 +1,20 @@
+//- Read only licence view eg from caselist when case is with a different role
+extends ../../layout
+
+block content
+
+  include ../../includes/back
+
+  h1.heading-large Notify Responsible officer
+  include ../../taskList/prisonerDetails
+  div.borderBottom.paddingBottom
+    h2.heading-medium Notify
+    div
+      p Notify the RO that they have been sent the offender's case.
+      p Pressing the button below will send an email to 
+        a(href="/hdc/contact/" + bookingId) #{prisonerInfo.com.name}
+        |, their functional mailbox and the clearing office.
+      form(method='POST' action='/admin/licences/' + bookingId + '/notifyRo')
+        input(type="hidden" name="_csrf" value=csrfToken)
+        input.requiredButton.button(type="submit" value="Send emails")
+      

--- a/server/views/admin/licences/view.pug
+++ b/server/views/admin/licences/view.pug
@@ -1,9 +1,14 @@
 //- Read only licence view eg from caselist when case is with a different role
 extends ../../layout
+include ../../includes/errorBannerWithDetail
 
 block content
 
   include ../../includes/back
+
+  +errorBannerWithDetail(errors, [
+    { field: 'notifyError' },
+  ])
 
   h1.heading-large Licence details
   include ../../taskList/prisonerDetails

--- a/test/routes/admin/licence.test.js
+++ b/test/routes/admin/licence.test.js
@@ -12,6 +12,9 @@ const createAdminRoute = require('../../../server/routes/admin/licence')
 
 describe('/licences/', () => {
   let audit
+  let roNotificationHandler
+  const licenceService = createLicenceServiceStub()
+  const prisonerService = createPrisonerServiceStub()
 
   beforeEach(() => {
     audit = {
@@ -31,6 +34,9 @@ describe('/licences/', () => {
         details: { notifications: [{}, {}, {}], notificationType: 'RO_NEW' },
       }),
     }
+    roNotificationHandler = {
+      sendRoEmail: jest.fn(),
+    }
   })
 
   describe('GET licence', () => {
@@ -44,6 +50,19 @@ describe('/licences/', () => {
           expect(res.text).toContain('Licence details')
           expect(res.text).toContain(`3 notifications sent of type: 'RO_NEW'`)
           expect(res.text).toContain(`Provided details for 'aSection'`)
+          expect(res.text).not.toContain('Notify RO of case handover')
+        })
+    })
+
+    test('Renders notify button when assigned to RO', () => {
+      licenceService.getLicence.mockReturnValue({ stage: 'PROCESSING_RO' })
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/licences/1')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Notify RO of case handover')
         })
     })
 
@@ -77,12 +96,59 @@ describe('/licences/', () => {
     })
   })
 
+  describe('GET notify Ro', () => {
+    test('Renders HTML output', () => {
+      prisonerService.getPrisonerDetails.mockReturnValue({ com: { name: 'Bob' } })
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/licences/1/notifyRo')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Notify Responsible officer')
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app)
+        .get('/admin/licences/1/notifyRo')
+        .expect(403)
+    })
+  })
+
+  describe('POST notify Ro', () => {
+    test('Renders HTML output', () => {
+      prisonerService.getPrisonerDetails.mockReturnValue({ com: { name: 'Bob' } })
+      const app = createApp('batchUser')
+      return request(app)
+        .post('/admin/licences/1/notifyRo')
+        .expect(302)
+        .expect('Location', '/admin/licences/1')
+        .expect(res => {
+          expect(roNotificationHandler.sendRoEmail).toHaveBeenCalledWith({
+            bookingId: '1',
+            token: 'system-token',
+            transition: { notificationType: 'RO_NEW', receiver: 'RO', type: 'caToRo' },
+            user: { name: 'nb last', role: 'BATCHLOAD', token: 'token', username: 'NOMIS_BATCHLOAD' },
+          })
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app)
+        .post('/admin/licences/1/notifyRo')
+        .expect(403)
+    })
+  })
+
   function createApp(user) {
-    const prisonerService = createPrisonerServiceStub()
-    const licenceService = createLicenceServiceStub()
     const signInService = createSignInServiceStub()
     const baseRouter = standardRouter({ licenceService, prisonerService, audit, signInService })
-    const route = baseRouter(createAdminRoute(licenceService, signInService, prisonerService, audit))
+    const route = baseRouter(
+      createAdminRoute(licenceService, signInService, prisonerService, audit, roNotificationHandler)
+    )
     return appSetup(route, user, '/admin/licences')
   }
 })


### PR DESCRIPTION
When a licence is with an RO, this changes adds a new button to the licence view which will allow an admin staff to send the email notification to the RO, their team and the clearing house.

This will generate a notify event in the audit log against the admin staff member who triggered the request 