### PR TITLE
DCS-395 Adding staff code to ro details

### DIFF
--- a/server/views/contact/deliusRo.pug
+++ b/server/views/contact/deliusRo.pug
@@ -17,6 +17,9 @@ block content
             div.pure-u-1-3.sm-midPaddingBottom Name
             div.pure-u-2-3.bold #{ro.name}
 
+            div.pure-u-1-3.sm-midPaddingBottom Staff code
+            div.pure-u-2-3.bold #{ro.deliusId}
+
             div.pure-u-1-3.sm-midPaddingBottom Local Delivery Unit
             div.pure-u-2-3.bold #{ro.lduDescription} (#{ro.lduCode})
 

--- a/test/routes/contact.test.js
+++ b/test/routes/contact.test.js
@@ -81,6 +81,7 @@ describe('/contact', () => {
           expect(res.text).toContain('ABC123')
           expect(res.text).toContain('LDU Description')
           expect(res.text).toContain('Ro Name')
+          expect(res.text).toContain('DELIUS_ID')
           expect(res.text).toContain('PA Description')
           expect(res.text).toContain('PA_CODE')
           expect(res.text).toContain('abc@def.com')


### PR DESCRIPTION
This is to aid debug issues around roll out where we seem to have duplicate staff records.