### PR TITLE
DCS-1180: location link text changed

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/common/CommonCaselistSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/common/CommonCaselistSpec.groovy
@@ -145,4 +145,18 @@ class CommonCaselistSpec extends GebReportingSpec {
     user << ['CA', 'DM', 'RO_USER']
   }
 
+  def 'Change location link displays correct text - user has multiple roles'() {
+
+    when: 'I go to the case list page'
+    actions.logIn(user)
+    via CaselistPage
+
+    then: 'I can see the Change location link'
+    changeLocationLink.text() == 'Change your role or location'
+
+    where:
+    user << ['CA_RO_DM']
+  }
+
+
 }

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/util/Actions.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/util/Actions.groovy
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.licences.pages.CaselistPage
 class Actions {
 
   def users = [
+    'CA_RO_DM': [username: 'CA_RO_DM_USER', password: 'password123456'],
     'READONLY': [username: 'LICENCE_READONLY_TEST', password: 'password123456'],
     'CA'      : [username: 'CA_USER_TEST', password: 'licences123456'],
     'CA_MULTI': [username: 'CA_USER_MULTI', password: 'licences123456'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8282,7 +8282,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -22,6 +22,7 @@ module.exports = (nomisClientBuilder) => {
     return {
       ...profile,
       username,
+      roles,
       role: roles[0],
       isPrisonUser,
       activeCaseLoad,

--- a/server/views/layout.pug
+++ b/server/views/layout.pug
@@ -75,12 +75,13 @@ html(lang="en")
       div(class="change-location")
         - var hasActiveCaseload = user.activeCaseLoad && !user.activeCaseLoad.description.includes('---')
         - var hasMultipleCaseloads = user.caseLoads && user.caseLoads.length > 1
+        - var locationLinkText = user.roles && user.roles.length > 1 ? "Change your role or location" : "Change your location"
 
         if hasActiveCaseload
           span(class="change-location__location" data-qa="active-location") #{user.activeCaseLoad.description}
 
         if hasMultipleCaseloads
-          a(class="change-location__link" href="/user" data-qa="change-location-link") Change your location
+          a(class="change-location__link" href="/user" data-qa="change-location-link") #{locationLinkText}
 
       if hasActiveCaseload || hasMultipleCaseloads
         hr(class="smallMarginBottom smallMarginTop")

--- a/test/services/userService.test.js
+++ b/test/services/userService.test.js
@@ -10,7 +10,9 @@ describe('userServiceTest', () => {
 
   beforeEach(() => {
     nomisClient = {
-      getUserRoles: jest.fn().mockReturnValue([{ roleCode: 'LICENCE_CA' }, { roleCode: 'PRISON' }]),
+      getUserRoles: jest
+        .fn()
+        .mockReturnValue([{ roleCode: 'LICENCE_CA' }, { roleCode: 'LICENCE_DM' }, { roleCode: 'PRISON' }]),
       getUserCaseLoads: jest.fn().mockReturnValue(activeCaseLoads),
       putActiveCaseLoad: jest.fn().mockReturnValue({}),
       getLoggedInUserInfo: jest.fn().mockReturnValue({ name: 'User Name' }),
@@ -20,13 +22,14 @@ describe('userServiceTest', () => {
   })
 
   describe('getUserProfile', () => {
-    test('should return an object with the profile, first role and active case load', () => {
+    test('should return an object with the profile, first role, all roles and active case load', () => {
       return expect(service.getUserProfile('t', 'rt', 'un')).resolves.toEqual({
         username: 'un',
         activeCaseLoadId: 'this',
         name: 'User Name',
         displayNameInitial: 'U. Name',
         role: 'CA',
+        roles: ['CA', 'DM'],
         isPrisonUser: true,
         activeCaseLoad: {
           caseLoadId: 'this',
@@ -39,7 +42,7 @@ describe('userServiceTest', () => {
 
   describe('getAllRoles', () => {
     test('should return roles and prison users status ', () => {
-      return expect(service.getAllRoles(user)).resolves.toEqual({ roles: ['CA'], isPrisonUser: true })
+      return expect(service.getAllRoles(user)).resolves.toEqual({ roles: ['CA', 'DM'], isPrisonUser: true })
     })
 
     test('should allow multiple roles', () => {


### PR DESCRIPTION
The location link text, which is in every page underneath the header, changes to 'Change your roles or location' user has multiple roles.