### PR TITLE
DCS-360- error/warning messages no longer displayed in DM tasklist page

### DIFF
--- a/server/routes/curfew.js
+++ b/server/routes/curfew.js
@@ -122,8 +122,9 @@ module.exports = ({ licenceService, nomisPushService }) => (router, audited, { p
   function addressWithdrawalPosts(formName) {
     return async (req, res) => {
       const { action, bookingId } = req.params
-      const { licence, stage } = res.locals.licence
+      await licenceService.removeDecision(bookingId, res.locals.licence)
 
+      const { licence, stage } = await licenceService.getLicence(bookingId)
       await licenceService.rejectProposedAddress(licence, bookingId, formName)
 
       const modify = ['DECIDED', 'MODIFIED', 'MODIFIED_APPROVAL'].includes(stage)

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -528,6 +528,36 @@ describe('GET /taskList/:prisonNumber', () => {
             expect(res.text).toContain('/hdc/vary/evidence/')
           })
       })
+
+      test('should not contain "Home detention curfew refused" at head of page', () => {
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'dmUser'
+        )
+
+        return request(app)
+          .get('/taskList/123')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            expect(res.text).not.toContain('Home detention curfew refused')
+          })
+      })
+
+      test('should not contain " Address unsuitable" content in the final decision task', () => {
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'dmUser'
+        )
+
+        return request(app)
+          .get('/taskList/123')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            expect(res.text).not.toContain('Address unsuitable')
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
http://localhost:3000/hdc/taskList/{bookingId}

Changes made in server/routes/curfew.js . If a DM refuses a curfew address and hands the case back to the CA, the CA can withdraw the address and submit a new one.  When the CA hands back to the DM, a warning message displays unnecessarily  in the DM tasklist. To prevent the warnings from displaying, have removed the 'approval' object in the licence data in the DB because it holds details of the DM's previous decision. Achieved by executing licenceService.removeDecision(bookingId, res.locals.licence) in curfew.js
The licenceService.getLicence(bookingId)  is then executed so that subsequent code has  the updated version of the licence data.