### PR TITLE
DCS-379 Initial shot at adding admin screen to aid migration 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@1.0.0
+  hmpps: ministryofjustice/hmpps@1.1.2
 
 executors:
   integration-tests:

--- a/server/app.js
+++ b/server/app.js
@@ -89,6 +89,7 @@ module.exports = function createApp({
   lduService,
   functionalMailboxService,
   roNotificationHandler,
+  migrationService,
 }) {
   const app = express()
 
@@ -344,7 +345,10 @@ module.exports = function createApp({
   )
   app.use('/caseList/', secureRoute(caseListRouter({ caseListService })))
   app.use('/admin/', secureRoute(adminRouter()))
-  app.use('/admin/roUsers/', secureRoute(userAdminRouter({ userAdminService }), { auditKey: 'USER_MANAGEMENT' }))
+  app.use(
+    '/admin/roUsers/',
+    secureRoute(userAdminRouter({ userAdminService, signInService, migrationService }), { auditKey: 'MAINTENANCE' })
+  )
   app.use('/admin/mailboxes/', secureRoute(mailboxesAdminRouter({ configClient })))
   app.use('/admin/jobs/', secureRoute(jobsAdminRouter({ jobSchedulerService })))
   app.use('/admin/delius/', secureRoute(deliusAdminRouter(roService)))

--- a/server/data/deliusClient.ts
+++ b/server/data/deliusClient.ts
@@ -43,5 +43,9 @@ export const createDeliusClient = (restClient): DeliusClient => {
         // Do nothing
       }
     },
+
+    async getUser(username) {
+      return restClient.getResource(`/users/${username}/details`)
+    },
   }
 }

--- a/server/data/nomisClientBuilder.ts
+++ b/server/data/nomisClientBuilder.ts
@@ -171,6 +171,22 @@ export = (token) => {
       return oauthRestClient.getResource(`/api/user/${userName}`)
     },
 
+    getAuthUser(username) {
+      return oauthRestClient.getResource(`/api/authuser/${username}`)
+    },
+
+    getAuthUserRoles(username) {
+      return oauthRestClient.getResource(`/api/authuser/${username}/roles`)
+    },
+
+    disableAuthUser(username) {
+      return oauthRestClient.putResource(`/api/authuser/${username}/disable`, {})
+    },
+
+    enableAuthUser(username) {
+      return oauthRestClient.putResource(`/api/authuser/${username}/enable`, {})
+    },
+
     getLoggedInUserInfo(): Promise<Profile> {
       return oauthRestClient.getResource(`/api/user/me`)
     },

--- a/server/data/userClient.js
+++ b/server/data/userClient.js
@@ -1,18 +1,19 @@
 const db = require('./dataAccess/db')
 
 module.exports = {
-  async getRoUsers() {
-    const query = {
-      text: 'select * from staff_ids order by nomis_id asc',
-    }
+  async getRoUsers(page) {
+    const query = page
+      ? {
+          text: 'select * from staff_ids order by nomis_id asc limit $1 offset $2',
+          values: [page.limit, page.offset],
+        }
+      : {
+          text: 'select * from staff_ids order by nomis_id asc',
+        }
 
     const { rows } = await db.query(query)
 
-    if (rows) {
-      return rows.map(convertPropertyNames)
-    }
-
-    return []
+    return rows.map(convertPropertyNames)
   },
 
   async getCasesRequiringRo() {

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ const { createLicenceService } = require('./services/licenceService')
 const { createPrisonerService } = require('./services/prisonerService')
 const createConditionsService = require('./services/conditionsService')
 const createCaseListService = require('./services/caseListService')
+const MigrationService = require('./services/migrationService').default
 const createPdfService = require('./services/pdfService')
 const createFormService = require('./services/formService')
 const createReportingService = require('./services/reportingService')
@@ -83,6 +84,7 @@ const userAdminService = createUserAdminService(nomisClientBuilder, userClient, 
 const userService = createUserService(nomisClientBuilder)
 const deadlineService = createDeadlineService(licenceClient)
 const roContactDetailsService = createRoContactDetailsService(userAdminService, roService, probationTeamsClient)
+const migrationService = new MigrationService(deliusClient, userAdminService, nomisClientBuilder)
 
 const notificationSender = createNotificationSender(notifyClient, audit, config.notifications.notifyKey)
 const roNotificationSender = createRoNotificationSender(notificationSender, config)
@@ -152,6 +154,7 @@ const app = createApp({
   lduService,
   functionalMailboxService,
   roNotificationHandler,
+  migrationService,
 })
 
 module.exports = app

--- a/server/services/migrationService.ts
+++ b/server/services/migrationService.ts
@@ -1,0 +1,126 @@
+import { DeliusClient } from './roService'
+import logger from '../../log'
+import config from '../config'
+
+export const enum Flag {
+  // Delius staff record not linked to a user
+  UNLINKED_ACCOUNT = 'UNLINKED_ACCOUNT',
+  // Email address mismatch in delius and auth
+  EMAIL_MISMATCH = 'EMAIL_MISMATCH',
+  // The user does not have the same usernames in both delius and auth
+  USERNAME_MISMATCH = 'USERNAME_MISMATCH',
+  DISABLED_IN_DELIUS = 'DISABLED_IN_DELIUS',
+  DISABLED_IN_AUTH = 'DISABLED_IN_AUTH',
+  // Contain more roles than just RO/global search.
+  MULTIPLE_NOMIS_ROLES = 'MULTIPLE_NOMIS_ROLES',
+  REQUIRES_RO_ROLE = 'REQUIRES_RO_ROLE',
+  MISSING_AUTH_USER = 'MISSING_AUTH_USER',
+  MISSING_DELIUS_USER = 'MISSING_DELIUS_USER',
+}
+
+export default class MigrationService {
+  constructor(
+    private readonly deliusClient: DeliusClient,
+    private readonly userAdminService,
+    private readonly nomisClientBuilder
+  ) {}
+
+  async getAll(token: string, page) {
+    const users = await this.userAdminService.getRoUsers(page)
+    const result = []
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const user of users) {
+      // we don't want to batter the source systems so running in a single thread
+      // eslint-disable-next-line no-await-in-loop
+      result.push(await this.enrich(token, user))
+    }
+    return result
+  }
+
+  async getStaffDetails(token: string, nomisUsername: string) {
+    const licenceUser = await this.userAdminService.getRoUser(nomisUsername)
+    return this.enrich(token, licenceUser)
+  }
+
+  async enrich(token: string, licenceUser: any) {
+    const { nomisId: nomisUsername } = licenceUser
+    const deliusStaffDetails = await this.deliusClient.getStaffDetailsByStaffCode(licenceUser.deliusId)
+    const isLinked = Boolean(deliusStaffDetails && deliusStaffDetails.username)
+
+    const deliusUser = isLinked && (await this.getUserFromDelius(deliusStaffDetails.username))
+    const authUser = await this.getStaffDetailsFromAuth(token, nomisUsername)
+
+    const flags = this.getFlags(deliusUser, authUser, licenceUser, deliusStaffDetails)
+    return { licenceUser, deliusUser: deliusStaffDetails, authUser, flags }
+  }
+
+  private getFlags(deliusUser, authUser, licenceUser, deliusStaffDetails) {
+    const deliusRoles = deliusUser ? deliusUser.roles : []
+    const hasRoRole = deliusRoles.map((r) => r.name).includes(config.delius.responsibleOfficerRoleId)
+
+    const multipleAuthRoles = authUser && authUser.roles.length > 1
+
+    const isLinked = deliusStaffDetails && deliusStaffDetails.username
+
+    const differentEmail = isLinked && licenceUser.email !== deliusStaffDetails.email
+    const differentUsernames = isLinked && authUser && authUser.username !== deliusStaffDetails.username
+
+    return [
+      ...(!deliusStaffDetails ? [Flag.MISSING_DELIUS_USER] : []),
+      ...(deliusStaffDetails && !deliusStaffDetails.username ? [Flag.UNLINKED_ACCOUNT] : []),
+      ...(deliusUser && !hasRoRole ? [Flag.REQUIRES_RO_ROLE] : []),
+      ...(deliusUser && !deliusUser.enabled ? [Flag.DISABLED_IN_DELIUS] : []),
+      ...(authUser && !authUser.enabled ? [Flag.DISABLED_IN_AUTH] : []),
+      ...(!authUser ? [Flag.MISSING_AUTH_USER] : []),
+      ...(multipleAuthRoles ? [Flag.MULTIPLE_NOMIS_ROLES] : []),
+      ...(differentEmail ? [Flag.EMAIL_MISMATCH] : []),
+      ...(differentUsernames ? [Flag.USERNAME_MISMATCH] : []),
+    ]
+  }
+
+  public async addRoRole(nomisUsername) {
+    const roUser = await this.userAdminService.getRoUser(nomisUsername)
+    const deliusRo = await this.getStaffByCode(roUser.deliusId)
+    await this.deliusClient.addResponsibleOfficerRole(deliusRo.username)
+  }
+
+  public async disableAuthAccount(token, nomisUsername) {
+    const nomisClient = this.nomisClientBuilder(token)
+    await nomisClient.disableAuthUser(nomisUsername)
+  }
+
+  public async enableAuthAccount(token, nomisUsername) {
+    const nomisClient = this.nomisClientBuilder(token)
+    await nomisClient.enableAuthUser(nomisUsername)
+  }
+
+  private async getStaffByCode(staffCode) {
+    try {
+      return await this.deliusClient.getStaffDetailsByStaffCode(staffCode)
+    } catch (error) {
+      logger.warn(`Problem retrieving staff member from delius for code: ${staffCode}`, error.stack)
+      return null
+    }
+  }
+
+  private async getUserFromDelius(username) {
+    try {
+      const result = await this.deliusClient.getUser(username)
+      return result
+    } catch (error) {
+      logger.warn(`Problem retrieving user from delius for username: ${username}`, error.stack)
+      return null
+    }
+  }
+
+  private async getStaffDetailsFromAuth(token, username) {
+    const nomisClient = this.nomisClientBuilder(token)
+    const user = await nomisClient.getAuthUser(username)
+    if (!user) {
+      return null
+    }
+    const roles = await nomisClient.getAuthUserRoles(username)
+    return { ...user, roles: (roles || []).map((r) => r.roleCode) }
+  }
+}

--- a/server/views/admin/users/migrate.pug
+++ b/server/views/admin/users/migrate.pug
@@ -1,0 +1,103 @@
+extends ../../layout
+include ../../includes/errorBannerWithDetail
+
+block content
+
+  -var inputs = userInput ? userInput : roUser ? roUser : {}
+
+  div.back-link-container.smallPaddingTop
+    a#back.link-back(href="javascript: window.history.back();") Back
+  +errorBannerWithDetail(errors, [
+    { field: 'nomisId' },
+    { field: 'deliusId' }
+  ])
+
+  h2.heading-large
+    | Migrate User
+    
+  div.pure-g.largePaddingBottom
+    div.purge-g  
+        div.pure-u-1-2
+            h3.heading-medium Licence record
+            div.pure-u-1-3 Name
+            div.pure-u-2-3.bold #{licenceUser.first} #{licenceUser.last} 
+
+            div.pure-u-1-3 Delius staff code
+            div.pure-u-2-3.bold #{licenceUser.deliusId}
+
+            div.pure-u-1-3 Auth username
+            div.pure-u-2-3.bold #{licenceUser.nomisId}
+
+            div.pure-u-1-3 Email
+            div.pure-u-2-3.bold #{licenceUser.email}
+
+            div.pure-u-1-3 Org Email
+            div.pure-u-2-3.bold #{licenceUser.orgEmail}
+
+        div.pure-u-1-2
+          h3.heading-medium Delius record
+          if deliusUser
+            div.pure-u-1-3 Name
+            div.pure-u-2-3.bold #{deliusUser.staff.forenames} #{deliusUser.staff.surname} 
+
+            div.pure-u-1-3 Delius staff code
+            div.pure-u-2-3.bold #{deliusUser.staffCode}
+            
+            if !flags.includes('UNLINKED_ACCOUNT')
+                div.pure-u-1-3 Delius username
+                div.pure-u-2-3.bold #{deliusUser.username}
+
+                div.pure-u-1-3 Email
+                div.pure-u-2-3.bold #{deliusUser.email}
+
+                div.pure-u-1-3 Enabled
+                div.pure-u-2-3.bold #{!flags.includes('DISABLED_IN_DELIUS')}
+
+                div.pure-u-1-3 RO role present
+                div.pure-u-2-3.bold #{!flags.includes('REQUIRES_RO_ROLE')}
+
+            div.pure-u-1-3 Linked account
+            div.pure-u-2-3.bold #{!flags.includes('UNLINKED_ACCOUNT')}
+          else
+            p Missing user with username: 
+              span.bold #{licenceUser.deliusId}
+
+  div.pure-g.largePaddingBottom
+      div.pure-u-1-2
+          h3.heading-medium Auth record
+          if authUser
+            div.pure-u-1-3 Name
+            div.pure-u-2-3.bold #{authUser.firstName} #{authUser.lastName} 
+
+            div.pure-u-1-3 Auth username
+            div.pure-u-2-3.bold #{authUser.username}
+
+            div.pure-u-1-3 Email
+            div.pure-u-2-3.bold #{authUser.email}
+
+            div.pure-u-1-3 Enabled
+            div.pure-u-2-3.bold #{authUser.enabled}
+
+            div.pure-u-1-3 Last logged in
+            div.pure-u-2-3.bold #{authUser.lastLoggedIn}
+
+            div.pure-u-1-3 Roles
+            div.pure-u-2-3.bold #{authUser.roles}
+          else
+            p Missing user with username: 
+              span.bold #{licenceUser.nomisId}
+      div.pure-u-1-2
+        h3.heading-medium Actions
+        div
+          form(method='POST', action='/admin/roUsers/assign-role/' + licenceUser.nomisId)
+              input(type="hidden" name="_csrf" value=csrfToken)
+              if flags.includes('REQUIRES_RO_ROLE')
+                  input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Assign RO role" formaction='/admin/roUsers/assign-role/' + licenceUser.nomisId)
+              if !flags.includes('DISABLED_IN_AUTH')
+                  input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Disable auth account" formaction='/admin/roUsers/disable-auth/' + licenceUser.nomisId) 
+              if flags.includes('DISABLED_IN_AUTH')
+                  input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Enable auth account" formaction='/admin/roUsers/enable-auth/' + licenceUser.nomisId) 
+          
+        div
+            a#backBtn.requiredButton.button.button-secondary.smallMarginTop(href="javascript: window.history.back();" role="button") Cancel
+

--- a/server/views/admin/users/usersTable.pug
+++ b/server/views/admin/users/usersTable.pug
@@ -8,6 +8,7 @@ table#hdcEligiblePrisoners.largeMarginBottom
       th In SSO
       th
       th
+      th
   tbody
     if roUsers && roUsers.length > 0
       each roUser, index in roUsers
@@ -33,3 +34,6 @@ table#hdcEligiblePrisoners.largeMarginBottom
           td.delete
             a.button.button-secondary.fullWidth.center(href="/admin/roUsers/delete/" + roUser.nomisId role="button")
               | Delete
+          td.migrate
+            a.button.button-secondary.fullWidth.center(href="/admin/roUsers/migrate/" + roUser.nomisId role="button")
+              | Migrate

--- a/test/data/deliusClient.test.js
+++ b/test/data/deliusClient.test.js
@@ -180,4 +180,12 @@ describe('deliusClient', () => {
       return expect(deliusClient.addResponsibleOfficerRole('bobUser')).resolves.toBeUndefined()
     })
   })
+
+  describe('getUser', () => {
+    test('should return data from api', () => {
+      fakeDelius.get(`/users/bobUser/details`).reply(200, { username: 'aaa' })
+
+      return expect(deliusClient.getUser('bobUser')).resolves.toStrictEqual({ username: 'aaa' })
+    })
+  })
 })

--- a/test/data/nomisClient.test.js
+++ b/test/data/nomisClient.test.js
@@ -451,6 +451,62 @@ describe('nomisClient', () => {
     })
   })
 
+  describe('getAuthUser', () => {
+    test('should return data from api', () => {
+      fakeAuth.get('/api/authuser/userName').reply(200, { username: 'result' })
+
+      return expect(nomisClient.getAuthUser('userName')).resolves.toEqual({ username: 'result' })
+    })
+
+    test('should reject if api fails', () => {
+      fakeAuth.get('/api/authuser/userName').thrice().reply(500)
+
+      return expect(nomisClient.getAuthUser('userName')).rejects.toStrictEqual(Error('Internal Server Error'))
+    })
+  })
+
+  describe('getAuthUserRoles', () => {
+    test('should return data from api', () => {
+      fakeAuth.get('/api/authuser/userName/roles').reply(200, ['RO_LICENCES'])
+
+      return expect(nomisClient.getAuthUserRoles('userName')).resolves.toEqual(['RO_LICENCES'])
+    })
+
+    test('should reject if api fails', () => {
+      fakeAuth.get('/api/authuser/userName/roles').thrice().reply(500)
+
+      return expect(nomisClient.getAuthUserRoles('userName')).rejects.toStrictEqual(Error('Internal Server Error'))
+    })
+  })
+
+  describe('disableAuthUser', () => {
+    test('should return data from api', () => {
+      fakeAuth.put('/api/authuser/userName/disable').reply(200)
+
+      return expect(nomisClient.disableAuthUser('userName')).resolves.toBeUndefined()
+    })
+
+    test('should reject if api fails', () => {
+      fakeAuth.put('/api/authuser/userName/disable').reply(500)
+
+      return expect(nomisClient.disableAuthUser('userName')).rejects.toStrictEqual(Error('Internal Server Error'))
+    })
+  })
+
+  describe('enableAuthUser', () => {
+    test('should return data from api', () => {
+      fakeAuth.put('/api/authuser/userName/enable').reply(200)
+
+      return expect(nomisClient.enableAuthUser('userName')).resolves.toBeUndefined()
+    })
+
+    test('should reject if api fails', () => {
+      fakeAuth.put('/api/authuser/userName/enable').reply(500)
+
+      return expect(nomisClient.enableAuthUser('userName')).rejects.toStrictEqual(Error('Internal Server Error'))
+    })
+  })
+
   describe('getLoggedInUserInfo', () => {
     test('should return data from api', () => {
       fakeAuth.get('/api/user/me').reply(200, { username: 'result' })

--- a/test/data/userClient.test.js
+++ b/test/data/userClient.test.js
@@ -26,17 +26,27 @@ describe('userClient', () => {
   const standardResponse = { rows: [{ user1, user2 }] }
 
   beforeEach(() => {
-    db.query = jest.fn().mockReturnValue(standardResponse)
+    db.query = jest.fn().mockResolvedValue(standardResponse)
   })
 
   describe('getRoUsers', () => {
     test('should call query', () => {
       userClient.getRoUsers()
-      expect(db.query).toHaveBeenCalled()
+      expect(db.query).toHaveBeenCalledWith({
+        text: 'select * from staff_ids order by nomis_id asc',
+      })
+    })
+
+    test('can do paged query', () => {
+      userClient.getRoUsers({ limit: 20, offset: 0 })
+      expect(db.query).toHaveBeenCalledWith({
+        text: 'select * from staff_ids order by nomis_id asc limit $1 offset $2',
+        values: [20, 0],
+      })
     })
 
     test('should return empty if no matches', async () => {
-      db.query = jest.fn().mockReturnValue({})
+      db.query.mockResolvedValue({ rows: [] })
       const result = await userClient.getRoUsers()
       expect(db.query).toHaveBeenCalled()
       expect(result).toEqual([])

--- a/test/mockClients.ts
+++ b/test/mockClients.ts
@@ -38,6 +38,7 @@ export const mockDeliusClient: () => DeliusClientMock = () => ({
   getROPrisoners: jest.fn(),
   getStaffDetailsByStaffCode: jest.fn(),
   getStaffDetailsByUsername: jest.fn(),
+  getUser: jest.fn(),
 })
 
 export interface ProbationTeamsClientMock extends ProbationTeamsClient {

--- a/test/mockServices.js
+++ b/test/mockServices.js
@@ -71,6 +71,8 @@ const createRoServiceStub = () => ({
   getROPrisoners: jest.fn(),
   getStaffByUsername: jest.fn(),
   findResponsibleOfficerByOffenderNo: jest.fn(),
+  getStaffDetailsFromDelius: jest.fn(),
+  addRoRole: jest.fn(),
 })
 
 const createUserAdminServiceStub = () => ({

--- a/test/services/migrationService.test.ts
+++ b/test/services/migrationService.test.ts
@@ -1,0 +1,211 @@
+import MigrationService, { Flag } from '../../server/services/migrationService'
+import { delius } from '../../server/config'
+
+describe('MigrationService', () => {
+  let deliusClient
+  let userAdminService
+  let nomisClient
+  const nomisClientBuilder = jest.fn()
+  let migrationService
+
+  beforeEach(() => {
+    nomisClient = {
+      disableAuthUser: jest.fn(),
+      enableAuthUser: jest.fn(),
+      getAuthUser: jest.fn(),
+      getAuthUserRoles: jest.fn(),
+    }
+
+    userAdminService = {
+      getRoUser: jest.fn(),
+    }
+
+    deliusClient = {
+      addResponsibleOfficerRole: jest.fn(),
+      getStaffDetailsByStaffCode: jest.fn(),
+      getUser: jest.fn(),
+    }
+
+    nomisClientBuilder.mockReturnValue(nomisClient)
+    migrationService = new MigrationService(deliusClient, userAdminService, nomisClientBuilder)
+  })
+
+  describe('disableAuthAccount', () => {
+    test('should call disable on nomis client', async () => {
+      await migrationService.disableAuthAccount('token-1', 'USER')
+      expect(nomisClientBuilder).toHaveBeenCalledWith('token-1')
+      expect(nomisClient.disableAuthUser).toHaveBeenCalledWith('USER')
+    })
+  })
+
+  describe('enableAuthAccount', () => {
+    test('should call enable on nomis client', async () => {
+      await migrationService.enableAuthAccount('token-1', 'USER')
+      expect(nomisClientBuilder).toHaveBeenCalledWith('token-1')
+      expect(nomisClient.enableAuthUser).toHaveBeenCalledWith('USER')
+    })
+  })
+
+  describe('addRoRole', () => {
+    test('should call add role on delius client', async () => {
+      userAdminService.getRoUser.mockResolvedValue({ deliusId: 123 })
+      deliusClient.getStaffDetailsByStaffCode.mockResolvedValue({ username: 'delius-user' })
+      deliusClient.addResponsibleOfficerRole.mockResolvedValue(null)
+
+      await migrationService.addRoRole('USER')
+      expect(deliusClient.getStaffDetailsByStaffCode).toHaveBeenCalledWith(123)
+      expect(deliusClient.addResponsibleOfficerRole).toHaveBeenCalledWith('delius-user')
+    })
+  })
+
+  describe('getStaffDetails', () => {
+    test('get staff details, no flags', async () => {
+      userAdminService.getRoUser.mockResolvedValue({ deliusId: 123, nomisId: 'user-1', email: 'user@gov.uk' })
+
+      nomisClient.getAuthUser.mockResolvedValue({ username: 'user-1', enabled: true })
+
+      deliusClient.getStaffDetailsByStaffCode.mockResolvedValue({ username: 'user-1', email: 'user@gov.uk' })
+      deliusClient.getUser.mockResolvedValue({
+        roles: [{ name: delius.responsibleOfficerRoleId }],
+        enabled: true,
+      })
+
+      const result = await migrationService.getStaffDetails('user-1')
+
+      expect(result).toStrictEqual({
+        authUser: {
+          enabled: true,
+          roles: [],
+          username: 'user-1',
+        },
+        deliusUser: {
+          username: 'user-1',
+          email: 'user@gov.uk',
+        },
+        flags: [],
+        licenceUser: {
+          deliusId: 123,
+          nomisId: 'user-1',
+          email: 'user@gov.uk',
+        },
+      })
+    })
+
+    test('get staff details, unlinked user', async () => {
+      userAdminService.getRoUser.mockResolvedValue({ deliusId: 123, nomisId: 'user-1', email: 'user@gov.uk' })
+
+      nomisClient.getAuthUser.mockResolvedValue({ username: 'user-1', enabled: true })
+
+      deliusClient.getStaffDetailsByStaffCode.mockResolvedValue({ staffCode: 'AA123' })
+
+      const result = await migrationService.getStaffDetails('user-1')
+
+      expect(result).toStrictEqual({
+        authUser: {
+          enabled: true,
+          roles: [],
+          username: 'user-1',
+        },
+        deliusUser: {
+          staffCode: 'AA123',
+        },
+        flags: [Flag.UNLINKED_ACCOUNT],
+        licenceUser: {
+          deliusId: 123,
+          email: 'user@gov.uk',
+          nomisId: 'user-1',
+        },
+      })
+    })
+
+    test('get staff details, mismatched details without RO role', async () => {
+      userAdminService.getRoUser.mockResolvedValue({ deliusId: 123, nomisId: 'user-1', email: 'user@gov.uk' })
+
+      nomisClient.getAuthUser.mockResolvedValue({ username: 'user-1', enabled: true })
+
+      deliusClient.getStaffDetailsByStaffCode.mockResolvedValue({
+        username: 'delius-user',
+        staffCode: 'AA123',
+        email: 'delius-user@gov.uk',
+      })
+      deliusClient.getUser.mockResolvedValue({
+        roles: [],
+        enabled: true,
+      })
+
+      const result = await migrationService.getStaffDetails('user-1')
+
+      expect(result).toStrictEqual({
+        authUser: {
+          enabled: true,
+          roles: [],
+          username: 'user-1',
+        },
+        deliusUser: {
+          email: 'delius-user@gov.uk',
+          staffCode: 'AA123',
+          username: 'delius-user',
+        },
+        flags: [Flag.REQUIRES_RO_ROLE, Flag.EMAIL_MISMATCH, Flag.USERNAME_MISMATCH],
+        licenceUser: {
+          deliusId: 123,
+          email: 'user@gov.uk',
+          nomisId: 'user-1',
+        },
+      })
+    })
+  })
+
+  test('get staff details, missing accounts in auth and delius', async () => {
+    userAdminService.getRoUser.mockResolvedValue({ deliusId: 123, nomisId: 'user-1', email: 'user@gov.uk' })
+
+    nomisClient.getAuthUser.mockResolvedValue(null)
+
+    deliusClient.getStaffDetailsByStaffCode.mockResolvedValue(null)
+
+    const result = await migrationService.getStaffDetails('user-1')
+
+    expect(result).toStrictEqual({
+      authUser: null,
+      deliusUser: null,
+      flags: [Flag.MISSING_DELIUS_USER, Flag.MISSING_AUTH_USER],
+      licenceUser: {
+        deliusId: 123,
+        email: 'user@gov.uk',
+        nomisId: 'user-1',
+      },
+    })
+  })
+
+  test('get staff details, multiple RO roles', async () => {
+    userAdminService.getRoUser.mockResolvedValue({ deliusId: 123, nomisId: 'user-1', email: 'user@gov.uk' })
+
+    nomisClient.getAuthUser.mockResolvedValue({ username: 'user-1', enabled: true })
+    nomisClient.getAuthUserRoles.mockResolvedValue([{ roleCode: 'LICENCES_RO' }, { roleCode: 'LICENCES_CA' }])
+    deliusClient.getStaffDetailsByStaffCode.mockResolvedValue({ username: 'user-1', email: 'user@gov.uk' })
+    deliusClient.getUser.mockResolvedValue({
+      roles: [{ name: delius.responsibleOfficerRoleId }],
+      enabled: true,
+    })
+
+    const result = await migrationService.getStaffDetails('user-1')
+
+    expect(result).toStrictEqual({
+      authUser: {
+        enabled: true,
+        roles: ['LICENCES_RO', 'LICENCES_CA'],
+        username: 'user-1',
+      },
+      deliusUser: {
+        username: 'user-1',
+        email: 'user@gov.uk',
+      },
+      flags: [Flag.MULTIPLE_NOMIS_ROLES],
+      licenceUser: {
+        deliusId: 123,
+        nomisId: 'user-1',
+        email: 'user@gov.uk',
+      },
+    })
+  })
+})

--- a/types/delius.d.ts
+++ b/types/delius.d.ts
@@ -98,4 +98,5 @@ export interface DeliusClient {
   getAllLdusForProbationArea: (probationAreaCode: string) => Promise<Page<Ldu>>
   getAllTeamsForLdu: (probationAreaCode: string, lduCode: string) => Promise<Page<ProbationTeam>>
   addResponsibleOfficerRole: (username: string) => Promise<void>
+  getUser: (username: string) => Promise<any>
 }


### PR DESCRIPTION
Also exposing admin only endpoint to allow extracting info to work out what state RO users are in prod.

We're going to look to see:
* how many licence staff records we can delete straight away (if they are linked to missing or disabled auth users for instance)
* how many licence staff we can automatically migrate over

There will also be some users that will require some manual intervention to migrate over:
* Users with unlinked accounts
* Incorrect contact details
* Users that don't have delius accounts (e.g: app support)
* Vary users
* Possibly others

