### PR TITLE
DCS-1081 prometheus alerts for prod to elp_alerts slack channel

### DIFF
--- a/helm_deploy/licences/Chart.yaml
+++ b/helm_deploy/licences/Chart.yaml
@@ -9,5 +9,5 @@ dependencies:
     version: "0.1.x"
     repository: file://subcharts/gotenberg
   - name: generic-prometheus-alerts
-    version: 0.1.2
+    version: 0.4.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/licences/values.yaml
+++ b/helm_deploy/licences/values.yaml
@@ -1,8 +1,8 @@
 ---
-# Values here are the same across all environments
 
 generic-prometheus-alerts:
   targetApplication: licences
+  alertSeverity: digital-prison-service-dev
 
 ingress:
   annotations:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -99,4 +99,5 @@ allowlist:
 
 # determine which slack channel alerts are sent to, via the correct Alert Manager receiver
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  targetApplication: licences
+  alertSeverity: elp_alerts


### PR DESCRIPTION
Dev and Preprod to digital-prison-service-dev.
Prod to elp_alerts.
Latest version of generic-proetheus-alerts is 0.4.1, see https://github.com/ministryofjustice/hmpps-helm-charts/releases?page=1