### PR TITLE
DCS-1239 Fixing pdf generation

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -125,7 +125,7 @@ module.exports = function createApp({
   // Secure code best practice - see:
   // 1. https://expressjs.com/en/advanced/best-practice-security.html,
   // 2. https://www.npmjs.com/package/helmet
-  app.use(helmet({ contentSecurityPolicy: false }))
+  app.use(helmet({ contentSecurityPolicy: false, crossOriginResourcePolicy: { policy: 'cross-origin' } }))
 
   app.use(addRequestId)
 


### PR DESCRIPTION
The browser instance within the gotenberg container relied on being able to access the pdf css from the running application. This was being blocked by the cross origin resource policy so the pdf was being generated without any styling