### PR TITLE
DCS-432 Remove duplicate logging and fix meta logging

### DIFF
--- a/log.js
+++ b/log.js
@@ -1,6 +1,5 @@
-// eslint-disable-next-line import/order
 const appInsights = require('./azure-appinsights')
-const { AzureApplicationInsightsLogger } = require('winston-azure-application-insights')
+// eslint-disable-next-line import/order
 const winston = require('winston')
 
 const { combine, colorize, simple, timestamp, json, prettyPrint } = winston.format
@@ -34,15 +33,7 @@ const logger = winston.createLogger({
 })
 
 if (appInsights) {
-  logger.info('Activating application insights logger')
-
-  logger.add(
-    new AzureApplicationInsightsLogger({
-      insights: appInsights,
-      level: 'info',
-      sendErrorsAsExceptions: true,
-    })
-  )
+  logger.info('Application insights logger is active')
 }
 
 module.exports = logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -14701,23 +14701,6 @@
         }
       }
     },
-    "winston-azure-application-insights": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/winston-azure-application-insights/-/winston-azure-application-insights-2.0.0.tgz",
-      "integrity": "sha512-baLc4dDcwivB8oXI61d2Bpnjysj8Eu8inrU4uppIS46lS4D3hezHWc7BBMxH2hsiqud3M21p4xqkH9QCXPSCqA==",
-      "requires": {
-        "winston-transport": "^4.2.0"
-      }
-    },
-    "winston-transport": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
-      "integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
-      "requires": {
-        "readable-stream": "^2.3.6",
-        "triple-beam": "^1.2.0"
-      }
-    },
     "with": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -134,8 +134,7 @@
     "swagger-ui-express": "^4.1.4",
     "util": "^0.12.2",
     "uuid": "^7.0.3",
-    "winston": "^3.2.1",
-    "winston-azure-application-insights": "^2.0.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@types/jest": "^25.2.1",

--- a/server/misc.js
+++ b/server/misc.js
@@ -11,14 +11,20 @@ function flattenObject(source, target, prefix) {
   })
 }
 
-exports.flattenMeta = function flattenMeta(meta) {
+exports.flattenMeta = function flattenMeta(...meta) {
   const flat = {}
-  Object.keys(meta || {}).forEach((key) => {
-    const val = meta[key]
-    if (val && typeof val === 'object') {
-      flattenObject(val, flat, key)
+  meta.forEach((item, i) => {
+    if (typeof item === 'object') {
+      Object.entries(item || {}).forEach(([prop, val]) => {
+        const key = meta.length === 1 ? prop : `${i}_${prop}`
+        if (val && typeof val === 'object') {
+          flattenObject(val, flat, key)
+        } else {
+          flat[key] = val
+        }
+      })
     } else {
-      flat[key] = val
+      flat[i] = item
     }
   })
   return flat

--- a/test/misc.test.js
+++ b/test/misc.test.js
@@ -35,5 +35,21 @@ describe('misc', () => {
     test('copes with nulls', () => {
       expect(flattenMeta(null)).toEqual({})
     })
+
+    test('copes with string', () => {
+      expect(flattenMeta('some vile thing')).toEqual({ '0': 'some vile thing' })
+    })
+
+    test('copes with strings', () => {
+      expect(flattenMeta('some vile thing', 'another one!')).toEqual({ '0': 'some vile thing', '1': 'another one!' })
+    })
+
+    test('copes with arrays', () => {
+      expect(flattenMeta([1, 2, 3])).toEqual({ '0': 1, '1': 2, '2': 3 })
+    })
+
+    test('copes with arrays of objects', () => {
+      expect(flattenMeta([{ name: 'bob' }, { name: 'jim' }])).toEqual({ '0_name': 'bob', '1_name': 'jim' })
+    })
   })
 })


### PR DESCRIPTION
Application insights automatically instruments winston now, meaning we don't need additional dependency.

Also fixing issue where passing a string as a meta item broke logging

The signature of a log method (info, warn, error, etc..) is:  `(message: string, meta: any[]) => {}`

The current flatten meta doesn't cope with more than one meta item or items of types other than `object`.

If passed a string as a second arg, for instance in the case:
```
      logger.warn(
        `Error calling delius, path: '${path}', verb: 'GET', response: '${getIn(error, ['response', 'text'])}'`,
        error.stack
      )
```
Then it would map the string, e.g: `str = 'abc'`, result = `{'0': 'a', '1': 'b', '2': 'c'}`

Now if one or more strings are passed:
`logger.info('A message', 'a', 'is', 'here' )`

It will create a flattened object of:
```js
{
 '0': 'a',
 '1': 'is',
 '2': 'nice',
}
```

If a single object is passed then it will add keys to the top level.
`logger.info('A message', {a: {is: 'nice'}})`

It will create a flattened object of:
```js
{
 'a_is': 'nice',
}
```

If multiple objects are passed then it will add keys to the top level.
`logger.info('A message', {a: {is: 'nice'}}, {a: {is: 'nice'}}, {b: {is: 'nice'}})`

It will create a flattened object of:
```
{
 '0_a_is': 'nice',
 '1_a_is': 'nice',
 '2_b_is': 'nice',
}
```

Also added tests to cover top level arrays.


