### PR TITLE
DCS-256 Fix bug where DM incorrectly sees rejected address task list

### DIFF
--- a/azure/licences_log_queries.txt
+++ b/azure/licences_log_queries.txt
@@ -8,7 +8,6 @@ traces
 | sort by Blocked asc
 
 // Blocked bookings - Staff not allocated
-
 traces
 | where cloud_RoleName == "licences"
 | where message startswith "Blocking case for booking:"
@@ -137,3 +136,25 @@ customEvents
 | where customDimensions.source_probationAreaCode in ('N01', 'C02', 'C06', 'C07')
 | summarize count() by ldu = tostring(strcat_delim(' - ', customDimensions.source_probationAreaCode, customDimensions.source_lduCode))
 | project ldu, target=count_;
+
+// New LDUS this week:
+let lastweek = customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.target_type == 'probation'
+| where customDimensions.target_probationAreaCode in ('N01', 'C02', 'C06', 'C07', 'N24')
+| where timestamp > startofday(datetime("2020-02-24")) and timestamp < endofday(datetime("2020-02-28"))
+| summarize count() by ldu = tostring(strcat_delim(' - ', customDimensions.target_probationAreaCode, customDimensions.target_lduCode))
+| project ldu, target=count_;
+
+let thisweek = customEvents
+| where cloud_RoleName == 'licences' 
+| where name == 'CaseHandover'
+| where customDimensions.target_type == 'probation'
+| where customDimensions.target_probationAreaCode in ('N01', 'C02', 'C06', 'C07', 'N24')
+| where timestamp > startofday(datetime("2020-03-02"))
+| summarize count() by ldu = tostring(strcat_delim(' - ', customDimensions.target_probationAreaCode, customDimensions.target_lduCode))
+| project ldu, target=count_;
+
+
+lastweek | join kind=rightanti thisweek on ldu;

--- a/server/routes/viewModels/taskLists/dmTasks.js
+++ b/server/routes/viewModels/taskLists/dmTasks.js
@@ -67,6 +67,7 @@ module.exports = licenceStatus => {
     decisions: {
       addressWithdrawn,
       approvedPremisesRequired,
+      bassAccepted,
       bassReferralNeeded,
       confiscationOrder,
       curfewAddressRejected,
@@ -89,7 +90,7 @@ module.exports = licenceStatus => {
     ]
   }
 
-  if (addressWithdrawn || curfewAddressRejected) {
+  if (bassAccepted !== 'Yes' && (addressWithdrawn || curfewAddressRejected)) {
     return rejectedAddressTaskList(licenceStatus)
   }
 

--- a/test/routes/viewModels/taskLists/dmTasks.test.js
+++ b/test/routes/viewModels/taskLists/dmTasks.test.js
@@ -1,0 +1,109 @@
+const dmTasks = require('../../../../server/routes/viewModels/taskLists/dmTasks.js')
+
+describe('dmTasks', () => {
+  const tasks = {}
+
+  describe('rejected task list', () => {
+    test('withdrawn address shows rejected list', () => {
+      const results = dmTasks({ tasks, decisions: { addressWithdrawn: true, bassAccepted: 'No' } })
+
+      expect(results.map(({ task, title }) => task || title)).toStrictEqual([
+        'eligibilitySummaryTask',
+        'Proposed curfew address',
+        'Return to prison case admin',
+        'Final decision',
+      ])
+    })
+
+    test('rejected curfew address shows rejected list with risk management', () => {
+      const results = dmTasks({ tasks, decisions: { curfewAddressRejected: true } })
+
+      expect(results.map(({ task, title }) => task || title)).toStrictEqual([
+        'eligibilitySummaryTask',
+        'Proposed curfew address',
+        'Risk management',
+        'Return to prison case admin',
+        'Final decision',
+      ])
+    })
+  })
+
+  describe('standard task list', () => {
+    test('default list', () => {
+      const results = dmTasks({
+        tasks,
+        decisions: {},
+      })
+
+      expect(results.map(({ task, title }) => task || title)).toStrictEqual([
+        'Proposed curfew address',
+        'Risk management',
+        'Victim liaison',
+        'Curfew hours',
+        'Additional conditions',
+        'Reporting instructions',
+        'Review case',
+        'Return to prison case admin',
+        'Final decision',
+      ])
+    })
+
+    test('Accepted BASS address', () => {
+      const results = dmTasks({
+        tasks,
+        decisions: { bassReferralNeeded: true, bassAccepted: 'Yes' },
+      })
+
+      expect(results.map(({ task, title }) => task || title)).toStrictEqual([
+        'BASS address',
+        'Risk management',
+        'Victim liaison',
+        'Curfew hours',
+        'Additional conditions',
+        'Reporting instructions',
+        'Review case',
+        'Return to prison case admin',
+        'Final decision',
+      ])
+    })
+
+    test('Confiscation order', () => {
+      const results = dmTasks({
+        tasks,
+        decisions: { confiscationOrder: true },
+      })
+
+      expect(results.map(({ task, title }) => task || title)).toStrictEqual([
+        'Proposed curfew address',
+        'Risk management',
+        'Victim liaison',
+        'Curfew hours',
+        'Additional conditions',
+        'Reporting instructions',
+        'Review case',
+        'Postpone',
+        'Return to prison case admin',
+        'Final decision',
+      ])
+    })
+
+    test('previously rejected address with bass accepted', () => {
+      const results = dmTasks({
+        tasks,
+        decisions: { curfewAddressRejected: true, bassReferralNeeded: true, bassAccepted: 'Yes' },
+      })
+
+      expect(results.map(({ task, title }) => task || title)).toStrictEqual([
+        'BASS address',
+        'Risk management',
+        'Victim liaison',
+        'Curfew hours',
+        'Additional conditions',
+        'Reporting instructions',
+        'Review case',
+        'Return to prison case admin',
+        'Final decision',
+      ])
+    })
+  })
+})


### PR DESCRIPTION
The Decision manager was presented the rejected list when an address is rejected and an offender goes on to have a BASS address accepted.
This is because we don't track decisions associated with an address and BASS and normal addresses are just stored as different parts of the JSON payload.
We can't prioritise decisons made associated with one type of address over the other.

This tweaks how we determine which task list to present.

This is merely the whacking one mole... we have some ideas of how to fix the root cause but this is just a sticking plaster.