### PR TITLE
DCS-360-DM no longer sees errors in tasklist

### DIFF
--- a/server/routes/viewModels/taskLists/dmTasks.js
+++ b/server/routes/viewModels/taskLists/dmTasks.js
@@ -213,7 +213,7 @@ function getDecisionLabel(licenceStatus) {
   } = licenceStatus
 
   if (refused && refusalReason) {
-    return `${statusLabel} : ${refusalReason}`
+    return `${statusLabel}`
   }
   return statusLabel
 }

--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -23,7 +23,7 @@ block content
   else if licenceStatus.decisions.unsuitableResult
     div.error-banner.marginTopMedium
       strong.bold The offender is presumed unsuitable for HDC release
-  else if licenceStatus.decisions.refused
+  else if user.role != 'DM' && licenceStatus.decisions.refused
     div.error-banner.marginTopMedium
       strong.bold Home detention curfew refused - #{licenceStatus.decisions.refusalReason}
   else if licenceStatus.decisions.optedOut

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -32,6 +32,20 @@ const prisonerInfoResponse = {
   },
 }
 
+const dmAddressRefusal = {
+  stage: 'DECIDED',
+  licence: {
+    approval: {
+      release: {
+        reason: 'addressUnsuitable',
+        decision: 'No',
+        decisionMaker: 'Diane Matthews',
+        reasonForDecision: '',
+      },
+    },
+  },
+}
+
 const licenceWithEligibilityComplete = {
   eligibility: {
     excluded: {
@@ -526,6 +540,38 @@ describe('GET /taskList/:prisonNumber', () => {
           .expect('Content-Type', /html/)
           .expect(res => {
             expect(res.text).toContain('/hdc/vary/evidence/')
+          })
+      })
+      test('should not contain "Home detention curfew refused" at head of page', () => {
+        licenceService.getLicence.mockResolvedValue(dmAddressRefusal)
+
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'dmUser'
+        )
+
+        return request(app)
+          .get('/taskList/123')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            expect(res.text).not.toContain('Home detention curfew refused')
+          })
+      })
+
+      test('should not contain "Address unsuitable" content in the final decision task', () => {
+        licenceService.getLicence.mockResolvedValue(dmAddressRefusal)
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'dmUser'
+        )
+
+        return request(app)
+          .get('/taskList/123')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            expect(res.text).not.toContain('Address unsuitable')
           })
       })
     })


### PR DESCRIPTION
http://localhost:3000/hdc/taskList/1200635

DM  tasklist displayed error messages  if DM had previously refused approval of the curfew address.
These error messages are not needed because the CA has now provided a new address for DM to consider so the approval process starts afresh