### PR TITLE
DCS-359 Agency Notification form displays Actual Release Date

### DIFF
--- a/mock-server/routes/delius.js
+++ b/mock-server/routes/delius.js
@@ -151,7 +151,7 @@ router.get('/offenders/nomsNumber/:nomsNumber/allOffenderManagers', (req, res) =
       isResponsibleOfficer: true,
       staff: { forenames: 'Ryan', surname: 'Orton' },
       staffCode: 'DELIUS_ID',
-      staffId: 999,
+      staffId: 2,
       team: teamC01T04,
       probationArea: { code: 'ABC', description: 'ABC probation area' },
     },

--- a/server/services/config/formConfig.js
+++ b/server/services/config/formConfig.js
@@ -23,6 +23,7 @@ module.exports = {
       'CURFEW_ADDRESS',
       'CURFEW_TELEPHONE',
       'SENT_HDCED',
+      'SENT_HDCAD',
       'SENT_CRD',
     ],
     cancel_agency_notification: [...headerFields, 'CURFEW_HOURS', 'CURFEW_ADDRESS', 'SENT_HDCED', 'SENT_CRD'],

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -69,6 +69,7 @@ module.exports = function createFormService(pdfFormatter, conditionsService, pri
       OFF_NOMS: () => getValue(prisoner, ['offenderNo']),
       EST_PREMISE: () => getValue(prisoner, ['agencyLocationDesc']),
       SENT_HDCED: () => getDateValue(prisoner, ['sentenceDetail', 'homeDetentionCurfewEligibilityDate']),
+      SENT_HDCAD: () => getDateValue(prisoner, ['sentenceDetail', 'homeDetentionCurfewActualDate']),
       SENT_CRD: () => getDateValue(prisoner, ['sentenceDetail', 'releaseDate']),
       CURFEW_ADDRESS: () => getCurfewAddress(pdfFormatter.pickCurfewAddress(selectPathsFrom(licence))),
       CURFEW_TELEPHONE: () => getCurfewTelephone(pdfFormatter.pickCurfewAddress(selectPathsFrom(licence))),

--- a/server/views/forms/agency_notification.pug
+++ b/server/views/forms/agency_notification.pug
@@ -14,7 +14,7 @@ block content
     tr
       td Tel:
 
-  p The following prisoner is due to be released on Home Detention Curfew on #{SENT_CRD}.
+  p The following prisoner is due to be released on Home Detention Curfew on #{SENT_HDCAD}.
   
   table.semi-wide
     tr

--- a/test/services/formService.test.js
+++ b/test/services/formService.test.js
@@ -300,7 +300,11 @@ describe('formService', () => {
         },
       }
       const prisoner = {
-        sentenceDetail: { homeDetentionCurfewEligibilityDate: 'Not a date', releaseDate: '32/13/100' },
+        sentenceDetail: {
+          homeDetentionCurfewEligibilityDate: 'Not a date',
+          releaseDate: '32/13/100',
+          homeDetentionCurfewActualDate: '',
+        },
       }
 
       const expectedData = {
@@ -309,6 +313,38 @@ describe('formService', () => {
         OFF_NAME: '',
         OFF_NOMS: '',
         SENT_CRD: '32/13/100',
+        SENT_HDCAD: '',
+        SENT_HDCED: 'Not a date',
+        CURFEW_ADDRESS: 'line1\nline2\ntown\npostcode',
+        CURFEW_FIRST: '',
+        CURFEW_HOURS: '',
+        CURFEW_TELEPHONE: '0123456789',
+      }
+
+      const data = await service.getTemplateData('agency_notification', licence, prisoner)
+      expect(data).toEqual(expectedData)
+    })
+    test('get HDCAD date', async () => {
+      const licence = {
+        proposedAddress: {
+          curfewAddress: { ...address, telephone: '0123456789' },
+        },
+      }
+      const prisoner = {
+        sentenceDetail: {
+          homeDetentionCurfewEligibilityDate: 'Not a date',
+          releaseDate: '32/13/100',
+          homeDetentionCurfewActualDate: '15/10/2019',
+        },
+      }
+
+      const expectedData = {
+        CREATION_DATE: creationDate,
+        EST_PREMISE: '',
+        OFF_NAME: '',
+        OFF_NOMS: '',
+        SENT_CRD: '32/13/100',
+        SENT_HDCAD: '15th October 2019',
         SENT_HDCED: 'Not a date',
         CURFEW_ADDRESS: 'line1\nline2\ntown\npostcode',
         CURFEW_FIRST: '',


### PR DESCRIPTION
The form now displays the Actual Release Date as well as the Conditional Release Date.
As a side issue, a change was also made to mock-server/routes/delius.js as the logic to match the RO now uses the unique staffId rather than the non-unique staffCode value.


Agency notification form before changes
=============================

<img width="600" alt="Screenshot 2020-10-06 at 09 35 13" src="https://user-images.githubusercontent.com/50441412/95178438-561bbc80-07b7-11eb-8ee8-398c23381270.png">



Agency notification form after changes
=============================
The relevant change is to the line "The following prisoner is due to be released on Home Detention Curfew on 13thSeptember 2019"
-------------------------

<img width="600" alt="Screenshot 2020-10-06 at 11 06 08" src="https://user-images.githubusercontent.com/50441412/95188338-2cb55d80-07c4-11eb-8c92-75f76bfbf3a6.png">

