### PR TITLE
DCS-351 Relax restriction on contact page,

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -374,7 +374,7 @@ module.exports = function createApp({
     secureRoute(licenceRouter(licenceService, signInService, prisonerService, audit, roNotificationHandler))
   )
 
-  app.use('/hdc/contact/', secureRoute(contactRouter(userAdminService, roService)))
+  app.use('/hdc/contact/', secureRoute(contactRouter(userAdminService, roService, signInService)))
   app.use('/hdc/pdf/', secureRoute(pdfRouter({ pdfService, prisonerService }), { auditKey: 'CREATE_PDF' }))
   app.use('/hdc/forms/', secureRoute(formsRouter({ formService })))
   app.use('/hdc/send/', secureRoute(sendRouter({ prisonerService, notificationService })))

--- a/server/authentication/authInit.js
+++ b/server/authentication/authInit.js
@@ -27,7 +27,7 @@ module.exports = (userService, audit) => {
       const user = await getUser(accessToken, refreshToken, params.expires_in, params.user_name)
       return done(null, user)
     } catch (error) {
-      logger.error('Sign in error ', error.stack)
+      logger.error(`Sign in error for user: '${params.user_name}'`, error.stack)
       return done(null, false, { message: 'A system error occurred; please try again later' })
     }
   }

--- a/server/routes/contact.js
+++ b/server/routes/contact.js
@@ -11,13 +11,14 @@ const { unwrapResult } = require('../utils/functionalHelpers')
  * @param {RoService} roService
  * @returns {function(*): *}
  */
-module.exports = (userAdminService, roService) => router => {
+module.exports = (userAdminService, roService, signInService) => router => {
   router.get(
     '/:theBookingId',
     asyncMiddleware(async (req, res) => {
       // because 'bookingId' is treated specially - see standardRouter.js
       const { theBookingId } = req.params
-      const [ro] = unwrapResult(await roService.findResponsibleOfficer(theBookingId, res.locals.token))
+      const token = await signInService.getClientCredentialsTokens(req.user.username)
+      const [ro] = unwrapResult(await roService.findResponsibleOfficer(theBookingId, token.token))
 
       const contact = ro && ro.deliusId && (await userAdminService.getRoUserByDeliusId(ro.deliusId))
       if (contact) {

--- a/test/routes/contact.test.js
+++ b/test/routes/contact.test.js
@@ -16,6 +16,7 @@ let app
 describe('/contact', () => {
   let userAdminService
   let roService
+  let signInService
 
   beforeEach(() => {
     roService = {
@@ -52,7 +53,9 @@ describe('/contact', () => {
       getFunctionalMailbox: jest.fn().mockReturnValue('abc@def.com'),
     }
 
-    app = createApp({ userAdminService, roService }, 'caUser')
+    signInService = createSignInServiceStub()
+
+    app = createApp({ userAdminService, roService, signInService }, 'caUser')
   })
 
   describe('GET /contact/:bookingId', () => {
@@ -63,7 +66,7 @@ describe('/contact', () => {
         .expect('Content-Type', /html/)
         .expect(() => {
           expect(roService.findResponsibleOfficer).toHaveBeenCalled()
-          expect(roService.findResponsibleOfficer).toHaveBeenCalledWith('123456', 'token')
+          expect(roService.findResponsibleOfficer).toHaveBeenCalledWith('123456', 'system-token')
           expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalled()
           expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalledWith('DELIUS_ID')
           expect(userAdminService.getFunctionalMailbox).toHaveBeenCalledWith('PA_CODE', 'ABC123', 'TEAM_CODE')
@@ -121,13 +124,12 @@ describe('/contact', () => {
   })
 })
 
-function createApp({ userAdminService, roService }, user) {
+function createApp({ userAdminService, roService, signInService }, user) {
   const prisonerService = createPrisonerServiceStub()
   const licenceService = createLicenceServiceStub()
-  const signInService = createSignInServiceStub()
 
   const baseRouter = standardRouter({ licenceService, prisonerService, audit: auditStub, signInService })
-  const route = baseRouter(createContactRoute(userAdminService, roService))
+  const route = baseRouter(createContactRoute(userAdminService, roService, signInService))
 
   return appSetup(route, user, '/contact/')
 }

--- a/test/supertestSetup.js
+++ b/test/supertestSetup.js
@@ -217,6 +217,14 @@ const setup = {
     app.use(bodyParser.json())
     app.use(bodyParser.urlencoded({ extended: false }))
     app.use(prefix, route)
+    app.use((error, req, res, next) => {
+      if (error.status !== 403) {
+        // eslint-disable-next-line no-console
+        console.log('an error occurred:', error)
+      }
+      next(error)
+    })
+
     return app
   },
 }


### PR DESCRIPTION
 Previously the accessing user required access to the caselist associated with the booking to view the responsible RO. 

The only info we use from NOMIS in this call is to map from booking id to nomis id, no personal info. 
