### PR TITLE
DCS-322 RO can modify licence when case is currently with CA

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/TaskListGuardSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/TaskListGuardSpec.groovy
@@ -1,0 +1,106 @@
+package uk.gov.justice.digital.hmpps.licences.specs
+
+import geb.spock.GebReportingSpec
+import spock.lang.Shared
+import spock.lang.Stepwise
+import spock.lang.Unroll
+import uk.gov.justice.digital.hmpps.licences.pages.CaselistPage
+import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
+import uk.gov.justice.digital.hmpps.licences.pages.review.ReviewLicencePage
+import uk.gov.justice.digital.hmpps.licences.util.Actions
+import uk.gov.justice.digital.hmpps.licences.util.TestData
+
+@Stepwise
+class TaskListGuardSpec extends GebReportingSpec {
+
+  @Shared
+  TestData testData = new TestData()
+
+  @Shared
+  Actions actions = new Actions()
+
+  def cleanup() {
+    actions.logOut()
+  }
+
+  @Unroll
+  def 'Case not started. #role views taskList'() {
+    given: 'Case not started. User logged in.'
+    testData.deleteLicences()
+    actions.logIn(role)
+
+    when: 'I view the taskList page'
+    via TaskListPage, testData.markAndrewsBookingId
+
+    then: 'Should be on #expectedPage'
+    at expectedPage
+
+    where:
+    role || expectedPage
+    'CA' || TaskListPage
+    'RO' || CaselistPage
+    'DM' || CaselistPage
+  }
+
+  @Unroll
+  def 'Case data is #licenceDataFilename. #role views taskList'() {
+    given:
+    testData.loadLicence(licenceDataFilename)
+    actions.logIn(role)
+
+    when: 'I view the taskList page'
+    via TaskListPage, testData.markAndrewsBookingId
+
+    then: 'Should be on #expectedPage'
+    at expectedPage
+
+    where:
+    role | licenceDataFilename              || expectedPage
+    'CA' | 'eligibility/unstarted'          || TaskListPage
+    'RO' | 'eligibility/unstarted'          || CaselistPage
+    'DM' | 'eligibility/unstarted'          || CaselistPage
+
+    'CA' | 'assessment/unstarted'           || ReviewLicencePage
+    'RO' | 'assessment/unstarted'           || TaskListPage
+    'DM' | 'assessment/unstarted'           || CaselistPage
+
+    'CA' | 'review/normal'                  || TaskListPage
+    'RO' | 'review/normal'                  || ReviewLicencePage
+    'DM' | 'review/normal'                  || CaselistPage
+
+    'CA' | 'finalchecks/unstarted'          || TaskListPage
+    'RO' | 'finalchecks/unstarted'          || ReviewLicencePage
+    'DM' | 'finalchecks/unstarted'          || CaselistPage
+
+    'CA' | 'decision/unstarted'             || ReviewLicencePage
+    'RO' | 'decision/unstarted'             || ReviewLicencePage
+    'DM' | 'decision/unstarted'             || TaskListPage
+
+    'CA' | 'decision/approved'              || TaskListPage
+    'RO' | 'decision/approved'              || ReviewLicencePage
+    'DM' | 'decision/approved'              || ReviewLicencePage
+
+    'CA' | 'postDecision/address-withdrawn' || TaskListPage
+    'RO' | 'postDecision/address-withdrawn' || ReviewLicencePage
+    'DM' | 'postDecision/address-withdrawn' || ReviewLicencePage
+  }
+
+  @Unroll
+  def 'Offender released. #role views taskList'() {
+    given:
+    testData.deleteLicences()
+    actions.logIn(role)
+
+    when: 'I view the taskList page for bookingId 2 (a released offender)'
+    via TaskListPage, 2
+
+    then: 'Should be on #expectedPage'
+    at expectedPage
+
+    where:
+    role || expectedPage
+    'CA' || CaselistPage
+    'RO' || TaskListPage
+    'DM' || CaselistPage
+  }
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/eligibility/EligibilityTaskListSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/eligibility/EligibilityTaskListSpec.groovy
@@ -29,6 +29,9 @@ class EligibilityTaskListSpec extends GebReportingSpec {
 
   def 'Shows details of the prisoner (from nomis)'() {
 
+    given: 'No licences'
+    testData.deleteLicences()
+
     when: 'I view the task list page'
     to TaskListPage, testData.markAndrewsBookingId
 

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/pdf/PdfSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/pdf/PdfSpec.groovy
@@ -6,6 +6,7 @@ import spock.lang.Stepwise
 import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
 import uk.gov.justice.digital.hmpps.licences.pages.pdf.LicenceTaskListPage
 import uk.gov.justice.digital.hmpps.licences.pages.pdf.LicenceTemplatePage
+import uk.gov.justice.digital.hmpps.licences.pages.review.ReviewLicencePage
 import uk.gov.justice.digital.hmpps.licences.util.Actions
 import uk.gov.justice.digital.hmpps.licences.util.TestData
 
@@ -32,10 +33,12 @@ class PdfSpec extends GebReportingSpec {
 
     when: 'I log in and view the tasklist'
     actions.logIn(user)
-    to TaskListPage, testData.markAndrewsBookingId
+    via TaskListPage, testData.markAndrewsBookingId
+    at ReviewLicencePage
 
     then: 'There is no option to create PDF'
-    !taskListAction('Create licence').isDisplayed()
+    at ReviewLicencePage
+
     actions.logOut()
 
     where:

--- a/server/authentication/signInService.js
+++ b/server/authentication/signInService.js
@@ -11,7 +11,7 @@ const timeoutSpec = {
 }
 
 const signInService = () => {
-  const getRefreshTokens = async (username, role, refreshToken, service) => {
+  const getRefreshTokens = async (refreshToken, service) => {
     const oauthClientToken = generateOauthClientToken()
     const oauthRequest = { grant_type: 'refresh_token', refresh_token: refreshToken }
 
@@ -22,12 +22,7 @@ const signInService = () => {
     async getRefreshedToken(user, service = 'nomis') {
       logger.info(`Refreshing token for : ${user.username}`)
 
-      const { token, refreshToken, expiresIn } = await getRefreshTokens(
-        user.username,
-        user.role,
-        user.refreshToken,
-        service
-      )
+      const { token, refreshToken, expiresIn } = await getRefreshTokens(user.refreshToken, service)
 
       const refreshTime = fiveMinutesBefore(expiresIn)
 

--- a/server/services/prisonerService.js
+++ b/server/services/prisonerService.js
@@ -83,8 +83,8 @@ function createPrisonerService(nomisClientBuilder, roService) {
           return getIn(release, ['fromAgency'])
         }
 
-        const locationId =
-          prisoner.agencyLocationId === 'OUT' ? await getReleaseEstablishment() : prisoner.agencyLocationId
+        const postRelease = prisoner.agencyLocationId ? prisoner.agencyLocationId.toUpperCase() === 'OUT' : false
+        const locationId = postRelease ? await getReleaseEstablishment() : prisoner.agencyLocationId
 
         return this.getEstablishment(locationId, token)
       } catch (error) {

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -33,7 +33,7 @@ const prisonerInfoResponse = {
 }
 
 const dmAddressRefusal = {
-  stage: 'DECIDED',
+  stage: 'APPROVAL',
   licence: {
     approval: {
       release: {
@@ -491,7 +491,7 @@ describe('GET /taskList/:prisonNumber', () => {
 
   describe('User is RO', () => {
     test('should pass the client credential token not the user one', () => {
-      licenceService.getLicence.mockResolvedValue({ stage: 'ELIGIBILITY', licence: {} })
+      licenceService.getLicence.mockResolvedValue({ stage: 'PROCESSING_RO', licence: {} })
       const app = createApp(
         { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
         'roUser'
@@ -542,6 +542,7 @@ describe('GET /taskList/:prisonNumber', () => {
             expect(res.text).toContain('/hdc/vary/evidence/')
           })
       })
+
       test('should not contain "Home detention curfew refused" at head of page', () => {
         licenceService.getLicence.mockResolvedValue(dmAddressRefusal)
 

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -577,6 +577,7 @@ describe('GET /taskList/:prisonNumber', () => {
       })
 
       test('should display the Forms link', () => {
+        licenceService.getLicence.mockResolvedValue({ stage: 'PROCESSING_RO', licence: {} })
         const app = createApp(
           { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
           'roUser'


### PR DESCRIPTION
Add a 'guard' to the taskList route handler. This checks the user's role, the case's stage and whether the offender has been released.  The outcome decides whether the user is shown the taskList, a read-only version of the task list or is redirected to the case list.