### PR TITLE
DCS-224 Fix first night curfew hours.

### DIFF
--- a/server/routes/pdf.js
+++ b/server/routes/pdf.js
@@ -86,13 +86,15 @@ module.exports = ({ pdfService, prisonerService }) => (router, audited) => {
         prisonerService.getPrisonerPersonalDetails(bookingId, token),
         pdfService.getPdfLicenceData(bookingId, licence, token),
       ])
+
       const postRelease = prisoner.agencyLocationId ? prisoner.agencyLocationId.toUpperCase() === 'OUT' : false
 
-      const incompleteGroupsVary = Object.keys(missing).filter(group => missing[group].mandatoryPostRelease)
-      const incompleteGroupsMandatory = Object.keys(missing).filter(group => missing[group].mandatory)
-      const incompleteGroups = postRelease
-        ? incompleteGroupsVary.concat(incompleteGroupsMandatory)
-        : incompleteGroupsMandatory
+      const incompleteGroupsFilter = postRelease
+        ? group => missing[group].mandatory || missing[group].mandatoryPostRelease
+        : group => missing[group].mandatory || missing[group].mandatoryPreRelease
+
+      const incompleteGroups = Object.keys(missing).filter(incompleteGroupsFilter)
+
       const incompletePreferredGroups = Object.keys(missing).filter(group => missing[group].preferred)
 
       const canPrint = !incompleteGroups || isEmpty(incompleteGroups)

--- a/server/services/config/pdfData.js
+++ b/server/services/config/pdfData.js
@@ -180,13 +180,13 @@ const CURFEW_FIRST_FROM = {
   paths: [['licence', 'curfew', 'firstNight', 'firstNightFrom']],
   displayName: 'Curfew first night from',
   group: 'firstNight',
-  required: 'optional',
+  required: 'mandatoryPreRelease',
 }
 const CURFEW_FIRST_UNTIL = {
   paths: [['licence', 'curfew', 'firstNight', 'firstNightUntil']],
   displayName: 'Curfew first night until',
   group: 'firstNight',
-  required: 'optional',
+  required: 'mandatoryPreRelease',
 }
 const CURFEW_MON_FROM = {
   paths: [['licence', 'curfew', 'curfewHours', 'mondayFrom']],

--- a/server/views/licences/vary_hdc_pss.pug
+++ b/server/views/licences/vary_hdc_pss.pug
@@ -34,8 +34,6 @@ block content
 
     +curfewAddress(CURFEW_ADDRESS, '6')
 
-    //+firstDayCurfew(CURFEW_FIRST_FROM, CURFEW_FIRST_UNTIL)
-
     include includes/curfewTimes
 
     +curfewConditions()

--- a/test/routes/pdf.test.js
+++ b/test/routes/pdf.test.js
@@ -18,10 +18,19 @@ const valuesWithMissing = {
     OFF_NAME: 'FIRST LAST',
   },
   missing: {
-    firstNight: { mandatory: { CURFEW_FIRST_FROM: 'Curfew first night from' } },
+    firstNight: { mandatoryPreRelease: { CURFEW_FIRST_FROM: 'Curfew first night from' } },
     reporting: { mandatory: { REPORTING_AT: 'reporting date' } },
     sentence: { mandatory: { OFF_NOMS: 'noms id' } },
     varyApproval: { mandatoryPostRelease: { VARY_APPROVER: 'Name of approver' } },
+  },
+}
+
+const valuesWithCurfewFirstNightMissing = {
+  values: {
+    OFF_NAME: 'FIRST LAST',
+  },
+  missing: {
+    firstNight: { mandatoryPreRelease: { CURFEW_FIRST_FROM: 'Curfew first night from' } },
   },
 }
 
@@ -177,6 +186,25 @@ describe('PDF:', () => {
         .expect('Content-Type', /html/)
         .expect(res => {
           expect(res.text).not.toContain('Ready to create')
+          expect(pdfServiceStub.getPdfLicenceData).toHaveBeenCalled()
+          expect(pdfServiceStub.getPdfLicenceData).toHaveBeenCalledWith(
+            '1233',
+            { licence: { key: 'value', document: { template: { decision: 'hdc_ap_pss' } } } },
+            'token'
+          )
+        })
+    })
+
+    test('Allows print when missing values  are pre-release only for vary', () => {
+      prisonerServiceStub.getPrisonerPersonalDetails.mockResolvedValue({ agencyLocationId: 'OUT' })
+      pdfServiceStub.getPdfLicenceData.mockResolvedValue(valuesWithCurfewFirstNightMissing)
+
+      return request(app)
+        .get('/hdc/pdf/taskList/1233')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Ready to print')
           expect(pdfServiceStub.getPdfLicenceData).toHaveBeenCalled()
           expect(pdfServiceStub.getPdfLicenceData).toHaveBeenCalledWith(
             '1233',

--- a/test/services/utils/pdfFormatter.test.js
+++ b/test/services/utils/pdfFormatter.test.js
@@ -531,7 +531,7 @@ const displayNames = {
     },
   },
   firstNight: {
-    optional: {
+    mandatoryPreRelease: {
       CURFEW_FIRST_FROM: 'Curfew first night from',
       CURFEW_FIRST_UNTIL: 'Curfew first night until',
     },


### PR DESCRIPTION
Was surprisingly simple in the end.
More or less reverted a change that Yasin made a long time ago, but classified the first-night config data  in pdfData.js as `mandatoryPreRelease` and tweaked a bit of filtering in pdfFormatter.js
Using the `mandatoryPreRelease` value means that the first-night values can be excluded from the list of mandatory values for 'vary' cases (post release), which in turn means that when those values are missing they don't prevent creating a PDF licence.
Also tweaked some code in the process of trying to work out how it works.  No idea if its any easier to comprehend, but I understand it better now.