### PR TITLE
DCS-599 Script to disable / enable auth service users.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4371,14 +4371,26 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "concurrently": {
@@ -5963,6 +5975,19 @@
         "debug": "^2.6.9",
         "mkdirp": "^0.5.4",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        }
       }
     },
     "extsprintf": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "case": "^1.6.3",
     "compression": "^1.7.4",
     "config": "^3.3.1",
+    "concat-stream": "^2.0.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
     "cookie-session": "^2.0.0-beta.3",

--- a/server/data/restClientBuilder.ts
+++ b/server/data/restClientBuilder.ts
@@ -21,7 +21,7 @@ export interface RestClientConfig {
 
 const NOT_FOUND = 404
 
-interface TokenSource {
+export interface TokenSource {
   (): Promise<string>
 }
 

--- a/server/disableUsers.ts
+++ b/server/disableUsers.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+/**
+ * Read a list of auth service usernames from stdin, one username per line.
+ * Disable or enable the account for every username in the list, printing the resulting user state to stdout as JSON.
+ * This script occurs twice, once as disableUsers.ts and again (via a soft link) as enableUsers.ts
+ * The script chooses whether to enable or disable users from the value of process.argv[1]
+ *
+ * If this script is included in a Docker image (as it will be if deployed to the cluster environments)
+ * it can be run in one of the deployed pods, with input redirected from a local file. That is, a file
+ * hosted on the machine where the kubectl command is run. Running the script in a pod means that the
+ * script will see correctly configured environment variables for that namespace.
+ *
+ * Such an invocation might look like:
+ *
+ * kubectl -n licences-prod exec -i licences-<pod_id> -- node server/disableUsers.js < usernames.txt
+ *
+ * Where pod_id is obtained from a previous kubectl get pods command and usernames.txt is a file in the current
+ * directory which contains auth service usernames, one per line.
+ */
+
+import concat from 'concat-stream'
+import { buildRestClient, clientCredentialsTokenSource, TokenSource } from './data/restClientBuilder'
+import createSignInService from './authentication/signInService'
+import config from './config'
+
+/**
+ * Always return the first token retrieved from the wrapped TokenSource.
+ * Sufficient for a script that will complete within the cached token's expiry time.
+ * Could extend this to refresh tokens when they expire which might be useful for
+ * REST clients that use client credentials.
+ */
+const cachingTokenSource = (tokenSource: TokenSource): TokenSource => {
+  let token: string
+  return async () => {
+    if (!token) {
+      token = await tokenSource()
+    }
+    return token
+  }
+}
+
+const oauthRestClient = buildRestClient(
+  cachingTokenSource(clientCredentialsTokenSource(createSignInService(), 'nomis')),
+  `${config.nomis.authUrl}`,
+  'OAuth API',
+  { timeout: config.nomis.timeout, agent: config.nomis.agent }
+)
+
+const disableAuthUser = (username) => oauthRestClient.putResource(`/api/authuser/${username}/disable`, {})
+const enableAuthUser = (username) => oauthRestClient.putResource(`/api/authuser/${username}/enable`, {})
+const getUser = (username) => oauthRestClient.getResource(`/api/authuser/${username}`)
+
+const updateUser = async (username, disableUser: boolean) => {
+  if (username) {
+    try {
+      await (disableUser ? disableAuthUser(username) : enableAuthUser(username))
+      return getUser(username)
+    } catch (error) {
+      // Carry on...
+    }
+  }
+  return undefined
+}
+
+const updateUsers = (usernames: string[], disableUsers = true) =>
+  usernames.reduce(
+    (promise, username) =>
+      promise
+        .then(() => updateUser(username, disableUsers))
+        .then((data) => new Promise((resolve) => process.stdout.write(`${JSON.stringify(data)}\n`, () => resolve()))),
+    Promise.resolve()
+  )
+
+const consumeInputBuffer = (buffer) => {
+  const usernames = buffer.toString().split('\n')
+  const disableUsers = !process.argv[1].includes('enableUsers')
+  updateUsers(usernames, disableUsers)
+    .then(() => process.stdout.write('Done\n'))
+    .then(() => process.exit(0))
+}
+
+process.stdin.pipe(concat(consumeInputBuffer))

--- a/server/enableUsers.ts
+++ b/server/enableUsers.ts
@@ -1,0 +1,1 @@
+disableUsers.ts


### PR DESCRIPTION
Read a list of auth service usernames from stdin, one username per line.
 Disable or enable the account for every username in the list, printing the resulting user state to stdout as JSON.
This script occurs twice, once as disableUsers.ts and again (via a soft link) as enableUsers.ts
The script chooses whether to enable or disable users from the value of process.argv[1]

 If this script is included in a Docker image (as it will be if deployed to the cluster environments)
 it can be run in one of the deployed pods, with input redirected from a local file. That is, a file
 hosted on the machine where the kubectl command is run. Running the script in a pod means that the
 script will see correctly configured environment variables for that namespace.

 Such an invocation might look like:
```bash
 kubectl -n licences-prod exec -i licences-<pod_id> -- node server/disableUsers.js < usernames.txt
```
 Where `pod_id` is obtained from a previous `kubectl get pods` command and `usernames.txt` is a file in the current
 directory which contains auth service usernames, one per line.
