### PR TITLE
DCS-348 Only process active reminders

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -153,7 +153,7 @@ module.exports = {
     clearingOfficeEmailEnabled: get('CLEARING_OFFICE_EMAIL_ENABLED', 'YES'),
     activeNotificationTypes: get(
       'NOTIFY_ACTIVE_TEMPLATES',
-      'CA_RETURN,CA_DECISION,RO_NEW,RO_TWO_DAYS,RO_DUE,RO_OVERDUE,DM_NEW, DM_TO_CA_RETURN'
+      'CA_RETURN,CA_DECISION,RO_NEW,RO_TWO_DAYS,RO_DUE,RO_OVERDUE,DM_NEW,DM_TO_CA_RETURN'
     ).split(','),
   },
 

--- a/server/index.js
+++ b/server/index.js
@@ -102,7 +102,8 @@ const reminderService = createReminderService(
   roContactDetailsService,
   prisonerService,
   deadlineService,
-  roNotificationSender
+  roNotificationSender,
+  config.notifications.activeNotificationTypes
 )
 const nomisPushService = createNomisPushService(nomisClientBuilder, signInService)
 const notificationJobs = createNotificationJobs(reminderService, signInService)

--- a/server/services/reminderService.js
+++ b/server/services/reminderService.js
@@ -16,12 +16,14 @@ const { NOTIFICATION_DATA_NOT_FOUND } = require('./serviceErrors')
  * @param {RoContactDetailsService} roContactDetailsService
  * @param {PrisonerService} prisonerService
  * @param {RoNotificationSender} roNotificationSender
+ * @param {string[]} activeNotificationTypes
  */
 module.exports = function createReminderService(
   roContactDetailsService,
   prisonerService,
   deadlineService,
-  roNotificationSender
+  roNotificationSender,
+  activeNotificationTypes
 ) {
   async function notifyRoReminders(token) {
     const overdue = await notifyCases(token, () => deadlineService.getOverdue('RO'), 'RO_OVERDUE')
@@ -33,6 +35,10 @@ module.exports = function createReminderService(
 
   async function notifyCases(token, caseFinderMethod, notificationType) {
     try {
+      if (!activeNotificationTypes.includes(notificationType)) {
+        logger.info(`notifying is disabled for notification type: ${notificationType}`)
+        return 0
+      }
       const cases = await caseFinderMethod()
       if (!isEmpty(cases)) {
         await sendReminders(token, cases, notificationType)

--- a/test/services/reminderService.test.js
+++ b/test/services/reminderService.test.js
@@ -31,10 +31,36 @@ describe('reminderService', () => {
       sendNotifications: jest.fn(),
     }
 
-    service = createReminderService(roContactDetailsService, prisonerService, deadlineService, roNotificationSender)
+    service = createReminderService(roContactDetailsService, prisonerService, deadlineService, roNotificationSender, [
+      'RO_OVERDUE',
+      'RO_DUE',
+      'RO_TWO_DAYS',
+    ])
   })
 
   describe('notifyRoReminders', () => {
+    test('should not send notifications if disabled', async () => {
+      service = createReminderService(
+        roContactDetailsService,
+        prisonerService,
+        deadlineService,
+        roNotificationSender,
+        []
+      )
+
+      const result = await service.notifyRoReminders('token')
+      expect(result).toEqual({ overdue: 0, due: 0, soon: 0 })
+    })
+
+    test('allows selective disabling of notifications', async () => {
+      service = createReminderService(roContactDetailsService, prisonerService, deadlineService, roNotificationSender, [
+        'RO_TWO_DAYS',
+      ])
+
+      const result = await service.notifyRoReminders('token')
+      expect(result).toEqual({ overdue: 0, due: 0, soon: 1 })
+    })
+
     test('should get notifiable booking IDs from deadline service', async () => {
       await service.notifyRoReminders('token')
       expect(deadlineService.getOverdue).toHaveBeenCalled()


### PR DESCRIPTION
At the moment a job runs at 1am in the morning and hammers the community-api and then doesn't actually do anything with the data for inactive notifications.

This change prevents the work being done entirely if a specific notification is disabled