### PR TITLE
DCS-1181: Page title changed

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/UserPage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/UserPage.groovy
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.licences.pages
+
+import geb.Page
+import uk.gov.justice.digital.hmpps.licences.modules.HeaderModule
+import uk.gov.justice.digital.hmpps.licences.modules.OffenderSummaryModule
+
+class UserPage extends Page {
+
+  static url = '/user'
+
+  static at = {
+    browser.currentUrl.contains(url)
+  }
+
+  static content = {
+    pageTitle(required: true) { $('h2').text() }
+    caseloadSelector(required: false) { $('#selectCaseLoad') }
+    roleSelector(required: false) { $('#selectRole') }
+  }
+
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/common/CommonCaselistSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/common/CommonCaselistSpec.groovy
@@ -139,7 +139,7 @@ class CommonCaselistSpec extends GebReportingSpec {
     changeLocationLink.click()
 
     and: 'I am taken to the Change location page'
-     $('h2').text() == 'Change location'
+     $('h2').text() == 'Change your location'
 
     where:
     user << ['CA', 'DM', 'RO_USER']

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/common/UserPageSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/common/UserPageSpec.groovy
@@ -1,0 +1,67 @@
+package uk.gov.justice.digital.hmpps.licences.specs.common
+
+import geb.spock.GebReportingSpec
+import spock.lang.Shared
+import uk.gov.justice.digital.hmpps.licences.pages.UserPage
+import uk.gov.justice.digital.hmpps.licences.util.Actions
+
+
+class UserPageSpec extends GebReportingSpec {
+
+  @Shared
+  Actions actions = new Actions()
+
+
+  def cleanup() {
+    actions.logOut()
+  }
+
+  def 'Shows correct page title - user has single role'() {
+
+    actions.logIn('CA')
+
+    given: 'I view the User page'
+    to UserPage
+
+    expect: 'The page title refers to location only'
+    pageTitle == "Change your location"
+
+  }
+
+  def 'Displays caseLoad selector - user has single role'() {
+
+    actions.logIn('CA')
+
+    given: 'I view the User page'
+    to UserPage
+
+    expect: 'Only caseLoad selector is displayed'
+    caseloadSelector.displayed
+    !roleSelector.displayed
+  }
+
+  def 'Shows correct page title - user has multiple roles'() {
+
+    actions.logIn('CA_RO_DM')
+
+    given: 'I view the User page'
+    to UserPage
+
+    expect: 'The page title refers to role and location'
+    pageTitle == "Change your role or location"
+
+  }
+
+  def 'Displays role selector - user has multiple roles'() {
+
+    actions.logIn('CA_RO_DM')
+
+    given: 'I view the User page'
+    to UserPage
+
+    expect: 'The role and caseLoad selectors are displayed'
+    roleSelector.displayed
+    caseloadSelector.displayed
+  }
+
+}

--- a/server/views/user/admin.pug
+++ b/server/views/user/admin.pug
@@ -10,6 +10,8 @@ block content
         include ../includes/back
 
   - var showCaseLoads = !isAdmin && allCaseLoads.length > 1
+  - var pageTitle = allRoles && allRoles.length > 1 ? "Change your role or location" : "Change your location"
+
   if allRoles.length > 1 || showCaseLoads
 
     form(method="post")
@@ -17,7 +19,7 @@ block content
       input(type="hidden" name="bookingId" value=bookingId || '')
 
       h2.pure-u-1.heading-large
-        | Change location
+        | #{pageTitle}
 
       if allRoles.length > 1
 


### PR DESCRIPTION
The page title on /user changes depending on whether the user has multiple roles. This is simlar to how the change location link changes (underneath the header), on every page