### PR TITLE
DCS-553: unapproved bespoke conditions displayed

### DIFF
--- a/server/routes/conditions.js
+++ b/server/routes/conditions.js
@@ -17,9 +17,12 @@ module.exports = ({ licenceService, conditionsService }) => (router, audited) =>
     const standardConditions = conditionsService.getStandardConditions()
     const { additionalConditionsRequired } =
       getIn(res.locals.licence, ['licence', 'licenceConditions', 'standard']) || {}
-    const { additionalConditions, pssConditions, bespokeConditions } = conditionsService.getNonStandardConditions(
-      res.locals.licence.licence
-    )
+    const {
+      additionalConditions,
+      pssConditions,
+      bespokeConditions,
+      unapprovedBespokeConditions,
+    } = conditionsService.getNonStandardConditions(res.locals.licence.licence)
 
     res.render('licenceConditions/standard', {
       action,
@@ -29,6 +32,7 @@ module.exports = ({ licenceService, conditionsService }) => (router, audited) =>
       additionalConditions,
       pssConditions,
       bespokeConditions,
+      unapprovedBespokeConditions,
     })
   }
 

--- a/server/services/conditionsService.js
+++ b/server/services/conditionsService.js
@@ -213,10 +213,15 @@ module.exports = function createConditionsService({ use2019Conditions }) {
       (condition) => condition.group === 'Bespoke' && condition.approved === 'Yes'
     )
 
+    const unapprovedBespokeConditions = licenceConditions.filter(
+      (condition) => condition.group === 'Bespoke' && (condition.approved === 'No' || !condition.approved)
+    )
+
     return {
       additionalConditions: allAdditionalConditions.map(formatConditionsText),
       bespokeConditions: bespokeConditions.map(formatConditionsText),
       pssConditions: pssConditions.map(formatConditionsText),
+      unapprovedBespokeConditions: unapprovedBespokeConditions.map(formatConditionsText),
     }
   }
 

--- a/server/views/licenceConditions/standard.pug
+++ b/server/views/licenceConditions/standard.pug
@@ -22,6 +22,7 @@ block content
   +additionalConditions('Additional conditions', additionalConditions, 'additional')
   +additionalConditions('Post sentence supervision conditions', pssConditions, 'post sentence supervision')
   +additionalConditions('Bespoke conditions', bespokeConditions, 'bespoke')
+  +additionalConditions('Unapproved bespoke conditions', unapprovedBespokeConditions, 'unapproved bespoke')
 
 
   form(method="post")

--- a/test/routes/licenceConditions.test.js
+++ b/test/routes/licenceConditions.test.js
@@ -42,6 +42,7 @@ describe('/hdc/licenceConditions', () => {
       additionalConditions: [{ text: '' }],
       bespokeConditions: [{ text: '' }],
       pssConditions: [{ text: '' }],
+      unapprovedBespokeConditions: [{ text: '' }],
     })
 
     const app = createApp({ licenceService, conditionsService: conditionsServiceStub }, 'roUser')
@@ -64,6 +65,7 @@ describe('/hdc/licenceConditions', () => {
         additionalConditions: [{ text: 'Not to contact directly or indirectly' }],
         bespokeConditions: [{ text: '' }],
         pssConditions: [{ text: '' }],
+        unapprovedBespokeConditions: [{ text: '' }],
       })
 
       const app = createApp({ licenceService, conditionsService: conditionsServiceStub }, 'roUser')
@@ -81,6 +83,7 @@ describe('/hdc/licenceConditions', () => {
         additionalConditions: [{ text: '' }],
         bespokeConditions: [{ text: '' }],
         pssConditions: [{ text: 'reasonably required by your supervisor, to give a sample' }],
+        unapprovedBespokeConditions: [{ text: '' }],
       })
 
       const app = createApp({ licenceService, conditionsService: conditionsServiceStub }, 'roUser')
@@ -98,6 +101,7 @@ describe('/hdc/licenceConditions', () => {
         additionalConditions: [{ text: '' }],
         bespokeConditions: [{ text: 'Bespoke condition - approval Yes' }],
         pssConditions: [{ text: '' }],
+        unapprovedBespokeConditions: [{ text: '' }],
       })
 
       const app = createApp({ licenceService, conditionsService: conditionsServiceStub }, 'roUser')
@@ -115,6 +119,7 @@ describe('/hdc/licenceConditions', () => {
         additionalConditions: [],
         bespokeConditions: [],
         pssConditions: [],
+        unapprovedBespokeConditions: [],
       })
 
       const app = createApp({ licenceService, conditionsService: conditionsServiceStub }, 'roUser')
@@ -126,6 +131,7 @@ describe('/hdc/licenceConditions', () => {
           expect(res.text).toContain('No additional conditions selected')
           expect(res.text).toContain('No post sentence supervision conditions selected')
           expect(res.text).toContain('No bespoke conditions selected')
+          expect(res.text).toContain('No unapproved bespoke conditions selected')
         })
     })
   })

--- a/test/services/conditionsService.test.js
+++ b/test/services/conditionsService.test.js
@@ -1157,7 +1157,7 @@ describe('conditionsService', () => {
     })
   })
   describe('getNonStandardConditions', () => {
-    test('should return correctly 3 formatted contents', () => {
+    test('should return correctly 4 formatted contents', () => {
       const licence = {
         licenceConditions: {
           additional: {
@@ -1177,6 +1177,9 @@ describe('conditionsService', () => {
               text: 'Bespoke condition 1',
               approved: 'Yes',
             },
+            {
+              text: 'some text input but yes/no not selected',
+            },
           ],
         },
       }
@@ -1195,27 +1198,35 @@ describe('conditionsService', () => {
               'Attend The Probation Service, 1, Some Address, as reasonably required by your supervisor, to give a sample of oral fluid/urine in order to test whether you have any specified Class A and specified Class B drugs in your body, for the purpose of ensuring that you are complying with the requirement of supervision period requiring you to be of good behaviour',
           },
         ],
+        unapprovedBespokeConditions: [{ text: 'some text input but yes/no not selected' }],
       })
     })
 
-    test('should return 3 empty arrays', () => {
+    test('should return 4 empty arrays', () => {
       const licence = {
-        licenceConditions: { bespoke: [], additional: {} },
+        licenceConditions: { bespoke: [], standard: { additionalConditionsRequired: 'Yes' }, additional: {} },
       }
 
       return expect(service.getNonStandardConditions(licence)).toEqual({
         additionalConditions: [],
         bespokeConditions: [],
         pssConditions: [],
+        unapprovedBespokeConditions: [],
       })
     })
 
-    test('should return empty array for bespoke condition if has not been approved', () => {
+    test('should return 2 unapprovedBespokeConditions if approved = No', () => {
       const licence = {
         licenceConditions: {
+          additional: {},
+          standard: { additionalConditionsRequired: 'Yes' },
           bespoke: [
             {
-              text: 'Bespoke condition text',
+              text: 'Bespoke condition text 1',
+              approved: 'No',
+            },
+            {
+              text: 'Bespoke condition text 2',
               approved: 'No',
             },
           ],
@@ -1226,12 +1237,15 @@ describe('conditionsService', () => {
         additionalConditions: [],
         bespokeConditions: [],
         pssConditions: [],
+        unapprovedBespokeConditions: [{ text: 'Bespoke condition text 1' }, { text: 'Bespoke condition text 2' }],
       })
     })
 
-    test('should empty array for bespoke condition if neither Yes/No has been selected', () => {
+    test('should return 0 bespoke conditions but 1 unapprovedBespokeConditions because approved is neither Yes/No', () => {
       const licence = {
         licenceConditions: {
+          additional: {},
+          standard: { additionalConditionsRequired: 'Yes' },
           bespoke: [
             {
               text: 'Bespoke condition text',
@@ -1244,6 +1258,7 @@ describe('conditionsService', () => {
         additionalConditions: [],
         bespokeConditions: [],
         pssConditions: [],
+        unapprovedBespokeConditions: [{ text: 'Bespoke condition text' }],
       })
     })
   })


### PR DESCRIPTION
http://localhost:3000/hdc/licenceConditions/standard/{bookingId}

If a user enters bespoke additional conditions but they are either unapproved or the user has not clicked Yes or No for approval, then these conditions are displayed in a new section called Unapproved bespoke conditions. 
Otherwise that section will show a message to say there are no unapproved bespoke conditions

<bkr>

<img width="699" alt="Screenshot 2020-07-03 at 13 51 10" src="https://user-images.githubusercontent.com/50441412/86471781-ea4c3280-bd35-11ea-8e87-e11e75374d29.png">
</bkr>
<bkr>
<img width="876" alt="Screenshot 2020-07-03 at 13 51 35" src="https://user-images.githubusercontent.com/50441412/86471042-7e1cff00-bd34-11ea-8371-255e18010324.png">

</bkr>