### PR TITLE
DCS-964 increasing space on admin pages to support longer LDU descriptions

### DIFF
--- a/server/views/admin/functionalMailboxes/lduWithTeams.pug
+++ b/server/views/admin/functionalMailboxes/lduWithTeams.pug
@@ -20,7 +20,7 @@ block content
 
   h2.heading-medium LDU
   div.pure-g.borderBottom.paddingBottom
-    div.pure-u-1.pure-u-md-1-3.midMarginBottom
+    div.pure-u-1.pure-u-md-2-3.midMarginBottom
       p
         span.bold LDU:&nbsp;
         span #{description} (#{lduCode})

--- a/server/views/admin/locations/ldus.pug
+++ b/server/views/admin/locations/ldus.pug
@@ -14,7 +14,7 @@ block content
   form(method="post")
     input(type="hidden" name="_csrf" value=csrfToken)
     div.pure-g.form-group.smallPaddingTop
-      div.form-group.pure-u-1.pure-u-sm-10-24
+      div.form-group.pure-u-1.pure-u-sm-20-24
         div.govuk-fieldset
           
           each ldu, index in probationArea.ldus


### PR DESCRIPTION
Currently:
<kbd>
<img width="401" alt="Screenshot 2020-11-19 at 14 44 59" src="https://user-images.githubusercontent.com/1517745/99681242-d485a280-2a75-11eb-85e8-7ab4c71dbe77.png">
</kbd>
Will be:
<kbd>
<img width="483" alt="Screenshot 2020-11-19 at 14 45 27" src="https://user-images.githubusercontent.com/1517745/99681310-e6674580-2a75-11eb-8125-d9d00397e69a.png">
</kbd>

And:
<kbd>
<img width="426" alt="Screenshot 2020-11-19 at 14 46 46" src="https://user-images.githubusercontent.com/1517745/99681465-11ea3000-2a76-11eb-85a9-a6048d92b947.png">
</kbd>
Will be:
<kbd>
<img width="462" alt="Screenshot 2020-11-19 at 14 47 28" src="https://user-images.githubusercontent.com/1517745/99681579-30502b80-2a76-11eb-92a6-5fa9c324cb99.png">
</kbd>