### PR TITLE
DCS-1384 migrate prod to live

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,7 @@ ingress:
   cert_secret: licences-cert
   path: /
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: licences-licences-prod-blue
+    external-dns.alpha.kubernetes.io/set-identifier: licences-licences-prod-green
 
 env:
   NOMIS_API_URL: "https://api.prison.service.justice.gov.uk"


### PR DESCRIPTION
prod ingress moved from blue to green.
This project hasn't used the 'generic-service' to construct values files so have updated the values-prod.yaml itself rather removing the annotations from dev and pre-prod to then apply in a values.yaml singularly.   