### PR TITLE
DCS-385 Adding batching of requests to when retrieving large numbers of sentences

### DIFF
--- a/azure/licences_log_queries.txt
+++ b/azure/licences_log_queries.txt
@@ -54,3 +54,86 @@ traces
 | where severityLevel  > 1 
 | project username=extract('Sign in error for user: \'(.*)\' Error: Login error - no acceptable role', 1, message)
 | distinct username
+
+// Prison to Prison
+customEvents
+| where cloud_RoleName == 'licences' 
+| where customDimensions.source_type == 'prison' and customDimensions.target_type == 'prison'
+| where name == 'CaseHandover'
+| project timestamp=format_datetime(timestamp, 'dd/MM/yyyy HH:mm') , bookingId=customDimensions.bookingId, source=customDimensions.source_agencyId, target=customDimensions.target_agencyId, type= customDimensions.transitionType
+| order by timestamp asc
+
+// Prison to Probation
+customEvents
+| where cloud_RoleName == 'licences' 
+| where customDimensions.source_type == 'prison' and customDimensions.target_type == 'probation'
+| where name == 'CaseHandover'
+| project timestamp=format_datetime(timestamp, 'dd/MM/yyyy HH:mm') , bookingId=customDimensions.bookingId, sourcePrison=customDimensions.source_agencyId, targetProbationArea=customDimensions.target_probationAreaCode, type= customDimensions.transitionType
+| order by timestamp asc
+
+
+// Probation area to prison area
+customEvents
+| where cloud_RoleName == 'licences' 
+| where customDimensions.source_type == 'probation' and customDimensions.target_type == 'prison'
+| where name == 'CaseHandover'
+| project timestamp=format_datetime(timestamp, 'dd/MM/yyyy HH:mm') , bookingId=customDimensions.bookingId, sourceProbationArea=customDimensions.source_probationAreaCode, sourceLdu=customDimensions.source_lduCode, targetPrison=customDimensions.target_agencyId,type= customDimensions.transitionType
+| order by timestamp asc
+
+
+// Prison sent/received
+let target_agencies = customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.target_type == 'prison'
+| summarize count() by agency = tostring(customDimensions.target_agencyId)
+| project agency, target=count_;
+
+let source_agencies = customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.source_type == 'prison'
+| summarize count() by agency = tostring(customDimensions.source_agencyId)
+| project agency, source=count_;
+
+target_agencies 
+| join kind=fullouter source_agencies on agency
+| project agency=coalesce(agency, agency1) , sent=source, received=target;
+
+// Probation areas sent/received
+let target = customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.target_type == 'probation'
+| summarize count() by ldu = tostring(strcat_delim(' - ', customDimensions.target_probationAreaCode, customDimensions.target_lduCode))
+| project ldu, target=count_;
+
+let source = customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.source_type == 'probation'
+| summarize count() by ldu = tostring(strcat_delim(' - ', customDimensions.source_probationAreaCode, customDimensions.source_lduCode))
+| project ldu, source=count_;
+
+target 
+| join kind=fullouter source on ldu
+| project ldu=coalesce(ldu, ldu1) , sent=source, received=target;
+
+// Prisons sent to the north west
+customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.source_type == 'prison'
+| where customDimensions.target_type == 'probation'
+| where customDimensions.target_probationAreaCode in ('N01', 'C02', 'C06', 'C07')
+| summarize count() by agency = tostring(customDimensions.source_agencyId)
+| project agency, count=count_;
+
+// LDUs sending cases in the north west
+customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.source_type == 'probation'
+| where customDimensions.source_probationAreaCode in ('N01', 'C02', 'C06', 'C07')
+| summarize count() by ldu = tostring(strcat_delim(' - ', customDimensions.source_probationAreaCode, customDimensions.source_lduCode))
+| project ldu, target=count_;

--- a/server/services/roService.js
+++ b/server/services/roService.js
@@ -62,11 +62,7 @@ module.exports = function createRoService(deliusClient, nomisClientBuilder) {
       const nomisClient = nomisClientBuilder(token)
       const requiredPrisoners = await getROPrisonersFromDelius(staffCode)
       const requiredIDs = requiredPrisoners.filter(prisoner => prisoner.nomsNumber).map(prisoner => prisoner.nomsNumber)
-      if (!isEmpty(requiredIDs)) {
-        return nomisClient.getOffenderSentencesByNomisId(requiredIDs)
-      }
-
-      return []
+      return nomisClient.getOffenderSentencesByNomisId(requiredIDs)
     },
 
     async findResponsibleOfficer(bookingId, token) {

--- a/server/utils/functionalHelpers.js
+++ b/server/utils/functionalHelpers.js
@@ -163,4 +163,5 @@ module.exports = {
   unwrapResultOrThrow,
   omit,
   sortKeys,
+  splitEvery: R.splitEvery,
 }

--- a/test/services/roService.test.js
+++ b/test/services/roService.test.js
@@ -81,14 +81,14 @@ describe('roService', () => {
       deliusClient.getROPrisoners.mockResolvedValue([])
       await service.getROPrisoners(123, 'token')
       expect(deliusClient.getROPrisoners).toHaveBeenCalled()
-      expect(nomisClient.getOffenderSentencesByNomisId).not.toHaveBeenCalled()
+      expect(nomisClient.getOffenderSentencesByNomisId).toHaveBeenCalled()
     })
 
     test('should not call getOffenderSentencesByNomisId when no offender numbers are returned from getROPrisoners', async () => {
       deliusClient.getROPrisoners.mockResolvedValue([{}, {}, {}])
       await service.getROPrisoners(123, 'token')
       expect(deliusClient.getROPrisoners).toHaveBeenCalled()
-      expect(nomisClient.getOffenderSentencesByNomisId).not.toHaveBeenCalled()
+      expect(nomisClient.getOffenderSentencesByNomisId).toHaveBeenCalledWith([])
     })
 
     test('should return empty array and explanation message if no eligible releases found', async () => {


### PR DESCRIPTION
NOMIS returns a 400 "Header too large" response when ROs are assigned a large list of offenders. This is due to coercing a large list of nomis ids into a very long query string.

ROs generally shouldn't be assigned large lists of offenders but it seems a small number of LDUs have strange ways of working and do end up in this state.

We could have potentially added a POST endpoint to handle lots of offender Nos but this seemed a bit overkill for such a small edge case.  