### PR TITLE
DCS-609 Adding fallback to load RO caseload

### DIFF
--- a/migrations/20200818182127_add-delius-username-to-staff-id.js
+++ b/migrations/20200818182127_add-delius-username-to-staff-id.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('staff_ids', (table) => {
+    table.string('delius_username').nullable()
+  })
+  await knex.schema.raw('CREATE OR REPLACE VIEW v_staff_ids AS SELECT * FROM staff_ids where deleted is false;')
+}
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('staff_ids', (table) => {
+    table.dropColumn('delius_username')
+  })
+  await knex.schema.raw('CREATE OR REPLACE VIEW v_staff_ids AS SELECT * FROM staff_ids where deleted is false;')
+}

--- a/server/data/licenceClient.ts
+++ b/server/data/licenceClient.ts
@@ -1,6 +1,6 @@
 import { LicenceStage } from '../services/config/licenceStage'
 import * as db from './dataAccess/db'
-import { ApprovedLicenceVersion, CaseWithApprovedVersion, CaseWithVaryVersion, DeliusId } from './licenceClientTypes'
+import { ApprovedLicenceVersion, CaseWithApprovedVersion, CaseWithVaryVersion, DeliusIds } from './licenceClientTypes'
 import { Licence } from './licenceTypes'
 
 async function updateVersion(bookingId, postRelease = false): Promise<void> {
@@ -131,9 +131,10 @@ export class LicenceClient {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async getDeliusUserName(nomisUserName): Promise<DeliusId[]> {
+  async getDeliusIds(nomisUserName): Promise<DeliusIds[]> {
     const query = {
-      text: 'select staff_id from v_staff_ids where upper(nomis_id) = upper($1)',
+      text:
+        'select staff_id "staffCode", delius_username "deliusUsername" from v_staff_ids where upper(nomis_id) = upper($1)',
       values: [nomisUserName],
     }
 

--- a/server/data/licenceClientTypes.ts
+++ b/server/data/licenceClientTypes.ts
@@ -23,6 +23,7 @@ export interface ApprovedLicenceVersion {
   timestamp: Date
 }
 
-export interface DeliusId {
-  staff_id: string
+export interface DeliusIds {
+  staffCode: string
+  deliusUsername?: string
 }

--- a/server/data/userClient.js
+++ b/server/data/userClient.js
@@ -71,12 +71,13 @@ module.exports = {
     email,
     orgEmail,
     telephone,
-    onboarded
+    onboarded,
+    deliusUsername
   ) {
     const query = {
       text: `update v_staff_ids
                     set nomis_id = $2, staff_id = $3, first_name = $4, last_name = $5,
-                    organisation = $6, job_role = $7, email = $8, org_email = $9, telephone = $10, auth_onboarded = $11
+                    organisation = $6, job_role = $7, email = $8, org_email = $9, telephone = $10, auth_onboarded = $11, delius_username = $12
                     where nomis_id = $1`,
       values: [
         originalNomisId,
@@ -90,6 +91,7 @@ module.exports = {
         orgEmail,
         telephone,
         onboarded,
+        deliusUsername,
       ],
     }
 
@@ -105,12 +107,36 @@ module.exports = {
     return db.query(query)
   },
 
-  async addRoUser(nomisId, deliusId, first, last, organisation, jobRole, email, orgEmail, telephone, onboarded) {
+  async addRoUser(
+    nomisId,
+    deliusId,
+    first,
+    last,
+    organisation,
+    jobRole,
+    email,
+    orgEmail,
+    telephone,
+    onboarded,
+    deliusUsername
+  ) {
     const query = {
       text: `insert into v_staff_ids
-                (nomis_id, staff_id, first_name, last_name, organisation, job_role, email, org_email, telephone, auth_onboarded)
-                values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-      values: [nomisId, deliusId, first, last, organisation, jobRole, email, orgEmail, telephone, onboarded],
+                (nomis_id, staff_id, first_name, last_name, organisation, job_role, email, org_email, telephone, auth_onboarded, delius_username)
+                values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+      values: [
+        nomisId,
+        deliusId,
+        first,
+        last,
+        organisation,
+        jobRole,
+        email,
+        orgEmail,
+        telephone,
+        onboarded,
+        deliusUsername,
+      ],
     }
 
     return db.query(query)
@@ -148,6 +174,7 @@ function convertPropertyNames(user) {
     ? {
         nomisId: user.nomis_id,
         deliusId: user.staff_id,
+        deliusUsername: user.delius_username,
         first: user.first_name,
         last: user.last_name,
         organisation: user.organisation,

--- a/server/routes/admin/delius.js
+++ b/server/routes/admin/delius.js
@@ -22,7 +22,7 @@ module.exports = (roService) => (router) => {
     asyncMiddleware(async (req, res) => {
       const { staffCode } = req.body
       logger.info('managedOffenders for', staffCode)
-      const offenders = await roService.getROPrisoners(staffCode, res.locals.token)
+      const offenders = (await roService.getROPrisoners(staffCode, res.locals.token)) || []
       logger.info(offenders)
 
       res.render('admin/delius/managedOffenders', { offenders })

--- a/server/services/roService.js
+++ b/server/services/roService.js
@@ -16,7 +16,7 @@ const { NO_OFFENDER_NUMBER, NO_COM_ASSIGNED, STAFF_NOT_PRESENT } = require('./se
 module.exports = function createRoService(deliusClient, nomisClientBuilder) {
   async function getROPrisonersFromDelius(staffCode) {
     try {
-      return (await deliusClient.getROPrisoners(staffCode)) || []
+      return await deliusClient.getROPrisoners(staffCode)
     } catch (error) {
       logger.error(`Problem retrieving RO prisoners for: ${staffCode}`, error.stack)
       throw error
@@ -46,6 +46,10 @@ module.exports = function createRoService(deliusClient, nomisClientBuilder) {
     async getROPrisoners(staffCode, token) {
       const nomisClient = nomisClientBuilder(token)
       const requiredPrisoners = await getROPrisonersFromDelius(staffCode)
+      if (!requiredPrisoners) {
+        return null
+      }
+
       const requiredIDs = requiredPrisoners
         .filter((prisoner) => prisoner.nomsNumber)
         .map((prisoner) => prisoner.nomsNumber)

--- a/server/services/userAdminService.js
+++ b/server/services/userAdminService.js
@@ -10,6 +10,7 @@ module.exports = function createUserService(nomisClientBuilder, userClient, prob
     originalNomisId,
     {
       nomisId,
+      deliusUsername,
       originalDeliusId,
       deliusId,
       first,
@@ -50,7 +51,8 @@ module.exports = function createUserService(nomisClientBuilder, userClient, prob
       email,
       orgEmail,
       telephone,
-      onboarded
+      onboarded,
+      deliusUsername
     )
   }
 

--- a/server/views/admin/users/roUserDetails.pug
+++ b/server/views/admin/users/roUserDetails.pug
@@ -29,6 +29,10 @@ block content
           div.form-group
             label.form-label(for="nomisId") Nomis Username
             input#nomisId.form-control(name="nomisId" type="text" value=inputs.nomisId)
+        div.pure-u-1.pure-u-md-4-5
+          div.form-group
+            label.form-label(for="deliusUsername") Delius Username
+            input#nomisId.form-control(name="deliusUsername" type="text" value=inputs.deliusUsername)
 
       div.pure-u-1.pure-u-md-2-5
         div.pure-u-1.pure-u-md-4-5

--- a/test/data/licenceClient.test.ts
+++ b/test/data/licenceClient.test.ts
@@ -174,15 +174,15 @@ describe('licenceClient', () => {
     })
   })
 
-  describe('getDeliusUserName', () => {
+  describe('getDeliusIds', () => {
     test('should call db.query', () => {
-      licenceClient.getDeliusUserName(5)
+      licenceClient.getDeliusIds(5)
       expect(db.query).toHaveBeenCalled()
     })
 
     test('should pass in the correct params and do case-insensitive search', async () => {
       const expectedClause = 'where upper(nomis_id) = upper($1)'
-      await licenceClient.getDeliusUserName(5)
+      await licenceClient.getDeliusIds(5)
 
       const { text, values } = db.query.mock.calls[0][0]
       expect(text).toContain(expectedClause)

--- a/test/data/userClient.test.js
+++ b/test/data/userClient.test.js
@@ -141,7 +141,8 @@ describe('userClient', () => {
         'email',
         'orgEmail',
         'phone',
-        'onboarded'
+        'onboarded',
+        'deliusUsername'
       )
 
       const call = db.query.mock.calls[0][0]
@@ -157,6 +158,7 @@ describe('userClient', () => {
         'orgEmail',
         'phone',
         'onboarded',
+        'deliusUsername',
       ])
     })
   })
@@ -185,7 +187,8 @@ describe('userClient', () => {
         'email',
         'orgEmail',
         'phone',
-        'onboarded'
+        'onboarded',
+        'deliusUsername'
       )
 
       const call = db.query.mock.calls[0][0]
@@ -200,6 +203,7 @@ describe('userClient', () => {
         'orgEmail',
         'phone',
         'onboarded',
+        'deliusUsername',
       ])
     })
   })

--- a/test/services/licenceService.test.ts
+++ b/test/services/licenceService.test.ts
@@ -30,7 +30,7 @@ describe('licenceService', () => {
       deleteAll: undefined,
       deleteAllTest: undefined,
       getLicences: undefined,
-      getDeliusUserName: undefined,
+      getDeliusIds: undefined,
       saveApprovedLicenceVersion: undefined,
       getLicencesInStageBetweenDates: undefined,
       getLicencesInStageBeforeDate: undefined,

--- a/test/services/roService.test.js
+++ b/test/services/roService.test.js
@@ -84,7 +84,7 @@ describe('roService', () => {
     test('should return empty array when staff member not found in delius', async () => {
       deliusClient.getROPrisoners.mockResolvedValue(undefined)
       const result = await service.getROPrisoners(123, 'token')
-      expect(result).toEqual([])
+      expect(result).toEqual(null)
     })
   })
 

--- a/test/services/userAdminService.test.js
+++ b/test/services/userAdminService.test.js
@@ -104,10 +104,11 @@ describe('userAdminService', () => {
         orgEmail: 9,
         telephone: 10,
         onboarded: 11,
+        deliusUsername: 12,
       })
 
       expect(userClient.updateRoUser).toHaveBeenCalled()
-      expect(userClient.updateRoUser).toHaveBeenCalledWith('nomisId', 1, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+      expect(userClient.updateRoUser).toHaveBeenCalledWith('nomisId', 1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
     })
   })
 


### PR DESCRIPTION
Currently to build up the RO caselist, we look up offender data using a staff code

1.) We initially search the local staff table for a mapping from auth user to delius staff code
2.) If that fails, we make a request to delius to find the staff code for the currently logged in user.

After the probation area split on the weekend, new staff codes will be generated so our mappings in 1.) will
become out of date. We hoped to migrate these users to use delius credentials to access these services but
unfortunately have not had time to organise comms.

To get round this, this change will store the users currently mapped delius username in the local db.
It will then use this as a fallback when 1.) and 2.) fail to allow retrieval of an appropriate staff code
which can then be used to retrieve additional data.