### PR TITLE
DCS-322 Give RO, CA, DM appropriate views on an offender's tasklist.

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/TaskListGuardSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/TaskListGuardSpec.groovy
@@ -38,7 +38,7 @@ class TaskListGuardSpec extends GebReportingSpec {
     where:
     role || expectedPage
     'CA' || TaskListPage
-    'RO' || CaselistPage
+    'RO' || TaskListPage
     'DM' || CaselistPage
   }
 
@@ -57,7 +57,7 @@ class TaskListGuardSpec extends GebReportingSpec {
     where:
     role | licenceDataFilename              || expectedPage
     'CA' | 'eligibility/unstarted'          || TaskListPage
-    'RO' | 'eligibility/unstarted'          || CaselistPage
+    'RO' | 'eligibility/unstarted'          || ReviewLicencePage
     'DM' | 'eligibility/unstarted'          || CaselistPage
 
     'CA' | 'assessment/unstarted'           || ReviewLicencePage

--- a/server/routes/taskList.js
+++ b/server/routes/taskList.js
@@ -43,6 +43,7 @@ const determineAccessLevel = (licence, postRelease, role) => {
 
     case 'CA':
       if (isEmpty(licence)) return READ_WRITE
+
       switch (stage) {
         case ELIGIBILITY:
         case PROCESSING_CA:
@@ -56,11 +57,13 @@ const determineAccessLevel = (licence, postRelease, role) => {
       }
 
     case 'RO':
-      if (isEmpty(licence)) return NONE
+      if (isEmpty(licence)) return READ_WRITE
+
       switch (stage) {
         case PROCESSING_RO:
           return READ_WRITE
 
+        case ELIGIBILITY:
         case PROCESSING_CA:
         case APPROVAL:
         case DECIDED:


### PR DESCRIPTION
Refinement: Give RO READ_WRITE for an un-started case and READ_ONLY for a case at the ELIGIBILITY stage.