### PR TITLE
DCS-432 Fixing application start up issue by enabling SSL for knex migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,9 +149,6 @@ jobs:
           name: Wait for node app to start
           command: sleep 5
       - run:
-          name: Initialise db
-          command: npm run db:knex-migrate up
-      - run:
           name: Seed db
           command: npm run db:seed
       - restore_cache:

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const config = require('./server/config')
 
 module.exports = {
@@ -8,7 +9,13 @@ module.exports = {
     user: config.db.username,
     password: config.db.password,
     database: config.db.database,
-    ssl: config.db.sslEnabled === 'true',
+    ssl:
+      config.db.sslEnabled === 'true'
+        ? {
+            ca: fs.readFileSync('root.cert'),
+            rejectUnauthorized: true,
+          }
+        : false,
   },
   acquireConnectionTimeout: 5000,
 


### PR DESCRIPTION
Knex was relying on not verifying certificates, which was the default behaviour in node-pg < 8.0.0.

Now enabling verifying connection and making root cert available for this purpose