### PR TITLE
DCS-613 Adding screens to allow app support to manage users HDC specific delius roles

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,6 +29,7 @@ const defaultRouter = require('./routes/default')
 
 const adminRouter = require('./routes/admin/admin')
 const userAdminRouter = require('./routes/admin/users')
+const manageRolesRouter = require('./routes/admin/manageRoles')
 const mailboxesAdminRouter = require('./routes/admin/mailboxes')
 const jobsAdminRouter = require('./routes/admin/jobs')
 const deliusAdminRouter = require('./routes/admin/delius')
@@ -347,8 +348,9 @@ module.exports = function createApp({
   app.use('/admin/', secureRoute(adminRouter()))
   app.use(
     '/admin/roUsers/',
-    secureRoute(userAdminRouter({ userAdminService, signInService, migrationService }), { auditKey: 'MIGRATION' })
+    secureRoute(userAdminRouter({ userAdminService, signInService, migrationService }), { auditKey: 'USER_MANAGEMENT' })
   )
+  app.use('/admin/manage-roles/', secureRoute(manageRolesRouter(migrationService), { auditKey: 'USER_MANAGEMENT' }))
   app.use('/admin/mailboxes/', secureRoute(mailboxesAdminRouter({ configClient })))
   app.use('/admin/jobs/', secureRoute(jobsAdminRouter({ jobSchedulerService })))
   app.use('/admin/delius/', secureRoute(deliusAdminRouter(roService)))

--- a/server/config.js
+++ b/server/config.js
@@ -67,8 +67,10 @@ module.exports = {
       freeSocketTimeout: 30000,
     },
     apiPrefix: get('DELIUS_API_PREFIX', '/api'),
-    // this refers to the 'HDC Digital Update' RBAC which is mapped to LICENCE_RO in the auth server
+    // this refers to the 'HDC Digital Update' RBAC which is mapped to LICENCE_RO and GLOBAL_SEARCH in the auth server
     responsibleOfficerRoleId: get('DELIUS_RO_ROLE_ID', 'LHDCBT002'),
+    // this refers to the 'HDC Digital Update' RBAC which is mapped to LICENCE_RO, GLOBAL_SEARCH and LICENCE_VARY in the auth server
+    responsibleOfficerVaryRoleId: get('DELIUS_RO_VARY_ROLE_ID', 'LHDCBT003'),
   },
 
   probationTeams: {

--- a/server/data/audit.js
+++ b/server/data/audit.js
@@ -14,7 +14,6 @@ const keys = [
   'LICENCE_SEARCH',
   'LOCATIONS',
   'FUNCTIONAL_MAILBOX',
-  'MIGRATION',
 ]
 
 /**

--- a/server/data/deliusClient.ts
+++ b/server/data/deliusClient.ts
@@ -1,5 +1,6 @@
 import { DeliusClient } from '../../types/delius'
 import config from '../config'
+import user from '../routes/user'
 
 // eslint-disable-next-line import/prefer-default-export
 export const createDeliusClient = (restClient): DeliusClient => {
@@ -37,8 +38,12 @@ export const createDeliusClient = (restClient): DeliusClient => {
     },
 
     async addResponsibleOfficerRole(username) {
+      await this.addRole(username, config.delius.responsibleOfficerRoleId)
+    },
+
+    async addRole(username, code) {
       try {
-        await restClient.putResource(`/users/${username}/roles/${config.delius.responsibleOfficerRoleId}`, '')
+        await restClient.putResource(`/users/${username}/roles/${code}`, '')
       } catch (error) {
         // Do nothing
       }

--- a/server/routes/admin/manageRoles.js
+++ b/server/routes/admin/manageRoles.js
@@ -1,0 +1,66 @@
+const logger = require('../../../log')
+const { asyncMiddleware, authorisationMiddleware } = require('../../utils/middleware')
+const { firstItem } = require('../../utils/functionalHelpers')
+const {
+  delius: { responsibleOfficerRoleId, responsibleOfficerVaryRoleId },
+} = require('../../config')
+
+const codes = {
+  [responsibleOfficerRoleId]: 'RO',
+  [responsibleOfficerVaryRoleId]: 'VARY',
+}
+
+module.exports = (migrationService) => (router) => {
+  router.use(authorisationMiddleware)
+
+  router.get(
+    '/',
+    asyncMiddleware(async (req, res) => {
+      const errors = firstItem(req.flash('errors')) || {}
+      return res.render('admin/manageRoles/index', { errors })
+    })
+  )
+
+  router.post(
+    '/',
+    asyncMiddleware(async (req, res) => {
+      const { deliusUsername } = req.body
+      return res.redirect(`/admin/manage-roles/${deliusUsername}`)
+    })
+  )
+
+  router.get(
+    '/:deliusUsername',
+    asyncMiddleware(async (req, res) => {
+      const { deliusUsername } = req.params
+      const roles = await migrationService.getDeliusRoles(deliusUsername)
+      if (!roles) {
+        req.flash('errors', { deliusUsername: `User '${deliusUsername}' does not exist` })
+        return res.redirect(`/admin/manage-roles`)
+      }
+      const currentRoles = roles.map((r) => codes[r])
+      const rolesToSelect = Object.keys(codes)
+        .filter((key) => !currentRoles.includes(codes[key]))
+        .reduce((obj, key) => ({ ...obj, [key]: codes[key] }), {})
+
+      return res.render('admin/manageRoles/viewUserRoles', { deliusUsername, errors: {}, currentRoles, rolesToSelect })
+    })
+  )
+
+  router.post(
+    '/:deliusUsername/roles',
+    asyncMiddleware(async (req, res) => {
+      const { deliusUsername } = req.params
+      const { role } = req.body
+
+      if (role) {
+        logger.info(`'${req.user.username}' is adding role '${role}' to delius user '${deliusUsername}'`)
+        await migrationService.addDeliusRole(deliusUsername, role)
+      }
+
+      return res.redirect(`/admin/manage-roles/${deliusUsername}`)
+    })
+  )
+
+  return router
+}

--- a/server/services/migrationService.ts
+++ b/server/services/migrationService.ts
@@ -96,6 +96,21 @@ export default class MigrationService {
     await this.deliusClient.addResponsibleOfficerRole(deliusRo.username)
   }
 
+  public async addDeliusRole(deliusUsername: string, role: string) {
+    await this.deliusClient.addRole(deliusUsername, role)
+  }
+
+  public async getDeliusRoles(deliusUsername): Promise<string[]> {
+    const user = await this.getUserFromDelius(deliusUsername)
+    if (!user) {
+      return null
+    }
+    const deliusRoles = user.roles || []
+    return deliusRoles
+      .map((r) => r.name)
+      .filter((r) => [config.delius.responsibleOfficerRoleId, config.delius.responsibleOfficerVaryRoleId].includes(r))
+  }
+
   public async disableAuthAccount(token, nomisUsername) {
     const nomisClient = this.nomisClientBuilder(token)
     await nomisClient.disableAuthUser(nomisUsername)

--- a/server/views/admin/index.pug
+++ b/server/views/admin/index.pug
@@ -14,6 +14,8 @@ block content
       div
         a(href='/admin/delius') Delius API search
       div
+        a(href='/admin/manage-roles') Manage delius roles
+      div
         a(href='/admin/warnings/outstanding') View Warnings
       div
         a(href='/admin/locations/probation-areas') Manage locations

--- a/server/views/admin/manageRoles/index.pug
+++ b/server/views/admin/manageRoles/index.pug
@@ -1,0 +1,21 @@
+extends ../../layout
+include ../../includes/errorBannerWithDetail
+
+block content
+
+  div.back-link-container.smallPaddingTop
+    a#back.link-back(href="javascript: window.history.back();") Back
+  +errorBannerWithDetail(errors, [
+    { field: 'deliusUsername' }
+  ])
+
+  h2.heading-large
+    | View roles for Delius username
+    
+  div.pure-g.largePaddingBottom
+      div.pure-u-1-2
+        div
+          form(method='POST', action='/admin/manage-roles')
+              input(type="hidden" name="_csrf" value=csrfToken)
+              input(name="deliusUsername" value=deliusUsername autofocus aria-label="Delius username" class=errors.deliusUsername ? "form-control form-control-error" : "form-control")
+              input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Search")

--- a/server/views/admin/manageRoles/viewUserRoles.pug
+++ b/server/views/admin/manageRoles/viewUserRoles.pug
@@ -1,0 +1,42 @@
+extends ../../layout
+include ../../includes/errorBannerWithDetail
+
+block content
+
+  div.back-link-container.smallPaddingTop
+    a#back.link-back(href="/admin/manage-roles") Back
+  +errorBannerWithDetail(errors, [
+    { field: 'deliusUsername' }
+  ])
+
+  h2.heading-large
+    | Roles for username: #{deliusUsername} 
+
+  h3.heading-medium
+    | Current Roles:
+  
+  if currentRoles.length > 0
+    table#list.largeMarginBottom
+      thead
+        tr
+          th.sortable Role
+      tbody
+          each role in currentRoles
+            tr
+              td
+                | #{role}
+  else
+    p No delius roles present               
+
+  if Object.keys(rolesToSelect).length !== 0
+    form(method='POST', action='/admin/manage-roles/' + deliusUsername + '/roles' )
+      div.pure-u-1.pure-u-sm-2-5
+        div.form-group
+          label.form-label(for="selectRole") Select role
+          select.form-control#selectRole(name="role")
+            option(value="" disabled selected) -- select --
+            for role, code in rolesToSelect
+              option(value=code) #{role}
+          
+          input(type="hidden" name="_csrf" value=csrfToken)
+          input#continueBtn.requiredButton.button.smallMarginTop(type="submit" value="Add role")

--- a/test/data/deliusClient.test.js
+++ b/test/data/deliusClient.test.js
@@ -169,8 +169,6 @@ describe('deliusClient', () => {
     test('should return data from api', () => {
       fakeDelius.put(`/users/bobUser/roles/${config.delius.responsibleOfficerRoleId}`).reply(200)
 
-      // The only place where addResponsibleOfficerRole is used is in roNotificationHandler.assignDeliusRoRole
-      // The assignDeliusRoRole function ignores the return value.
       return expect(deliusClient.addResponsibleOfficerRole('bobUser')).resolves.toBeUndefined()
     })
 
@@ -178,6 +176,20 @@ describe('deliusClient', () => {
       fakeDelius.put(`/users/bobUser/roles/${config.delius.responsibleOfficerRoleId}`).reply(500)
 
       return expect(deliusClient.addResponsibleOfficerRole('bobUser')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('addRole', () => {
+    test('should return data from api', () => {
+      fakeDelius.put(`/users/bobUser/roles/CODE-1`).reply(200)
+
+      return expect(deliusClient.addRole('bobUser', 'CODE-1')).resolves.toBeUndefined()
+    })
+
+    test('should ignore errors', () => {
+      fakeDelius.put(`/users/bobUser/roles/CODE-1`).reply(500)
+
+      return expect(deliusClient.addRole('bobUser', 'CODE-1')).resolves.toBeUndefined()
     })
   })
 

--- a/test/mockClients.ts
+++ b/test/mockClients.ts
@@ -31,6 +31,7 @@ export interface DeliusClientMock extends DeliusClient {
 
 export const mockDeliusClient: () => DeliusClientMock = () => ({
   addResponsibleOfficerRole: jest.fn(),
+  addRole: jest.fn(),
   getAllLdusForProbationArea: jest.fn(),
   getAllOffenderManagers: jest.fn(),
   getAllProbationAreas: jest.fn(),

--- a/test/routes/admin/manageRoles.test.ts
+++ b/test/routes/admin/manageRoles.test.ts
@@ -1,0 +1,140 @@
+import request from 'supertest'
+import { mockAudit } from '../../mockClients'
+import { startRoute } from '../../supertestSetup'
+import createManageRoles from '../../../server/routes/admin/manageRoles'
+import config from '../../../server/config'
+
+const {
+  delius: { responsibleOfficerRoleId, responsibleOfficerVaryRoleId },
+} = config
+
+describe('/manage-roles', () => {
+  let migrationService
+
+  beforeEach(() => {
+    migrationService = {
+      getDeliusRoles: jest.fn(),
+      addDeliusRole: jest.fn(),
+    }
+  })
+
+  const createApp = (user, audit = mockAudit()) =>
+    startRoute(createManageRoles(migrationService), '/admin/manage-roles', user, 'USER_MANAGEMENT', null, audit)
+
+  describe('GET /admin/manage-roles', () => {
+    test('calls user service and renders HTML output', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/manage-roles')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain('View roles for Delius username')
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app).get('/admin/manage-roles').expect(403)
+    })
+  })
+
+  describe('POST /', () => {
+    test('calls user service and renders HTML output', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .post('/admin/manage-roles')
+        .send({ deliusUsername: 'BOB' })
+        .expect(302)
+        .expect('Location', '/admin/manage-roles/BOB')
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app).post('/admin/manage-roles').send({ deliusUsername: 'BOB' }).expect(403)
+    })
+  })
+
+  describe('GET /admin/manage-roles/BOB', () => {
+    test('Gathers roles and renders HTML output', () => {
+      const app = createApp('batchUser')
+      migrationService.getDeliusRoles.mockResolvedValue([responsibleOfficerRoleId, responsibleOfficerVaryRoleId])
+      return request(app)
+        .get('/admin/manage-roles/BOB')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain('Roles for username: BOB')
+          expect(res.text).toContain('<td>RO</td>')
+          expect(res.text).toContain('<td>VARY</td>')
+        })
+    })
+    test('Gathers no roles and renders HTML output', () => {
+      const app = createApp('batchUser')
+      migrationService.getDeliusRoles.mockResolvedValue([])
+      return request(app)
+        .get('/admin/manage-roles/BOB')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain('No delius roles present')
+        })
+    })
+
+    test('When more roles can be added', () => {
+      const app = createApp('batchUser')
+      migrationService.getDeliusRoles.mockResolvedValue([responsibleOfficerRoleId])
+      return request(app)
+        .get('/admin/manage-roles/BOB')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain('Roles for username: BOB')
+          expect(res.text).toContain('<td>RO</td>')
+          expect(res.text).toContain('<option value="LHDCBT003">VARY</option>')
+        })
+    })
+
+    test('Redirects back to search page When invalid username', () => {
+      const app = createApp('batchUser')
+      migrationService.getDeliusRoles.mockResolvedValue(null)
+      return request(app).get('/admin/manage-roles/BOB').expect(302).expect('Location', '/admin/manage-roles')
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app).get('/admin/manage-roles/BOB').expect(403)
+    })
+  })
+
+  describe('POST /admin/manage-roles/BOB/roles', () => {
+    test('Adds a role and redirects to view role page', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .post('/admin/manage-roles/BOB/roles')
+        .send({ role: responsibleOfficerRoleId })
+        .expect(302)
+        .expect('Location', '/admin/manage-roles/BOB')
+        .expect(() => {
+          expect(migrationService.addDeliusRole).toBeCalledWith('BOB', responsibleOfficerRoleId)
+        })
+    })
+
+    test('Does not select a role and redirects to view role page', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .post('/admin/manage-roles/BOB/roles')
+        .send({})
+        .expect(302)
+        .expect('Location', '/admin/manage-roles/BOB')
+        .expect(() => {
+          expect(migrationService.addDeliusRole).not.toBeCalled()
+        })
+    })
+
+    test('should throw if submitted by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app).post('/admin/manage-roles/BOB/roles').expect(403)
+    })
+  })
+})

--- a/types/delius.d.ts
+++ b/types/delius.d.ts
@@ -98,5 +98,6 @@ export interface DeliusClient {
   getAllLdusForProbationArea: (probationAreaCode: string) => Promise<Page<Ldu>>
   getAllTeamsForLdu: (probationAreaCode: string, lduCode: string) => Promise<Page<ProbationTeam>>
   addResponsibleOfficerRole: (username: string) => Promise<void>
+  addRole: (username: string, roleCode: string) => Promise<void>
   getUser: (username: string) => Promise<any>
 }


### PR DESCRIPTION
App support need to be able to manage HDC specific delius roles. 

These screens allow an admin staff to search for delius users by username and see what HDC specific roles they have.
It also allows them to add HDC roles.

Haven't mapped the readonly role as we aren't using it yet.  