### PR TITLE
DCS-240 - the RO tasklist page displays Forms link

### DIFF
--- a/server/routes/config/authorisation.js
+++ b/server/routes/config/authorisation.js
@@ -12,7 +12,7 @@ module.exports = {
     authorised: [{ role: 'RO' }],
   },
   '/hdc/forms/': {
-    authorised: [{ role: 'CA' }],
+    authorised: [{ role: 'CA' }, { role: 'RO' }],
   },
   '/hdc/proposedAddress/curfewAddressChoice/': {
     authorised: [{ role: 'CA' }, { role: 'RO', stage: ['VARY'] }],

--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -12,7 +12,7 @@ include ./includes/utils
 
 block content
 
-  if user.role === 'CA' && licenceVersion !== 0
+  if licenceVersion !== 0 && (user.role === 'RO' || user.role === 'CA')
     include ../includes/back-caselist-and-forms
   else
     include ../includes/backToCaseList

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -574,6 +574,20 @@ describe('GET /taskList/:prisonNumber', () => {
             expect(res.text).not.toContain('Address unsuitable')
           })
       })
+
+      test('should display the Forms link', () => {
+        const app = createApp(
+          { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+          'roUser'
+        )
+        return request(app)
+          .get('/taskList/123')
+          .expect(200)
+          .expect('Content-Type', /html/)
+          .expect(res => {
+            expect(res.text).toContain('Forms')
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
http://localhost:3000/hdc/taskList/{bookng id}

The Forms link was previously only displayed to CA's.
The link is also now presented to RO's beccause they need access to the forms.