### PR TITLE
DCS-253 Bug fix

### DIFF
--- a/server/data/deliusClient.ts
+++ b/server/data/deliusClient.ts
@@ -124,7 +124,7 @@ export const createDeliusClient = (signInService): DeliusClient => {
         if (error.status === NOT_FOUND) {
           return { content: [] }
         }
-        logger.error(`deliusClient.getAllLdusForProbationArea(${probationAreaCode})`, error.stack)
+        logger.error(`deliusClient.getAllTeamsForLdu(${probationAreaCode}, ${lduCode})`, error.stack)
         throw error
       }
     },

--- a/server/data/deliusClient.ts
+++ b/server/data/deliusClient.ts
@@ -113,12 +113,18 @@ export const createDeliusClient = (signInService): DeliusClient => {
 
     async getAllTeamsForLdu(probationAreaCode, lduCode) {
       try {
-        return await get(`${apiUrl}/probationAreas/code/${probationAreaCode}/localDeliveryUnits/code/${lduCode}/teams`)
+        const body = await get(
+          `${apiUrl}/probationAreas/code/${probationAreaCode}/localDeliveryUnits/code/${lduCode}/teams`
+        )
+        if (body && body.content) {
+          return body
+        }
+        return { content: [] }
       } catch (error) {
         if (error.status === NOT_FOUND) {
           return { content: [] }
         }
-        logger.error(`deliusClient.getAllTeamsForLdu(${probationAreaCode}, ${lduCode})`, error.stack)
+        logger.error(`deliusClient.getAllLdusForProbationArea(${probationAreaCode})`, error.stack)
         throw error
       }
     },

--- a/server/services/functionalMailboxService.ts
+++ b/server/services/functionalMailboxService.ts
@@ -63,7 +63,7 @@ export class FunctionalMailboxService {
   }
 
   getLdusForProbationArea = async (probationAreaCode): Promise<LduMap> => {
-    const [{ content: ldus = [] } = {}, { localDeliveryUnits = {} } = {}] = await Promise.all([
+    const [{ content: ldus }, { localDeliveryUnits = {} } = {}] = await Promise.all([
       this.deliusClient.getAllLdusForProbationArea(probationAreaCode),
       this.probationTeamsClient.getProbationArea(probationAreaCode),
     ])
@@ -72,11 +72,7 @@ export class FunctionalMailboxService {
   }
 
   getLduWithProbationTeams = async ({ probationAreaCode, lduCode }): Promise<LduWithTeams> => {
-    const [
-      { content: ldus = [] } = {},
-      { content: probationTeams = [] } = {},
-      localDeliveryUnitDto,
-    ] = await Promise.all([
+    const [{ content: ldus }, { content: probationTeams }, localDeliveryUnitDto] = await Promise.all([
       this.deliusClient.getAllLdusForProbationArea(probationAreaCode),
       this.deliusClient.getAllTeamsForLdu(probationAreaCode, lduCode),
       this.probationTeamsClient.getLduWithProbationTeams({ probationAreaCode, lduCode }),

--- a/server/services/functionalMailboxService.ts
+++ b/server/services/functionalMailboxService.ts
@@ -55,7 +55,7 @@ export class FunctionalMailboxService {
   ) {}
 
   getAllProbationAreas = async () => {
-    const [{ content: probationAreas = [] } = {}, probationAreaCodes = []] = await Promise.all([
+    const [{ content: probationAreas } = { content: [] }, probationAreaCodes = []] = await Promise.all([
       this.deliusClient.getAllProbationAreas(),
       this.probationTeamsClient.getProbationAreaCodes(),
     ])
@@ -63,7 +63,7 @@ export class FunctionalMailboxService {
   }
 
   getLdusForProbationArea = async (probationAreaCode): Promise<LduMap> => {
-    const [{ content: ldus }, { localDeliveryUnits = {} } = {}] = await Promise.all([
+    const [{ content: ldus = [] } = {}, { localDeliveryUnits = {} } = {}] = await Promise.all([
       this.deliusClient.getAllLdusForProbationArea(probationAreaCode),
       this.probationTeamsClient.getProbationArea(probationAreaCode),
     ])
@@ -72,7 +72,11 @@ export class FunctionalMailboxService {
   }
 
   getLduWithProbationTeams = async ({ probationAreaCode, lduCode }): Promise<LduWithTeams> => {
-    const [{ content: ldus }, { content: probationTeams }, localDeliveryUnitDto] = await Promise.all([
+    const [
+      { content: ldus = [] } = {},
+      { content: probationTeams = [] } = {},
+      localDeliveryUnitDto,
+    ] = await Promise.all([
       this.deliusClient.getAllLdusForProbationArea(probationAreaCode),
       this.deliusClient.getAllTeamsForLdu(probationAreaCode, lduCode),
       this.probationTeamsClient.getLduWithProbationTeams({ probationAreaCode, lduCode }),

--- a/test/data/deliusClient.test.js
+++ b/test/data/deliusClient.test.js
@@ -126,7 +126,28 @@ describe('deliusClient', () => {
       })
     })
 
-    test('LDU not known to Delius', () => {
+    test('LDU not known to Delius: 200, but no "content" field', () => {
+      fakeDelius.get('/probationAreas/code/N02/localDeliveryUnits/code/LDU/teams').reply(200, {
+        pageable: 'INSTANCE',
+        totalElements: 0,
+        last: true,
+        totalPages: 1,
+        sort: {
+          sorted: false,
+          unsorted: true,
+          empty: true,
+        },
+        first: true,
+        number: 0,
+        size: 0,
+        numberOfElements: 0,
+        empty: true,
+      })
+
+      return expect(deliusClient.getAllTeamsForLdu('N02', 'LDU')).resolves.toStrictEqual({ content: [] })
+    })
+
+    test('LDU not known to Delius: 404', () => {
       fakeDelius.get('/probationAreas/code/N02/localDeliveryUnits/code/LDU/teams').reply(404)
 
       return expect(deliusClient.getAllTeamsForLdu('N02', 'LDU')).resolves.toStrictEqual({ content: [] })

--- a/test/services/functionalMailboxService.test.ts
+++ b/test/services/functionalMailboxService.test.ts
@@ -196,7 +196,7 @@ describe('FunctionalMailboxService', () => {
       })
 
       it('Handles missing data', async () => {
-        deliusClient.getAllLdusForProbationArea.mockResolvedValue({ content: [] })
+        deliusClient.getAllLdusForProbationArea.mockResolvedValue(undefined)
         probationTeamsClient.getProbationArea.mockResolvedValue(undefined)
 
         expect(await functionalMailboxService.getLdusForProbationArea('PA')).toEqual({})
@@ -256,6 +256,23 @@ describe('FunctionalMailboxService', () => {
       })
 
       it('No data', async () => {
+        deliusClient.getAllLdusForProbationArea.mockResolvedValue({ content: undefined })
+        deliusClient.getAllTeamsForLdu.mockResolvedValue({ content: undefined })
+        probationTeamsClient.getLduWithProbationTeams.mockResolvedValue(undefined)
+
+        expect(
+          await functionalMailboxService.getLduWithProbationTeams({
+            probationAreaCode: 'PA',
+            lduCode: 'B',
+          })
+        ).toEqual({
+          description: '',
+          functionalMailbox: '',
+          probationTeams: {},
+        })
+      })
+
+      it('Not found', async () => {
         deliusClient.getAllLdusForProbationArea.mockResolvedValue({ content: [] })
         deliusClient.getAllTeamsForLdu.mockResolvedValue({ content: [] })
         probationTeamsClient.getLduWithProbationTeams.mockResolvedValue(undefined)

--- a/test/services/functionalMailboxService.test.ts
+++ b/test/services/functionalMailboxService.test.ts
@@ -196,7 +196,7 @@ describe('FunctionalMailboxService', () => {
       })
 
       it('Handles missing data', async () => {
-        deliusClient.getAllLdusForProbationArea.mockResolvedValue(undefined)
+        deliusClient.getAllLdusForProbationArea.mockResolvedValue({ content: [] })
         probationTeamsClient.getProbationArea.mockResolvedValue(undefined)
 
         expect(await functionalMailboxService.getLdusForProbationArea('PA')).toEqual({})
@@ -256,8 +256,8 @@ describe('FunctionalMailboxService', () => {
       })
 
       it('No data', async () => {
-        deliusClient.getAllLdusForProbationArea.mockResolvedValue({ content: undefined })
-        deliusClient.getAllTeamsForLdu.mockResolvedValue({ content: undefined })
+        deliusClient.getAllLdusForProbationArea.mockResolvedValue({ content: [] })
+        deliusClient.getAllTeamsForLdu.mockResolvedValue({ content: [] })
         probationTeamsClient.getLduWithProbationTeams.mockResolvedValue(undefined)
 
         expect(


### PR DESCRIPTION
A community API request for probation teams can return one of:
- A 200 response and a JSON body containing an object having a "content" field that is an array of result objects
- A 200 response and a JSON body containing an object that does not have a "content" field
- A 404 response

Requests for LDUs return either
- A 200 response and a JSON body containing an object having a "content" field that is an array of result objects
- A 404 response

These cases need handling correctly. 