### PR TITLE
DCS-391 Showing 'inform offender task' when made ineligible in post approval

### DIFF
--- a/server/routes/viewModels/taskLists/caTasks.js
+++ b/server/routes/viewModels/taskLists/caTasks.js
@@ -20,7 +20,6 @@ const resubmitToDm = require('./tasks/ca/resubmitToDm')
 const caBlocked = (errorCode) => () => ({ task: 'caBlockedTask', errorCode })
 const eligibilityTask = namedTask('eligibilityTask')
 const eligibilitySummaryTask = namedTask('eligibilitySummaryTask')
-const invisibleInformOffenderTask = namedTask('informOffenderTask')
 
 module.exports = {
   getTasksForBlocked: (errorCode) => tasklist({}, [[eligibilityTask], [informOffenderTask], [caBlocked(errorCode)]]),
@@ -126,7 +125,7 @@ module.exports = {
     const context = { decisions, tasks, stage, allowedTransition }
 
     if (!eligible) {
-      return tasklist(context, [[eligibilitySummaryTask, validAddress], [invisibleInformOffenderTask]])
+      return tasklist(context, [[eligibilitySummaryTask, validAddress], [informOffenderTask]])
     }
 
     return tasklist(context, [

--- a/server/routes/viewModels/taskLists/tasks/ca/informOffenderTask.js
+++ b/server/routes/viewModels/taskLists/tasks/ca/informOffenderTask.js
@@ -1,6 +1,6 @@
 module.exports = () => ({
   title: 'Inform the offender',
-  label: 'You should now tell the offender using the relevant HDC form from NOMIS',
+  label: 'You should now tell the offender using the relevant HDC form',
   action: {
     type: 'btn-secondary',
     href: '/caseList/active',

--- a/test/routes/viewModels/taskListModelsCA.test.js
+++ b/test/routes/viewModels/taskListModelsCA.test.js
@@ -9,10 +9,9 @@ describe('TaskList models', () => {
       text: 'Back to case list',
       type: 'btn-secondary',
     },
-    label: 'You should now tell the offender using the relevant HDC form from NOMIS',
+    label: 'You should now tell the offender using the relevant HDC form',
     title: 'Inform the offender',
   }
-  const informOffenderStandard = { task: 'informOffenderTask', visible: undefined }
 
   const curfewAddress = {
     action: {
@@ -781,7 +780,7 @@ describe('TaskList models', () => {
           },
           {}
         )
-      ).toEqual([eligibilitySummary, informOffenderStandard])
+      ).toEqual([eligibilitySummary, informOffender])
     })
 
     test('should send for refusal if no approved address and no new one added', () => {


### PR DESCRIPTION
Also fixing wording - the forms are now held in the service so don't need to use nomis