### PR TITLE
DCS-632 Use staffIdentifier based instead of staffCode based community-api endpoints.

### DIFF
--- a/mock-server/routes/delius.js
+++ b/mock-server/routes/delius.js
@@ -151,6 +151,7 @@ router.get('/offenders/nomsNumber/:nomsNumber/allOffenderManagers', (req, res) =
       isResponsibleOfficer: true,
       staff: { forenames: 'Ryan', surname: 'Orton' },
       staffCode: 'DELIUS_ID',
+      staffId: 999,
       team: teamC01T04,
       probationArea: { code: 'ABC', description: 'ABC probation area' },
     },

--- a/server/data/deliusClient.ts
+++ b/server/data/deliusClient.ts
@@ -64,7 +64,7 @@ export interface ProbationArea {
 
 export interface CommunityOrPrisonOffenderManager {
   staffCode: string
-  staffIdentifier: number
+  staffId: number
   isResponsibleOfficer: boolean
   isPrisonOffenderManager: boolean
   isUnallocated: boolean

--- a/server/routes/admin/delius.js
+++ b/server/routes/admin/delius.js
@@ -46,7 +46,8 @@ module.exports = (roService) => (router) => {
     asyncMiddleware(async (req, res) => {
       const { value, type } = req.body
 
-      const staffDetails = type === 'STAFF_CODE' ? await getStaffByStaffIdentifier(value) : await staffByUsername(value)
+      const staffDetails =
+        type === 'STAFF_IDENTIFIER' ? await getStaffByStaffIdentifier(value) : await staffByUsername(value)
 
       logger.info('Found staff:', staffDetails)
 

--- a/server/routes/contact.js
+++ b/server/routes/contact.js
@@ -27,7 +27,8 @@ module.exports = (userAdminService, roService, signInService) => (router) => {
       const token = await signInService.getClientCredentialsTokens(req.user.username)
       const [ro] = unwrapResult(await roService.findResponsibleOfficer(theBookingId, token.token))
 
-      const contact = ro && ro.staffIdentifier && (await userAdminService.getRoUserByDeliusId(ro.deliusId))
+      const contact =
+        ro && ro.staffIdentifier && (await userAdminService.getRoUserByStaffIdentifier(ro.staffIdentifier))
       if (contact) {
         return res.render('contact/ro', { contact })
       }

--- a/server/services/caseListService.ts
+++ b/server/services/caseListService.ts
@@ -42,8 +42,8 @@ export = function createCaseListService(
   const getROCaseList = async (username, token) => {
     const idsFromLocalDB = await getIdsFromDb(username)
     const ids = await idsFromLocalDB.orRecoverAsync(() => getIdsFromDelius(username))
-    const offendersForStaffCode = await ids.mapAsync(getOffendersForIds(token))
-    return offendersForStaffCode.match(R.identity, (message) => ({ hdcEligible: [], message }))
+    const offenders = await ids.mapAsync(getOffendersForIds(token))
+    return offenders.match(R.identity, (message) => ({ hdcEligible: [], message }))
   }
 
   const getIdsFromDb = async (username: string): Promise<Result<DeliusIds, string>> => {

--- a/server/services/notifications/roNotificationHandler.js
+++ b/server/services/notifications/roNotificationHandler.js
@@ -34,12 +34,12 @@ module.exports = function createRoNotificationHandler(
   eventPublisher
 ) {
   /** Need to alert staff to link the records manually otherwise we won't be able to access the RO's email address from their user record and so won't be able to notify them  */
-  async function raiseUnlinkedAccountWarning(bookingId, { deliusId, name, nomsNumber }) {
+  async function raiseUnlinkedAccountWarning(bookingId, { deliusId, staffIdentifier, name, nomsNumber }) {
     logger.info(`Staff and user records not linked in delius: ${deliusId}`)
     await warningClient.raiseWarning(
       bookingId,
       STAFF_NOT_LINKED,
-      `RO with delius staff code: '${deliusId}' and name: '${name}', responsible for managing: '${nomsNumber}', has unlinked staff record in delius`
+      `RO with delius staff code: '${deliusId}', staff identifier: '${staffIdentifier}' and name: '${name}', responsible for managing: '${nomsNumber}', has unlinked staff record in delius`
     )
   }
 

--- a/server/services/roService.ts
+++ b/server/services/roService.ts
@@ -23,7 +23,7 @@ export class RoService {
       const result = await this.deliusClient.getStaffDetailsByStaffIdentifier(staffIdentifier)
       return result || { code: STAFF_NOT_PRESENT, message: `Staff does not exist in delius: ${staffIdentifier}` }
     } catch (error) {
-      logger.error(`Problem retrieving staff member for code: ${staffIdentifier}`, error.stack)
+      logger.error(`Problem retrieving staff member for staff identifier: ${staffIdentifier}`, error.stack)
       throw error
     }
   }

--- a/server/services/roService.ts
+++ b/server/services/roService.ts
@@ -90,7 +90,7 @@ function toResponsibleOfficer(
   const {
     staff: { forenames, surname },
     staffCode,
-    staffIdentifier,
+    staffId,
     isUnallocated,
     team: { localDeliveryUnit, code, description },
     probationArea,
@@ -100,7 +100,7 @@ function toResponsibleOfficer(
     name,
     isAllocated: !isUnallocated,
     deliusId: staffCode,
-    staffIdentifier,
+    staffIdentifier: staffId,
     nomsNumber: offenderNumber,
     teamCode: code,
     teamDescription: description,

--- a/server/views/admin/delius/index.pug
+++ b/server/views/admin/delius/index.pug
@@ -15,9 +15,9 @@ block content
         div.pure-u-2-3.midPaddingBottom
           div.pure-g.u-paddingBottom
             div.pure-u-1
-              label.form-label(for="staffCode") Delius staff code
+              label.form-label(for="staffIdentifier") Delius staff identifier
             div.pure-u-sm-5-12
-              input.form-control(id="staffCode" type="text" name="staffCode")
+              input.form-control(id="staffIdentifier" type="text" name="staffIdentifier")
             div.pure-u-sm-1-6.sm-PadLeftRight15
               input.requiredButton.button(type="submit" value="Search")
             div.pure-u-sm-5-12
@@ -53,7 +53,7 @@ block content
 
         div.pure-u-2-3.midPaddingBottom
           div.pure-g.u-paddingBottom
-            div.pure-u-1.midPaddingBottom Search by Staff Code or username
+            div.pure-u-1.midPaddingBottom Search by Staff Identifier or username
             div.pure-u-sm-5-12.sm-PadLeftRight15
               label.form-label(for="type") Type
             div.pure-u-sm-5-12
@@ -61,7 +61,7 @@ block content
             div.pure-u-sm-1-6
             div.pure-u-sm-5-12.sm-PadLeftRight15
               select.form-control(id="type" name="type")
-                option(value="STAFF_CODE" selected) Staff code
+                option(value="STAFF_IDENTIFIER" selected) Staff identifier
                 option(value="USERNAME" ) Username
             div.pure-u-sm-5-12.sm-PadLeftRight15
               input.form-control(id="value" type="text" name="value")

--- a/server/views/admin/delius/responsibleOfficer.pug
+++ b/server/views/admin/delius/responsibleOfficer.pug
@@ -7,13 +7,13 @@ block content
 
     if ro.message
       h2 Error retrieving responsible officer from delius: #{staffDetails.message}
-    else   
+    else
       div.pure-g.pure-u-1.paddingTop
         form(method='POST' action='/admin/delius/managedOffenders')
           input(type="hidden" name="_csrf" value=csrfToken)
-          input(type="hidden" name="staffCode" value=ro.deliusId)
+          input(type="hidden" name="staffIdentifier" value=ro.staffIdentifier)
           div.pure-u-1-3
-            input.link(type="submit" value="View managed offenders for " + ro.deliusId)
+            input.link(type="submit" value="View managed offenders for " + ro.staffIdentifier + " (" + ro.deliusId + ")")
 
           div.pure-u-1
             table.largeMarginBottom

--- a/server/views/contact/deliusRo.pug
+++ b/server/views/contact/deliusRo.pug
@@ -20,6 +20,9 @@ block content
             div.pure-u-1-3.sm-midPaddingBottom Staff code
             div.pure-u-2-3.bold #{ro.deliusId}
 
+            div.pure-u-1-3.sm-midPaddingBottom Staff identifier
+            div.pure-u-2-3.bold #{ro.staffIdentifier}
+
             div.pure-u-1-3.sm-midPaddingBottom Local Delivery Unit
             div.pure-u-2-3.bold #{ro.lduDescription} (#{ro.lduCode})
 

--- a/test/routes/contact.test.ts
+++ b/test/routes/contact.test.ts
@@ -5,7 +5,7 @@ import { createSignInServiceStub } from '../mockServices'
 import { startRoute } from '../supertestSetup'
 import createContactRoute from '../../server/routes/contact'
 import UserAdminService from '../../server/services/userAdminService'
-import { RoUser } from "../../server/data/userClient";
+import { RoUser } from '../../server/data/userClient'
 
 jest.mock('../../server/services/roService')
 jest.mock('../../server/services/userAdminService')

--- a/test/routes/contact.test.ts
+++ b/test/routes/contact.test.ts
@@ -4,13 +4,16 @@ import { RoService } from '../../server/services/roService'
 import { createSignInServiceStub } from '../mockServices'
 import { startRoute } from '../supertestSetup'
 import createContactRoute from '../../server/routes/contact'
+import UserAdminService from '../../server/services/userAdminService'
+import { RoUser } from "../../server/data/userClient";
 
 jest.mock('../../server/services/roService')
+jest.mock('../../server/services/userAdminService')
 
 let app
 
 describe('/contact', () => {
-  let userAdminService
+  let userAdminService: UserAdminService
   let roService: RoService
   let signInService
 
@@ -18,7 +21,7 @@ describe('/contact', () => {
     roService = new RoService(undefined, undefined)
     mocked(roService).findResponsibleOfficer.mockResolvedValue({
       deliusId: 'DELIUS_ID',
-      staffIdentifier: 1,
+      staffIdentifier: 999,
       name: 'Ro Name',
       nomsNumber: undefined,
       teamCode: 'TEAM_CODE',
@@ -33,7 +36,7 @@ describe('/contact', () => {
       username: 'username',
       email: '123456@somewhere.com',
       staffCode: 'DELIUS_ID',
-      staffIdentifier: 1,
+      staffIdentifier: 999,
       staff: { forenames: 'RO', surname: 'Name' },
       teams: [
         {
@@ -47,11 +50,7 @@ describe('/contact', () => {
       ],
     })
 
-    userAdminService = {
-      getRoUserByDeliusId: jest.fn().mockReturnValue(undefined),
-      getRoUserByDeliusUsername: jest.fn().mockReturnValue(undefined),
-      getFunctionalMailbox: jest.fn().mockReturnValue('abc@def.com'),
-    }
+    userAdminService = new UserAdminService(undefined, undefined, undefined)
 
     signInService = createSignInServiceStub()
 
@@ -67,13 +66,14 @@ describe('/contact', () => {
         .expect(() => {
           expect(roService.findResponsibleOfficer).toHaveBeenCalled()
           expect(roService.findResponsibleOfficer).toHaveBeenCalledWith('123456', 'system-token')
-          expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalled()
-          expect(userAdminService.getRoUserByDeliusId).toHaveBeenCalledWith('DELIUS_ID')
-          expect(userAdminService.getFunctionalMailbox).toHaveBeenCalledWith('PA_CODE', 'ABC123', 'TEAM_CODE')
+          expect(mocked(userAdminService).getRoUserByStaffIdentifier).toHaveBeenCalled()
+          expect(mocked(userAdminService).getRoUserByStaffIdentifier).toHaveBeenCalledWith(999)
+          expect(mocked(userAdminService).getFunctionalMailbox).toHaveBeenCalledWith('PA_CODE', 'ABC123', 'TEAM_CODE')
         })
     })
 
     test('should display RO details (from delius)', () => {
+      mocked(userAdminService).getFunctionalMailbox.mockResolvedValue('abc@def.com')
       return request(app)
         .get('/contact/123456')
         .expect(200)
@@ -82,6 +82,7 @@ describe('/contact', () => {
           expect(res.text).toContain('LDU Description')
           expect(res.text).toContain('Ro Name')
           expect(res.text).toContain('DELIUS_ID')
+          expect(res.text).toContain('999')
           expect(res.text).toContain('PA Description')
           expect(res.text).toContain('PA_CODE')
           expect(res.text).toContain('abc@def.com')
@@ -90,7 +91,7 @@ describe('/contact', () => {
     })
 
     test('should display RO details (from local store)', () => {
-      userAdminService.getRoUserByDeliusId.mockResolvedValue({
+      mocked(userAdminService).getRoUserByStaffIdentifier.mockResolvedValue({
         first: 'first',
         last: 'last',
         jobRole: 'JR',
@@ -98,7 +99,8 @@ describe('/contact', () => {
         telephone: '01234567890',
         organisation: 'The Org',
         orgEmail: 'org@email.com',
-      })
+        staffIdentifier: 999,
+      } as RoUser)
 
       return request(app)
         .get('/contact/123456')
@@ -110,15 +112,15 @@ describe('/contact', () => {
           expect(res.text).toContain('The Org')
           expect(res.text).toContain('org@email.com')
 
-          expect(userAdminService.getRoUserByDeliusId).toBeCalledWith('DELIUS_ID')
+          expect(userAdminService.getRoUserByStaffIdentifier).toBeCalledWith(999)
           expect(userAdminService.getRoUserByDeliusUsername).not.toBeCalled()
         })
     })
 
     test('should display RO details, from local store, when mapped username in delius', () => {
-      userAdminService.getRoUserByDeliusId.mockResolvedValueOnce(null)
+      mocked(userAdminService).getRoUserByStaffIdentifier.mockResolvedValueOnce(null)
 
-      userAdminService.getRoUserByDeliusUsername.mockResolvedValueOnce({
+      mocked(userAdminService).getRoUserByDeliusUsername.mockResolvedValueOnce({
         first: 'first',
         last: 'last',
         jobRole: 'JR',
@@ -127,7 +129,7 @@ describe('/contact', () => {
         telephone: '01234567890',
         organisation: 'The Org',
         orgEmail: 'org@email.com',
-      })
+      } as RoUser)
 
       return request(app)
         .get('/contact/123456')
@@ -139,8 +141,8 @@ describe('/contact', () => {
           expect(res.text).toContain('The Org')
           expect(res.text).toContain('org@email.com')
 
-          expect(userAdminService.getRoUserByDeliusId).toBeCalledWith('DELIUS_ID')
-          expect(userAdminService.getRoUserByDeliusUsername).toBeCalledWith('username')
+          expect(mocked(userAdminService).getRoUserByStaffIdentifier).toBeCalledWith(999)
+          expect(mocked(userAdminService).getRoUserByDeliusUsername).toBeCalledWith('username')
         })
     })
 

--- a/test/services/notifications/roNotificationHandler.test.ts
+++ b/test/services/notifications/roNotificationHandler.test.ts
@@ -176,6 +176,7 @@ describe('roNotificationHandler', () => {
       const responsibleOfficer = {
         name: 'Jo Smith',
         deliusId: 'STAFF-1',
+        staffIdentifier: 1,
         lduCode: 'code-1',
         lduDescription: 'lduDescription-1',
         nomsNumber: 'AAAA12',
@@ -198,7 +199,7 @@ describe('roNotificationHandler', () => {
       expect(warningClient.raiseWarning).toHaveBeenCalledWith(
         bookingId,
         STAFF_NOT_LINKED,
-        `RO with delius staff code: 'STAFF-1' and name: 'Jo Smith', responsible for managing: 'AAAA12', has unlinked staff record in delius`
+        `RO with delius staff code: 'STAFF-1', staff identifier: '1' and name: 'Jo Smith', responsible for managing: 'AAAA12', has unlinked staff record in delius`
       )
 
       expect(roNotificationSender.sendNotifications).toHaveBeenCalledWith({

--- a/test/services/roService.test.ts
+++ b/test/services/roService.test.ts
@@ -135,7 +135,7 @@ describe('roService', () => {
           isResponsibleOfficer: true,
           staff: { forenames: 'Jo', surname: 'Smith' },
           staffCode: 'CODE-1',
-          staffIdentifier: 1,
+          staffId: 1,
           isUnallocated: false,
           team: {
             localDeliveryUnit: { code: 'LDU-1', description: 'LDU-1 Description' },


### PR DESCRIPTION
* Fixes mistake in handling response to community-api end-point `GET /offenders/nomsNumber/${offenderNo}/allOffenderManagers` which returns `staffId` not `staffIdentifier`
* Show staff identifier in RO details page linked from offender details section of task list
* Admin changes to allow search by staff identifier instead of staff code on Delius api page.
* Show staff identifier in messages and RO related information