### PR TITLE
DCS-590 Extend statistics collection - No production changes

### DIFF
--- a/server/statistics/AuditStatisticsCollector.ts
+++ b/server/statistics/AuditStatisticsCollector.ts
@@ -62,7 +62,9 @@ export class AuditStatisticsCollector implements RowConsumer<AuditRow> {
         return Event.dmToCaReturn
 
       case 'roToCa':
-        return Event.roToCa
+        return this.getBookingState(details.bookingId).booking.getApprovedPremises()
+          ? Event.roToCaApprovedPremises
+          : Event.roToCa
 
       case 'roToCaAddressRejected':
         return Event.roToCaAddressRejected

--- a/server/statistics/booking.ts
+++ b/server/statistics/booking.ts
@@ -33,6 +33,8 @@ export default class Booking {
 
   private addressChoice?: AddressChoice
 
+  private approvedPremises?: boolean
+
   private event: Event
 
   /**
@@ -68,6 +70,30 @@ export default class Booking {
       this.addressChoice = AddressChoice.Address
     } else if (hasPath(details, '/hdc/bassReferral/bassRequest/')) {
       this.addressChoice = AddressChoice.Bass
+    } else if (hasPath(details, '/hdc/bassReferral/bassAreaCheck')) {
+      if (details?.userInput?.bassAreaCheckSeen === 'true') {
+        switch (details?.userInput?.approvedPremisesRequiredYesNo) {
+          case 'Yes':
+            this.approvedPremises = true
+            break
+          case 'No':
+            this.approvedPremises = false
+            break
+          default:
+            break
+        }
+      }
+    } else if (hasPath(details, '/hdc/curfew/approvedPremises')) {
+      switch (details?.userInput?.required) {
+        case 'Yes':
+          this.approvedPremises = true
+          break
+        case 'No':
+          this.approvedPremises = false
+          break
+        default:
+          break
+      }
     }
   }
 
@@ -91,5 +117,9 @@ export default class Booking {
 
   getAddressChoice(): AddressChoice {
     return this.addressChoice
+  }
+
+  getApprovedPremises(): boolean {
+    return this.approvedPremises === true
   }
 }

--- a/server/statistics/types.ts
+++ b/server/statistics/types.ts
@@ -68,6 +68,7 @@ export enum Event {
 
   roToCa = 'RO -> CA',
   roToCaAddressRejected = 'RO -> CA (Rej)',
+  roToCaApprovedPremises = 'RO -> CA (AP)',
 
   pdfLicence = 'PDF Licence',
 


### PR DESCRIPTION
Account for cases sent from RO to CA with approved premises selected.
This only affects the statistics collection scripts and does not affect any production code.