### PR TITLE
DCS-384 Fixing issue with bad request when getting sentences from elite

### DIFF
--- a/server/services/roService.js
+++ b/server/services/roService.js
@@ -61,8 +61,8 @@ module.exports = function createRoService(deliusClient, nomisClientBuilder) {
     async getROPrisoners(staffCode, token) {
       const nomisClient = nomisClientBuilder(token)
       const requiredPrisoners = await getROPrisonersFromDelius(staffCode)
-      if (!isEmpty(requiredPrisoners)) {
-        const requiredIDs = requiredPrisoners.map(prisoner => prisoner.nomsNumber)
+      const requiredIDs = requiredPrisoners.filter(prisoner => prisoner.nomsNumber).map(prisoner => prisoner.nomsNumber)
+      if (!isEmpty(requiredIDs)) {
         return nomisClient.getOffenderSentencesByNomisId(requiredIDs)
       }
 

--- a/test/data/nomisClient.test.js
+++ b/test/data/nomisClient.test.js
@@ -58,6 +58,14 @@ describe('nomisClient', () => {
     })
   })
 
+  describe('getOffenderSentencesByNomisId', () => {
+    test('should return data from api', () => {
+      fakeNomis.get(`/offender-sentences?offenderNo=1&offenderNo=2`).reply(200, [])
+
+      return expect(nomisClient.getOffenderSentencesByNomisId(['1', '2'])).resolves.toStrictEqual([])
+    })
+  })
+
   describe('getBookingByOffenderNumber', () => {
     test('should return data from api', () => {
       fakeNomis.get(`/bookings/offenderNo/ABC123D`).reply(200, { key: 'value' })

--- a/test/services/roService.test.js
+++ b/test/services/roService.test.js
@@ -77,8 +77,15 @@ describe('roService', () => {
       expect(nomisClient.getOffenderSentencesByNomisId).toHaveBeenCalledWith(['A', 'B', 'C'])
     })
 
-    test('should not call getOffenderSentencesByBookingId when no results from getROPrisoners', async () => {
+    test('should not call getOffenderSentencesByNomisId when no results from getROPrisoners', async () => {
       deliusClient.getROPrisoners.mockResolvedValue([])
+      await service.getROPrisoners(123, 'token')
+      expect(deliusClient.getROPrisoners).toHaveBeenCalled()
+      expect(nomisClient.getOffenderSentencesByNomisId).not.toHaveBeenCalled()
+    })
+
+    test('should not call getOffenderSentencesByNomisId when no offender numbers are returned from getROPrisoners', async () => {
+      deliusClient.getROPrisoners.mockResolvedValue([{}, {}, {}])
       await service.getROPrisoners(123, 'token')
       expect(deliusClient.getROPrisoners).toHaveBeenCalled()
       expect(nomisClient.getOffenderSentencesByNomisId).not.toHaveBeenCalled()


### PR DESCRIPTION
If we don't specify offender numbers when requesting sentences, elite throws a 400 bad request.
We had a guard to protect against this but it assumed that offender numbers would always be
present in delius for each prisoner and this is not always the case.

Offenders without offender numbers would be filtered out of the request but
If all prisoners did not have offender numbers then this would result in a 400

This fixes the guard to prevent this edgecase.