### PR TITLE
DCS-379 Handling case when auth fails to load user data. 

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -347,7 +347,7 @@ module.exports = function createApp({
   app.use('/admin/', secureRoute(adminRouter()))
   app.use(
     '/admin/roUsers/',
-    secureRoute(userAdminRouter({ userAdminService, signInService, migrationService }), { auditKey: 'MAINTENANCE' })
+    secureRoute(userAdminRouter({ userAdminService, signInService, migrationService }), { auditKey: 'MIGRATION' })
   )
   app.use('/admin/mailboxes/', secureRoute(mailboxesAdminRouter({ configClient })))
   app.use('/admin/jobs/', secureRoute(jobsAdminRouter({ jobSchedulerService })))

--- a/server/data/audit.js
+++ b/server/data/audit.js
@@ -14,6 +14,7 @@ const keys = [
   'LICENCE_SEARCH',
   'LOCATIONS',
   'FUNCTIONAL_MAILBOX',
+  'MIGRATION',
 ]
 
 /**

--- a/test/services/migrationService.test.ts
+++ b/test/services/migrationService.test.ts
@@ -208,4 +208,31 @@ describe('MigrationService', () => {
       },
     })
   })
+
+  test('get staff details, error calling auth', async () => {
+    userAdminService.getRoUser.mockResolvedValue({ deliusId: 123, nomisId: 'user-1', email: 'user@gov.uk' })
+
+    nomisClient.getAuthUser.mockRejectedValue(Error('bang!'))
+    deliusClient.getStaffDetailsByStaffCode.mockResolvedValue({ username: 'user-1', email: 'user@gov.uk' })
+    deliusClient.getUser.mockResolvedValue({
+      roles: [{ name: delius.responsibleOfficerRoleId }],
+      enabled: true,
+    })
+
+    const result = await migrationService.getStaffDetails('user-1')
+
+    expect(result).toStrictEqual({
+      authUser: undefined,
+      deliusUser: {
+        username: 'user-1',
+        email: 'user@gov.uk',
+      },
+      flags: [Flag.AUTH_CANNOT_LOAD],
+      licenceUser: {
+        deliusId: 123,
+        nomisId: 'user-1',
+        email: 'user@gov.uk',
+      },
+    })
+  })
 })


### PR DESCRIPTION
These load errors  happen due to duplicate records in delius non unique errors being thrown

There is most likely only one user in this state in prod which will need fixing but its preventing loading the rest of the records on their 'page'