### PR TITLE
DCS-632 Switch to using staffId based instead of staffCode based community-api endpoints

### DIFF
--- a/migrations/20200923124221_add-staff-identifier-to_staff_ids.js
+++ b/migrations/20200923124221_add-staff-identifier-to_staff_ids.js
@@ -1,0 +1,13 @@
+exports.up = async function (knex) {
+  await knex.schema.alterTable('staff_ids', (table) => {
+    table.bigInteger('staff_identifier').nullable().comment('Delius staff identifier (not staff code)')
+  })
+  await knex.schema.raw('CREATE OR REPLACE VIEW v_staff_ids AS SELECT * FROM staff_ids where deleted is false;')
+}
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('staff_ids', (table) => {
+    table.dropColumn('staff_identifier')
+  })
+  await knex.schema.raw('CREATE OR REPLACE VIEW v_staff_ids AS SELECT * FROM staff_ids where deleted is false;')
+}


### PR DESCRIPTION
🚧   Add staffIdentifier column to staff_ids table. Preparatory work to be deployed to prod.