### PR TITLE
DCS-271: New navigation buttons

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,3 +10,4 @@ jsconfig.json
 tsconfig.json
 *.md
 licences-specs/src/test/resources/licences/
+.project

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/SendApprovalPage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/SendApprovalPage.groovy
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.licences.pages
+
+import geb.Page
+import uk.gov.justice.digital.hmpps.licences.modules.HeaderModule
+import uk.gov.justice.digital.hmpps.licences.modules.SubmissionTargetModule
+
+class SendApprovalPage extends Page {
+
+  static url = '/hdc/send/approval'
+
+  static at = {
+    browser.currentUrl.contains(url)
+  }
+
+  static content = {
+    backToPrint {$('#backToPrint')}
+  }
+
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/pdf/LicenceTaskListPage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/pdf/LicenceTaskListPage.groovy
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.licences.pages.pdf
 
 import geb.Page
-import geb.module.Select
+import geb.module.RadioButtons
 
 class LicenceTaskListPage extends Page {
 
@@ -12,6 +12,8 @@ class LicenceTaskListPage extends Page {
   }
 
   static content = {
-
+    backToDm {$('#backToDm')}
   }
 }
+
+

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/pdf/PdfSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/pdf/PdfSpec.groovy
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
 import uk.gov.justice.digital.hmpps.licences.pages.pdf.LicenceTaskListPage
 import uk.gov.justice.digital.hmpps.licences.pages.pdf.LicenceTemplatePage
 import uk.gov.justice.digital.hmpps.licences.pages.review.ReviewLicencePage
+import uk.gov.justice.digital.hmpps.licences.pages.SendApprovalPage
 import uk.gov.justice.digital.hmpps.licences.util.Actions
 import uk.gov.justice.digital.hmpps.licences.util.TestData
 
@@ -103,5 +104,26 @@ class PdfSpec extends GebReportingSpec {
 
     then: 'Reporting and tagging company details are not complete'
     !driver.getPageSource().contains('Not complete')
+  }
+
+  def 'Resubmit to DM button navigates to /hdc/send/approval and Return to print navigates back to tasklist page'() {
+
+    given: 'An approved licence'
+    testData.loadLicence('decision/approved')
+
+    when: 'I am at the pdf tasklist page'
+    to LicenceTaskListPage, testData.markAndrewsBookingId
+
+    then: 'I select the Resubmit to DM button'
+    backToDm.click()
+
+    and: 'I will be at the hdc/send/approval page '
+    at SendApprovalPage
+
+    when: 'I select the Return to printing licence button'
+    backToPrint.click()
+
+    then: 'I am back at the /hdc/pdf/tasklist page'
+    at LicenceTaskListPage
   }
 }

--- a/licences-specs/src/test/resources/licences/decision/approved.json
+++ b/licences-specs/src/test/resources/licences/decision/approved.json
@@ -122,6 +122,12 @@
         "decision": "No"
       }
     },
+    "document": {
+      "template": {
+        "decision": "hdc_ap",
+        "offenceCommittedBeforeFeb2015": "No"
+      }
+    },
     "approval": {
       "release": {
         "decision": "Yes"

--- a/server/routes/pdf.js
+++ b/server/routes/pdf.js
@@ -109,6 +109,7 @@ module.exports = ({ pdfService, prisonerService }) => (router, audited) => {
         canPrint,
         postRelease,
         versionInfo: versionInfo(licence),
+        reSubmitToDm: licence.stage === 'DECIDED' || licence.stage === 'MODIFIED',
       })
     })
   )

--- a/server/routes/send.js
+++ b/server/routes/send.js
@@ -11,6 +11,7 @@ const transitionsForDestinations = require('../services/notifications/transition
  */
 module.exports = ({ prisonerService, notificationService }) => router => {
   router.get('/:destination/:bookingId', async (req, res) => {
+    const { licence } = res.locals
     const { destination, bookingId } = req.params
     const transition = transitionsForDestinations[destination]
     const submissionTarget = await prisonerService.getOrganisationContactDetails(
@@ -19,7 +20,13 @@ module.exports = ({ prisonerService, notificationService }) => router => {
       res.locals.token
     )
 
-    res.render(`send/${transition.type}`, { bookingId, submissionTarget })
+    let reReferralToDm = false
+
+    if (transition.type === 'caToDm' && (licence.stage === 'DECIDED' || licence.stage === 'MODIFIED')) {
+      reReferralToDm = true
+    }
+
+    res.render(`send/${transition.type}`, { bookingId, submissionTarget, reReferralToDm })
   })
 
   router.post(

--- a/server/views/includes/backToDm.pug
+++ b/server/views/includes/backToDm.pug
@@ -1,0 +1,5 @@
+div.paddingBottom.smallPaddingTop
+  div.pure-u-1.inlineButtons
+    p.lede Resubmit back to DM if a reconsideration is required
+    a#backToDm.requiredButton.button.button-secondary.smallMarginTop(href="/hdc/send/approval/"+ bookingId role="button" name='backToDm') Resubmit to DM
+

--- a/server/views/pdf/createLicenceTaskList.pug
+++ b/server/views/pdf/createLicenceTaskList.pug
@@ -33,4 +33,6 @@ block content
     div.paddingTop
       include ../includes/caseListReturn
 
-
+    if reSubmitToDm
+      div.paddingTop
+       include ../includes/backToDm

--- a/server/views/send/includes/sendButtons.pug
+++ b/server/views/send/includes/sendButtons.pug
@@ -1,3 +1,6 @@
 div.pure-u-1.inlineButtons.paddingBottom
   input#continueBtn.requiredButton.button.button-start.midMarginBottom(type="submit" value="Submit")
-  a#backBtn.requiredButton.button.button-secondary.button-start-height(href="/hdc/taskList/" + bookingId role="button") Return to task list
+  if reReferralToDm
+    a#backToPrint.requiredButton.button.button-secondary.button-start-height(href="/hdc/pdf/taskList/" + bookingId role="button") Return to printing licence
+  else 
+    a#backBtn.requiredButton.button.button-secondary.button-start-height(href="/hdc/taskList/" + bookingId role="button") Return to task list

--- a/test/routes/pdf.test.js
+++ b/test/routes/pdf.test.js
@@ -177,6 +177,95 @@ describe('PDF:', () => {
         })
     })
 
+    test('Shows Resubmit to DM button when stage is DECIDED', () => {
+      prisonerServiceStub.getPrisonerPersonalDetails.mockResolvedValue({})
+      pdfServiceStub.getPdfLicenceData.mockResolvedValue(valuesWithoutMissing)
+
+      const licenceData = {
+        document: {
+          template: {
+            decision: 'hdc_ap',
+            offenceCommittedBeforeFeb2015: 'No',
+          },
+        },
+      }
+
+      licenceServiceStub.getLicence.mockResolvedValue({
+        versionDetails: { version: 1 },
+        approvedVersionDetails: { template: 'hdc_ap' },
+        stage: 'DECIDED',
+        licence: licenceData,
+      })
+
+      return request(app)
+        .get('/hdc/pdf/taskList/1232')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Resubmit to DM')
+          expect(res.text).toContain('Resubmit back to DM if a reconsideration is required')
+        })
+    })
+    test('Shows Resubmit to DM button when stage is MODIFIED', () => {
+      prisonerServiceStub.getPrisonerPersonalDetails.mockResolvedValue({})
+      pdfServiceStub.getPdfLicenceData.mockResolvedValue(valuesWithoutMissing)
+
+      const licenceData = {
+        document: {
+          template: {
+            decision: 'hdc_ap',
+            offenceCommittedBeforeFeb2015: 'No',
+          },
+        },
+      }
+
+      licenceServiceStub.getLicence.mockResolvedValue({
+        versionDetails: { version: 1 },
+        approvedVersionDetails: { template: 'hdc_ap' },
+        stage: 'MODIFIED',
+        licence: licenceData,
+      })
+
+      return request(app)
+        .get('/hdc/pdf/taskList/1232')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).toContain('Resubmit to DM')
+          expect(res.text).toContain('Resubmit back to DM if a reconsideration is required')
+        })
+    })
+
+    test('Does NOT show Resubmit to DM button when stage is anything other than MODFIED or DECIDED', () => {
+      prisonerServiceStub.getPrisonerPersonalDetails.mockResolvedValue({})
+      pdfServiceStub.getPdfLicenceData.mockResolvedValue(valuesWithoutMissing)
+
+      const licenceData = {
+        document: {
+          template: {
+            decision: 'hdc_ap',
+            offenceCommittedBeforeFeb2015: 'No',
+          },
+        },
+      }
+
+      licenceServiceStub.getLicence.mockResolvedValue({
+        versionDetails: { version: 1 },
+        approvedVersionDetails: { template: 'hdc_ap' },
+        stage: 'APPROVAL',
+        licence: licenceData,
+      })
+
+      return request(app)
+        .get('/hdc/pdf/taskList/1232')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(res => {
+          expect(res.text).not.toContain('Resubmit to DM')
+          expect(res.text).not.toContain('Resubmit back to DM if a reconsideration is required')
+        })
+    })
+
     test('Does not allow print when missing values', () => {
       pdfServiceStub.getPdfLicenceData.mockResolvedValue(valuesWithMissing)
 


### PR DESCRIPTION
http://localhost:3000/hdc/pdf/taskList/{bookingId}
http://localhost:3000/hdc/send/approval/{bookingId}
CA can now hand-off case back to DM even though the DM has previously APPROVED the release. The re-referral is required in light iof new information.
It is assumed the CA and DM have already discussed the case and have agreed the need for the re-referral.
The new navigation buttons appear in /hdc/pdf/taskList/ and /hdc/send/approval/ but only if the case stage is DECIDED or MODIFIED