### PR TITLE
DCS-411: changes to HDC refusal message

### DIFF
--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -23,12 +23,9 @@ block content
   else if licenceStatus.decisions.unsuitableResult
     div.error-banner.marginTopMedium
       strong.bold The offender is presumed unsuitable for HDC release
-  else if user.role === 'CA' && licenceStatus.decisions.caRefused && licenceStatus.decisions.refusalReason
+  else if user.role === 'CA' && licenceStatus.decisions.caRefused
     div.error-banner.marginTopMedium
-      strong.bold Home detention curfew refused by prison case admin: #{licenceStatus.decisions.refusalReason}
-  else if user.role === 'CA' && licenceStatus.decisions.caRefused && !licenceStatus.decisions.refusalReason
-    div.error-banner.marginTopMedium
-      strong.bold Home detention curfew refused by prison case admin
+      strong.bold Home detention curfew refused by prison case admin#{licenceStatus.decisions.refusalReason ?': ' + licenceStatus.decisions.refusalReason : ''}
   else if user.role === 'CA' && licenceStatus.decisions.refused && licenceStatus.decisions.decisionComments
     div.error-banner.marginTopMedium
       details.govuk-details.alignLeft(data-module="govuk-details")

--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -23,9 +23,12 @@ block content
   else if licenceStatus.decisions.unsuitableResult
     div.error-banner.marginTopMedium
       strong.bold The offender is presumed unsuitable for HDC release
-  else if user.role === 'CA' && licenceStatus.decisions.caRefused
+  else if user.role === 'CA' && licenceStatus.decisions.caRefused && licenceStatus.decisions.refusalReason
     div.error-banner.marginTopMedium
       strong.bold Home detention curfew refused by prison case admin: #{licenceStatus.decisions.refusalReason}
+  else if user.role === 'CA' && licenceStatus.decisions.caRefused && !licenceStatus.decisions.refusalReason
+    div.error-banner.marginTopMedium
+      strong.bold Home detention curfew refused by prison case admin
   else if user.role === 'CA' && licenceStatus.decisions.refused && licenceStatus.decisions.decisionComments
     div.error-banner.marginTopMedium
       details.govuk-details.alignLeft(data-module="govuk-details")

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -60,7 +60,7 @@ const dmHasProvidedHdcDecisionComments = {
   },
 }
 
-const caHasRefusedHdc = {
+const caHasRefusedHdcButNotProvidedReason = {
   stage: 'DECIDED',
   licence: {
     approval: {
@@ -71,6 +71,23 @@ const caHasRefusedHdc = {
     finalChecks: {
       refusal: {
         decision: 'Yes',
+      },
+    },
+  },
+}
+
+const caHasRefusedHdcAndProvidedReason = {
+  stage: 'DECIDED',
+  licence: {
+    approval: {
+      release: {
+        decision: 'Yes',
+      },
+    },
+    finalChecks: {
+      refusal: {
+        decision: 'Yes',
+        reason: 'addressUnsuitable',
       },
     },
   },
@@ -353,8 +370,8 @@ describe('GET /taskList/:prisonNumber', () => {
         })
     })
 
-    test('should contain "Home detention curfew refused by prison case administrator" ', () => {
-      licenceService.getLicence.mockResolvedValue(caHasRefusedHdc)
+    test('should contain "Home detention curfew refused by prison case admin" ', () => {
+      licenceService.getLicence.mockResolvedValue(caHasRefusedHdcButNotProvidedReason)
 
       const app = createApp(
         { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
@@ -367,6 +384,24 @@ describe('GET /taskList/:prisonNumber', () => {
         .expect('Content-Type', /html/)
         .expect((res) => {
           expect(res.text).toContain('Home detention curfew refused by prison case admin')
+          expect(res.text).not.toContain('case admin:')
+        })
+    })
+
+    test('should contain "Home detention curfew refused by prison case admin: No available address" ', () => {
+      licenceService.getLicence.mockResolvedValue(caHasRefusedHdcAndProvidedReason)
+
+      const app = createApp(
+        { licenceServiceStub: licenceService, prisonerServiceStub: prisonerService, caServiceStub: caService },
+        'caUser'
+      )
+
+      return request(app)
+        .get('/taskList/123')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain('Home detention curfew refused by prison case admin: No available address')
         })
     })
 


### PR DESCRIPTION
This is temporary fix for a bug. There may be occasions when a CA only partly completes the HDC refusal task. In these cases the message will display a colon but with nothing to its right hand side. Fix implemented to remove the colon if the CA does not provide a corresponding refusal reason .