### PR TITLE
DCS-590 :bug: :white_check_mark:  BASS request + Approved Premises problem

### DIFF
--- a/server/routes/viewModels/taskLists/tasks/bassAddress.js
+++ b/server/routes/viewModels/taskLists/tasks/bassAddress.js
@@ -86,12 +86,12 @@ const getOfferAction = ({ decisions, tasks }) => {
   const { bassWithdrawn, approvedPremisesRequired } = decisions
   const { bassAreaCheck, bassOffer, optOut, curfewAddress, bassRequest } = tasks
 
-  if (bassWithdrawn) {
-    return change('/hdc/bassReferral/bassOffer/', 'bass-address')
+  if (approvedPremisesRequired === true) {
+    return viewEdit('/hdc/bassReferral/approvedPremisesChoice/', 'approved-premises-choice')
   }
 
-  if (approvedPremisesRequired === true) {
-    return viewEdit('/hdc/bassReferral/approvedPremisesChoice/')
+  if (bassWithdrawn) {
+    return change('/hdc/bassReferral/bassOffer/', 'bass-address')
   }
 
   if (bassAreaCheck === 'DONE') {

--- a/server/routes/viewModels/taskLists/tasks/bassAddress.js
+++ b/server/routes/viewModels/taskLists/tasks/bassAddress.js
@@ -90,7 +90,7 @@ const getOfferAction = ({ decisions, tasks }) => {
     return change('/hdc/bassReferral/bassOffer/', 'bass-address')
   }
 
-  if (bassAreaCheck === 'DONE' && approvedPremisesRequired === true) {
+  if (approvedPremisesRequired === true) {
     return viewEdit('/hdc/bassReferral/approvedPremisesChoice/')
   }
 

--- a/server/services/licence/caTransitions.ts
+++ b/server/services/licence/caTransitions.ts
@@ -31,7 +31,7 @@ function canSendCaToRo(licenceStatus: LicenceStatus) {
 
   if ([PROCESSING_CA, MODIFIED, MODIFIED_APPROVAL].includes(stage)) {
     if (bassReferralNeeded) {
-      if (licenceStatus.tasks.bassAreaCheck === TaskState.UNSTARTED) {
+      if (!approvedPremisesRequired && licenceStatus.tasks.bassAreaCheck === TaskState.UNSTARTED) {
         return true
       }
     } else if (!optedOut && !approvedPremisesRequired && tasks.curfewAddressReview === TaskState.UNSTARTED) {

--- a/test/routes/viewModels/taskListModelsCA.test.js
+++ b/test/routes/viewModels/taskListModelsCA.test.js
@@ -134,6 +134,7 @@ describe('TaskList models', () => {
       href: '/hdc/bassReferral/approvedPremisesChoice/',
       text: 'View/Edit',
       type: 'btn-secondary',
+      dataQa: 'approved-premises-choice',
     },
   }
 

--- a/test/services/licence/caTransitions.test.ts
+++ b/test/services/licence/caTransitions.test.ts
@@ -116,6 +116,46 @@ describe('getAllowedTransition', () => {
       expect(allowed).toBe('caToRo')
     })
 
+    test('Should be any transitions when in the PROCESSING_CA for BASS when BASS area check not done, but approved premises required', () => {
+      const status = {
+        stage: LicenceStage.PROCESSING_CA,
+        postApproval: false,
+        tasks: {
+          curfewAddress: TaskState.UNSTARTED,
+          bassOffer: TaskState.DONE,
+          bassAreaCheck: TaskState.UNSTARTED,
+        },
+        decisions: {
+          bassReferralNeeded: true,
+          approvedPremisesRequired: true,
+        },
+      }
+
+      const allowed = getAllowedTransition(status)
+
+      expect(allowed).toBeNull()
+    })
+
+    test('Should be any transitions when in the MODIFIED stage for BASS when BASS area check not done, but approved premises required', () => {
+      const status = {
+        stage: LicenceStage.MODIFIED,
+        postApproval: true,
+        tasks: {
+          curfewAddress: TaskState.UNSTARTED,
+          bassOffer: TaskState.DONE,
+          bassAreaCheck: TaskState.UNSTARTED,
+        },
+        decisions: {
+          bassReferralNeeded: true,
+          approvedPremisesRequired: true,
+        },
+      }
+
+      const allowed = getAllowedTransition(status)
+
+      expect(allowed).toBeNull()
+    })
+
     test('should allow CA to RO when address review has not been started', () => {
       const status = {
         stage: LicenceStage.PROCESSING_CA,


### PR DESCRIPTION
:bug:
Prison submitted BASS area to RO.
RO updated to AP required and had added the AP address.
Only the original BASS area address is visible to the CA at the prison when expecting to see Approved Premises address.

:white_check_mark: 
Fixed this bug and added some tests to guard against regressions. 
All tests and integration tests pass but test coverage is poor to non-existent for BASS + Approved Premises.  
This change might have broken some other part of the application but I have tested the main flows in this area by hand and they all seem correct.
