### PR TITLE
DCS-471 CAs HDC refusal is not recorded if reason not provided

### DIFF
--- a/server/routes/eligibility.js
+++ b/server/routes/eligibility.js
@@ -1,6 +1,6 @@
 const formConfig = require('./config/eligibility')
 const { asyncMiddleware } = require('../utils/middleware')
-const { getIn, firstItem } = require('../utils/functionalHelpers')
+const { getIn } = require('../utils/functionalHelpers')
 const createStandardRoutes = require('./routeWorkers/standard')
 
 module.exports = ({ licenceService, nomisPushService }) => (router, audited, config) => {

--- a/server/services/licenceService.js
+++ b/server/services/licenceService.js
@@ -295,6 +295,12 @@ module.exports = function createLicenceService(licenceClient) {
     return updatedLicence
   }
 
+  async function removeCaRefusalDecision(bookingId, licence) {
+    const changedLicence = removePath(['finalChecks', 'refusal'], licence)
+    await licenceClient.updateLicence(bookingId, changedLicence, false)
+    return licenceClient.getLicence(bookingId)
+  }
+
   function rejectBass(licence, bookingId, bassRequested, reason) {
     const lastBassReferral = getIn(licence, ['bassReferral'])
 
@@ -495,6 +501,7 @@ module.exports = function createLicenceService(licenceClient) {
     saveApprovedLicenceVersion: licenceClient.saveApprovedLicenceVersion,
     addSplitDateFields,
     removeDecision,
+    removeCaRefusalDecision,
     rejectBass,
     withdrawBass,
     reinstateBass,

--- a/server/views/taskList/taskListTemplate.pug
+++ b/server/views/taskList/taskListTemplate.pug
@@ -26,7 +26,7 @@ block content
       strong.bold The offender is presumed unsuitable for HDC release
   else if user.role === 'CA' && decisions.caRefused
     div.error-banner.marginTopMedium
-      strong.bold Home detention curfew refused by prison case admin#{decisions.refusalReason ?': ' + decisions.refusalReason : ''}
+      strong.bold Home detention curfew refused by prison case admin: #{licenceStatus.decisions.refusalReason}
   else if user.role === 'CA' && decisions.refused
     if decisions.decisionComments
       div.error-banner.marginTopMedium

--- a/test/routes/taskList.test.js
+++ b/test/routes/taskList.test.js
@@ -62,15 +62,10 @@ const dmHasProvidedHdcDecisionComments = {
 const caHasRefusedHdcButNotProvidedReason = {
   stage: 'DECIDED',
   licence: {
-    approval: {
-      release: {
-        decision: 'Yes',
-      },
-    },
-    finalChecks: {
-      refusal: {
-        decision: 'Yes',
-      },
+    refusal: {
+      reason: '',
+      decision: 'Yes',
+      outOfTimeReasons: '[]',
     },
   },
 }
@@ -369,7 +364,7 @@ describe('GET /taskList/:prisonNumber', () => {
         })
     })
 
-    test('should contain "Home detention curfew refused by prison case admin" ', () => {
+    test('should not contain "Home detention curfew refused by prison case admin" ', () => {
       licenceService.getLicence.mockResolvedValue(caHasRefusedHdcButNotProvidedReason)
 
       const app = createApp(
@@ -382,8 +377,7 @@ describe('GET /taskList/:prisonNumber', () => {
         .expect(200)
         .expect('Content-Type', /html/)
         .expect((res) => {
-          expect(res.text).toContain('Home detention curfew refused by prison case admin')
-          expect(res.text).not.toContain('case admin:')
+          expect(res.text).not.toContain('Home detention curfew refused by prison case admin')
         })
     })
 

--- a/test/services/licenceService.test.js
+++ b/test/services/licenceService.test.js
@@ -324,6 +324,41 @@ describe('licenceService', () => {
     })
   })
 
+  describe('removeCaRefusalDecision', () => {
+    test('should update licence', () => {
+      service.removeCaRefusalDecision('1', {})
+
+      expect(licenceClient.updateLicence).toHaveBeenCalled()
+      expect(licenceClient.updateLicence).toHaveBeenCalledWith('1', {}, false)
+    })
+
+    test('should strip out refusal object from finalChecks object', () => {
+      const licence = {
+        finalChecks: {
+          refusal: {
+            reason: '',
+            decision: 'Yes',
+            outOfTimeReasons: '[]',
+          },
+          seriousOffence: {
+            decision: 'No',
+          },
+        },
+      }
+
+      const licenceNoRefusal = {
+        finalChecks: {
+          seriousOffence: {
+            decision: 'No',
+          },
+        },
+      }
+
+      service.removeCaRefusalDecision('1', licence)
+      expect(licenceClient.updateLicence).toHaveBeenCalledWith('1', licenceNoRefusal, false)
+    })
+  })
+
   describe('addSplitDateFields', () => {
     test('should add day, month and year fields to split dates', () => {
       const rawData = {


### PR DESCRIPTION
If a CA refuses HDC by selecting Yes in the page /hdc/finalChecks/refuse/{bookingId} but doesn't follow it up with a reason in page /hdc/finalChecks/refusal/{bookingId}, then when CA returns back to the CA tasklist, the previous Yes decision is deleted because the refusal has not been fully completed. The refusal can not be treated as complete without a reason being registered. 
The tasklist will not therefore display any refusal message and will have returned to the original state.