### PR TITLE
DCS-1767 add new extremism additional condition

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/LicenceConditionsSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/LicenceConditionsSpec.groovy
@@ -87,7 +87,7 @@ class LicenceConditionsSpec extends GebReportingSpec {
     conditions.every { !it.value() }
 
     and: 'I see the right number of conditions'
-    conditions.size() == 50
+    conditions.size() == 51
   }
 
   def 'Select a condition reveals the input form'() {

--- a/server/data/licenceTypes.ts
+++ b/server/data/licenceTypes.ts
@@ -200,6 +200,7 @@ export type AdditionalConditionsV2 = {
   ELECTRONIC_MONITORING_TRAIL?: any
   CURFEW_UNTIL_INSTALLATION?: any
   ALCOHOL_MONITORING?: any
+  ALLOW_POLICE_SEARCH?: any
 }
 
 export interface LicenceConditions {

--- a/server/services/config/conditions/v2/conditions.ts
+++ b/server/services/config/conditions/v2/conditions.ts
@@ -463,6 +463,14 @@ export const conditions: ConditionMetadata[] = [
     subgroup_name: null,
   },
   {
+    id: 'ALLOW_POLICE_SEARCH',
+    text: 'You must let the police search you if they ask. You must also let them search a vehicle you are with, like a car or a motorbike.',
+    user_input: null,
+    field_position: null,
+    group_name: GroupName.EXTREMISM,
+    subgroup_name: null,
+  },
+  {
     id: 'POLYGRAPH',
     text: 'To comply with any instruction given by your supervising officer requiring you to attend polygraph testing. To participate in polygraph sessions and examinations as instructed by or under the authority of your supervising officer and to comply with any instruction given to you during a polygraph session by the person conducting the polygraph.',
     user_input: null,

--- a/server/services/config/conditions/v2/validation.ts
+++ b/server/services/config/conditions/v2/validation.ts
@@ -137,4 +137,5 @@ export default joi.object({
     attendSampleDetailsName: joi.string().required(),
     attendSampleDetailsAddress: joi.string().required(),
   }),
+  ALLOW_POLICE_SEARCH: joi.object({}),
 })


### PR DESCRIPTION
Additional extremism licence added, appears in additional licences list and if selected also shown under licence conditions section on generated pdf:
<img width="781" alt="Screenshot 2022-08-10 at 12 12 13" src="https://user-images.githubusercontent.com/48809053/183887812-df68d830-359c-4512-a7ea-69298427c482.png">

<img width="1158" alt="Screenshot 2022-08-10 at 12 13 13" src="https://user-images.githubusercontent.com/48809053/183887834-5eddffd7-006b-4b80-88ee-ae4c310aa397.png">

