### PR TITLE
DCS-772 Hide 'Exit to DPS link' from users for whom the link makes no sense (Non-NOMIS users).

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -138,7 +138,6 @@ module.exports = function createApp({
     tls:
       config.redis.tls_enabled === 'true'
         ? {
-            ca: fs.readFileSync('root.cert'),
             rejectUnauthorized: config.production,
           }
         : false,


### PR DESCRIPTION
Remove CA cert for Redis. It doesn't work in the docker image, isn't used elsewhere (for Redis TLS connections) , is tedious to investigate and fix and not needed.

For some reason the Redis connection code in app.js doesn't like the CA certificate, can't find it or something similar.  Odd, because the knex and db config appears to use the same code and works perfectly well.

This is only a problem when running the code from a Docker image in the Kubernetes cluster.  Running the same code outside the image (locally) works against a port-forwarded Redis (AWS) server with TLS enabled.  Note that when the code is run outside AWS TLS host checking must be disabled (rejectUnauthorized: false), whereas rejectUnauthorized would be (should be) true when the code is run in the Kubernetes cluster. 

Disabling host checking was the original reason for changing this code from the configurations used elsewhere - so that I could run licences against the 'dev' environment and check behaviour for NOMIS users having multiple licences Roles. (CA + RO + DM + BATCHLOAD).

Having made changes to allow disabling host checking, adding the CA cert check appeared to be almost 'free'.  Yet it doesn't work when it needs to.  The only way to fix this that I can think of is to build and test docker images against the 'dev' environment.  This is slow, tedious and, since the CA cert check isn't needed, pointless.  