### PR TITLE
DCS-427 HDC - Address change following Licence Variation update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10089,7 +10089,7 @@
       "dependencies": {
         "jsonwebtoken": {
           "version": "8.2.1",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
           "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
           "requires": {
             "jws": "^3.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9954,7 +9954,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/server/app.js
+++ b/server/app.js
@@ -61,7 +61,7 @@ const reviewRouter = require('./routes/review')
 const reportingRouter = require('./routes/reporting')
 const riskRouter = require('./routes/risk')
 const victimRouter = require('./routes/victim')
-const varyRouter = require('./routes/vary')
+const { varyRouter } = require('./routes/vary')
 
 const version = moment.now().toString()
 const { production } = config

--- a/server/routes/vary.ts
+++ b/server/routes/vary.ts
@@ -1,10 +1,11 @@
-/**
- * @typedef {import("../services/prisonerService").PrisonerService} PrisonerService
- */
-const { asyncMiddleware } = require('../utils/middleware')
-const createStandardRoutes = require('./routeWorkers/standard')
-const { pickBy, getFieldName, isEmpty, firstItem, getIn, lastItem } = require('../utils/functionalHelpers')
-const formConfig = require('./config/vary')
+import { asyncMiddleware } from '../utils/middleware'
+import createStandardRoutes from './routeWorkers/standard'
+import { firstItem, getFieldName, getIn, isEmpty, lastItem, pickBy, selectPathsFrom } from '../utils/functionalHelpers'
+import formConfig from './config/vary'
+import { LicenceService } from '../services/licenceService'
+import { PrisonerService } from '../../types/licences'
+import { Licence } from '../data/licenceTypes'
+import { pickCurfewAddress } from '../services/utils/pdfFormatter'
 
 const expectedFieldsForForm = {
   address: ['addressLine1', 'addressLine2', 'addressTown', 'postCode', 'telephone'],
@@ -19,11 +20,28 @@ const expectedFieldsForForm = {
 }
 
 /**
- * @param {object} args
- * @param {any} args.licenceService
- * @param {PrisonerService} args.prisonerService
+ * The data for the varyAddress form can come from one of four locations within the licence object.
+ * The pickCurfewAddress function from the pdfFormatter module returns the address that will be printed on a PDF licence.
  */
-module.exports = ({ licenceService, prisonerService }) => (router, audited) => {
+function extractFormData(formName: string, licence: Licence, licencePosition: string[]) {
+  if (formName === 'varyAddress') {
+    return pickCurfewAddress(selectPathsFrom(licence))
+  }
+  return getIn(licence, licencePosition)
+}
+
+function mapFromLicenceDataToFormData(licence: Licence, formName: string, licencePosition: string[]) {
+  const formData = extractFormData(formName, licence, licencePosition)
+  return renameKeysForForm(formData, formName) || {}
+}
+
+export = ({
+  licenceService,
+  prisonerService,
+}: {
+  licenceService: LicenceService
+  prisonerService: PrisonerService
+}) => (router, audited) => {
   const standard = createStandardRoutes({ formConfig, licenceService, sectionName: 'vary' })
 
   router.get(
@@ -31,7 +49,7 @@ module.exports = ({ licenceService, prisonerService }) => (router, audited) => {
     asyncMiddleware(async (req, res) => {
       const { bookingId } = req.params
       // page should only be viewed if no licence
-      if (res.locals.licenceStatus.tasks.curfewAddress !== 'UNSTARTED') {
+      if (res.locals?.licenceStatus?.tasks?.curfewAddress !== 'UNSTARTED') {
         return res.redirect(`/hdc/taskList/${bookingId}`)
       }
 
@@ -84,8 +102,7 @@ module.exports = ({ licenceService, prisonerService }) => (router, audited) => {
     const errorObject = firstItem(req.flash('errors')) || {}
     const userInput =
       firstItem(req.flash('userInput')) ||
-      renameKeysForForm(getIn(res.locals.licence, ['licence', ...licencePosition]), formName) ||
-      {}
+      mapFromLicenceDataToFormData(res.locals?.licence?.licence, formName, licencePosition)
 
     res.render(`vary/${formName}`, {
       errorObject,
@@ -95,6 +112,7 @@ module.exports = ({ licenceService, prisonerService }) => (router, audited) => {
   }
 
   router.get('/address/:bookingId', getVaryForm('varyAddress', ['proposedAddress', 'curfewAddress']))
+
   router.get(
     '/reportingAddress/:bookingId',
     getVaryForm('varyReportingAddress', ['reporting', 'reportingInstructions'])
@@ -143,9 +161,14 @@ module.exports = ({ licenceService, prisonerService }) => (router, audited) => {
 
 function renameKeysForForm(licenceObject, formName) {
   // some vary form field names are not the same as their licence field name
-  if (isEmpty(licenceObject) || formName !== 'varyReportingAddress') {
+  if (isEmpty(licenceObject)) {
     return licenceObject
   }
+
+  if (formName !== 'varyReportingAddress') {
+    return licenceObject
+  }
+
   return expectedFieldsForForm.reportingAddress.reduce((userInput, uiKey) => {
     const formFieldConfig = formConfig.licenceDetails.fields.find((field) => getFieldName(field) === uiKey)
     const licenceFieldName = lastItem(formFieldConfig[uiKey].licencePosition)

--- a/server/routes/vary.ts
+++ b/server/routes/vary.ts
@@ -35,7 +35,8 @@ function mapFromLicenceDataToFormData(licence: Licence, formName: string, licenc
   return renameKeysForForm(formData, formName) || {}
 }
 
-export = ({
+// eslint-disable-next-line import/prefer-default-export
+export const varyRouter = ({
   licenceService,
   prisonerService,
 }: {

--- a/server/services/utils/pdfFormatter/index.js
+++ b/server/services/utils/pdfFormatter/index.js
@@ -1,3 +1,3 @@
-const { formatPdfData, DEFAULT_PLACEHOLDER, pickCurfewAddress } = require('./pdfFormatter')
+const { formatPdfData, DEFAULT_PLACEHOLDER, pickCurfewAddress, pickCurfewAddressPath } = require('./pdfFormatter')
 
-module.exports = { formatPdfData, DEFAULT_PLACEHOLDER, pickCurfewAddress }
+module.exports = { formatPdfData, DEFAULT_PLACEHOLDER, pickCurfewAddress, pickCurfewAddressPath }

--- a/server/services/utils/pdfFormatter/pdfFormatter.js
+++ b/server/services/utils/pdfFormatter/pdfFormatter.js
@@ -7,7 +7,7 @@ const config = require('../../../config')
 
 const DEFAULT_PLACEHOLDER = 'N/A'
 
-module.exports = { formatPdfData, DEFAULT_PLACEHOLDER, pickCurfewAddress, getConditionText }
+module.exports = { formatPdfData, DEFAULT_PLACEHOLDER, pickCurfewAddress, pickCurfewAddressPath, getConditionText }
 
 function formatPdfData(
   templateName,
@@ -69,25 +69,28 @@ function valueOrPlaceholder(dataSelector, placeholder, templateName) {
 }
 
 function pickCurfewAddress(licencePathSelector) {
+  return licencePathSelector(pickCurfewAddressPath(licencePathSelector))
+}
+
+function pickCurfewAddressPath(licencePathSelector) {
   const approvedPremisesRequired =
     licencePathSelector(['curfew', 'approvedPremises', 'required']) ||
     licencePathSelector(['bassReferral', 'bassAreaCheck', 'approvedPremisesRequiredYesNo'])
 
   if (approvedPremisesRequired === 'Yes') {
-    return (
-      licencePathSelector(['curfew', 'approvedPremisesAddress']) ||
-      licencePathSelector(['bassReferral', 'approvedPremisesAddress'])
-    )
+    return licencePathSelector(['curfew', 'approvedPremisesAddress'])
+      ? ['curfew', 'approvedPremisesAddress']
+      : ['bassReferral', 'approvedPremisesAddress']
   }
 
   const bassRequested = licencePathSelector(['bassReferral', 'bassRequest', 'bassRequested'])
   const bassAccepted = licencePathSelector(['bassReferral', 'bassOffer', 'bassAccepted'])
 
   if (bassRequested === 'Yes' && bassAccepted === 'Yes') {
-    return licencePathSelector(['bassReferral', 'bassOffer'])
+    return ['bassReferral', 'bassOffer']
   }
 
-  return licencePathSelector(['proposedAddress', 'curfewAddress'])
+  return ['proposedAddress', 'curfewAddress']
 }
 
 function getConditionsForConfig(licencePathSelector, templateName, configName) {

--- a/test/routes/vary.test.ts
+++ b/test/routes/vary.test.ts
@@ -4,8 +4,11 @@ import { mockAudit } from '../mockClients'
 import { appSetup, testFormPageGets } from '../supertestSetup'
 import { createPrisonerServiceStub, createSignInServiceStub } from '../mockServices'
 import standardRouter from '../../server/routes/routeWorkers/standardRouter'
-import createRoute from '../../server/routes/vary'
-const formConfig = require('../../server/routes/config/vary')
+
+import { varyRouter } from '../../server/routes/vary'
+
+import formConfig from '../../server/routes/config/vary'
+
 import NullTokenVerifier from '../../server/authentication/tokenverifier/NullTokenVerifier'
 import { LicenceRecord, LicenceService } from '../../server/services/licenceService'
 
@@ -239,7 +242,7 @@ describe('/hdc/vary', () => {
           expect(licenceService.createLicenceFromFlatInput).toHaveBeenCalledWith(
             { bookingId: 1, addressLine1: 'this' },
             1,
-            { },
+            {},
             formConfig.licenceDetails,
             true
           )
@@ -276,7 +279,7 @@ describe('POST /hdc/vary/', () => {
       const licenceService = new LicenceService(undefined)
       const audit = mockAudit()
 
-      mocked(licenceService).getLicence.mockResolvedValue({ licence: { vary: { evidence: {} } }} as LicenceRecord)
+      mocked(licenceService).getLicence.mockResolvedValue({ licence: { vary: { evidence: {} } } } as LicenceRecord)
       mocked(licenceService).update.mockResolvedValue({ vary: { evidence: {} } })
       const app = createApp({ licenceServiceStub: licenceService, audit }, 'roUser')
 
@@ -308,7 +311,7 @@ function createApp({ licenceServiceStub, audit = mockAudit() }, user) {
     tokenVerifier: new NullTokenVerifier(),
     config: null,
   })
-  const route = baseRouter(createRoute({ licenceService, prisonerService }))
+  const route = baseRouter(varyRouter({ licenceService, prisonerService }))
 
   return appSetup(route, user, '/hdc/vary')
 }

--- a/test/services/licenceService.test.ts
+++ b/test/services/licenceService.test.ts
@@ -3,12 +3,11 @@ import {
   LicenceService,
   adaptFieldConfigToSelectWorkingAddress,
 } from '../../server/services/licenceService'
-import varyConfig from '../../server/routes/config/vary'
+import * as varyConfig from '../../server/routes/config/vary'
 import formValidation from '../../server/services/utils/formValidation'
 import { LicenceClient } from '../../server/data/licenceClient'
 import { CaseWithVaryVersion } from '../../server/data/licenceClientTypes'
 import { Licence } from '../../server/data/licenceTypes'
-import { licenceDetails } from '../../server/routes/config/vary'
 
 jest.mock('../../server/services/utils/formValidation')
 
@@ -1830,7 +1829,9 @@ describe('licenceService', () => {
 
   describe('adaptFieldConfigToSelectWorkingAddress', () => {
     it('leaves config untouched by default', () => {
-      expect(adaptFieldConfigToSelectWorkingAddress({}, licenceDetails.fields)).toEqual(licenceDetails.fields)
+      expect(adaptFieldConfigToSelectWorkingAddress({}, varyConfig.licenceDetails.fields)).toEqual(
+        varyConfig.licenceDetails.fields
+      )
     })
 
     it('adapts to curfew address approved premises', () => {
@@ -1846,7 +1847,8 @@ describe('licenceService', () => {
         },
       }
       expect(
-        adaptFieldConfigToSelectWorkingAddress(licence, licenceDetails.fields)[0].addressLine1.licencePosition
+        adaptFieldConfigToSelectWorkingAddress(licence, varyConfig.licenceDetails.fields)[0].addressLine1
+          .licencePosition
       ).toEqual(['curfew', 'approvedPremisesAddress', 'addressLine1'])
     })
 
@@ -1875,7 +1877,8 @@ describe('licenceService', () => {
         },
       }
       expect(
-        adaptFieldConfigToSelectWorkingAddress(licence, licenceDetails.fields)[0].addressLine1.licencePosition
+        adaptFieldConfigToSelectWorkingAddress(licence, varyConfig.licenceDetails.fields)[0].addressLine1
+          .licencePosition
       ).toEqual(['bassReferral', 'bassOffer', 'addressLine1'])
     })
 
@@ -1897,7 +1900,8 @@ describe('licenceService', () => {
         },
       }
       expect(
-        adaptFieldConfigToSelectWorkingAddress(licence, licenceDetails.fields)[0].addressLine1.licencePosition
+        adaptFieldConfigToSelectWorkingAddress(licence, varyConfig.licenceDetails.fields)[0].addressLine1
+          .licencePosition
       ).toEqual(['bassReferral', 'approvedPremisesAddress', 'addressLine1'])
     })
   })


### PR DESCRIPTION
The updated address was not saving into the new version of the Licence when generated.
The vary address task only ever worked when a pre-existing licence object contained just a proposed address.  It failed to take account of objects where a bass address or approved premises address (for the bass or curfew address) had been specified.