### PR TITLE
DCS-364 Filtering out dodgy probation areas 

### DIFF
--- a/server/data/deliusClient.js
+++ b/server/data/deliusClient.js
@@ -46,7 +46,7 @@ module.exports = signInService => {
     },
 
     getAllProbationAreas() {
-      return get(`${apiUrl}/probationAreas`)
+      return get(`${apiUrl}/probationAreas?excludeEstablishments=true&active=true`)
     },
 
     getAllLdusForProbationArea(probationAreaCode) {

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -29,7 +29,7 @@ module.exports = ({ userService }) => router => {
         await userService.setActiveCaseLoad(caseLoadId, req.user, res.locals.token)
       }
 
-      res.redirect('/user')
+      res.redirect('/')
     })
   )
 

--- a/test/data/deliusClient.test.js
+++ b/test/data/deliusClient.test.js
@@ -99,7 +99,9 @@ describe('deliusClient', () => {
 
   describe('getAllProbationAreas', () => {
     test('should return list of all probation areas', () => {
-      fakeDelius.get(`/probationAreas`).reply(200, [{ code: 'some code', description: 'some description' }])
+      fakeDelius
+        .get(`/probationAreas?excludeEstablishments=true&active=true`)
+        .reply(200, [{ code: 'some code', description: 'some description' }])
 
       return expect(deliusClient.getAllProbationAreas()).resolves.toStrictEqual([
         { code: 'some code', description: 'some description' },

--- a/test/routes/user.test.js
+++ b/test/routes/user.test.js
@@ -157,7 +157,7 @@ describe('/user', () => {
         .post('/')
         .send({ role: 'RO' })
         .expect(302)
-        .expect('Location', '/user')
+        .expect('Location', '/')
     })
   })
 


### PR DESCRIPTION
Adding filtering to probation areas to exclude inactive areas or areas which represent prisons. 

Also removing super annoying bug, which only really affect internal staff (but affects them all the time, even if they are aware of it) 

Whenever you change role you get redirected to the same screen with no visual indicator, so users just wait as they think nothings happened. 
Now redirecting the `/` as users won't want to do additional changes on the `/user` page. 
