### PR TITLE
DCS-1766: 🆙 upgrade Ingress apiVersion to networking.k8s.io/v1 and nginx-ingress-controller to v1.2 

### DIFF
--- a/helm_deploy/licences/templates/ingress.yaml
+++ b/helm_deploy/licences/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "app.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -22,7 +22,10 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
 {{- end }}

--- a/helm_deploy/licences/templates/ingress.yaml
+++ b/helm_deploy/licences/templates/ingress.yaml
@@ -8,11 +8,11 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
     {{ if .Values.ingress.enable_allowlist }}nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.allowlist | quote }}{{ end }}
 spec:
+  ingressClassName: default
   tls:
   - hosts:
     - {{ .Values.ingress.host }}


### PR DESCRIPTION
This PR is intended to test downtime moving to the new Ingress apiVersion and nginx-ingress-controller.

It will be tested in dev and potentially pre-prod. 

If the downtime is acceptable. It will then be pushed through to production at a reasonable time.

If not, we will revert this PR and raise another in favour of the [ 0 downtime process](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.html#switch-to-the-new-ingress-controller-with-zero-downtime).