### PR TITLE
DCS-595 Admin page /admin/delius/managedOffenders is broken

### DIFF
--- a/server/views/admin/delius/managedOffenders.pug
+++ b/server/views/admin/delius/managedOffenders.pug
@@ -22,7 +22,8 @@ block content
             th First name
             th Last name
         tbody
-          each offender in offenders
+          - var prisoners = offenders
+          each offender in prisoners
             tr
               td #{offender.bookingId}
               td #{offender.offenderNo}


### PR DESCRIPTION
Bug in pug 3.0.0.
Can't use a variable that starts with 'of' in an iteration expression. eg `each offender in offenders`. 
See  https://github.com/pugjs/pug/pull/3274