### PR TITLE
DCS-1907: ✨ Add Standard Conditions Versioning For Licences

### DIFF
--- a/migrations/20221130124953_add-standard-conditions-version.js
+++ b/migrations/20221130124953_add-standard-conditions-version.js
@@ -1,0 +1,11 @@
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('licences', (table) => {
+    table.integer('standard_conditions_version').nullable()
+  })
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('licences', (table) => {
+    table.dropColumn('standard_conditions_version')
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "jest": "^29.3.1",
         "jest-html-reporter": "^3.7.0",
         "jest-junit": "^15.0.0",
-        "lint-staged": "^13.0.4",
+        "lint-staged": "^13.0.3",
         "nock": "^13.2.9",
         "node-sass": "^8.0.0",
         "nodemon": "^2.0.20",
@@ -3150,6 +3150,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
       "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
       "dev": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
@@ -5361,6 +5362,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
       "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
+      "deprecated": "Please use another csrf package",
       "dependencies": {
         "cookie": "0.4.0",
         "cookie-signature": "1.0.6",

--- a/server/data/licenceClient.ts
+++ b/server/data/licenceClient.ts
@@ -3,7 +3,7 @@ import {
   ApprovedLicenceVersion,
   CaseWithApprovedVersion,
   CaseWithVaryVersion,
-  ConditionVersion,
+  AdditionalConditionsVersion,
   DeliusIds,
   StandardConditionsVersion,
 } from './licenceClientTypes'
@@ -170,10 +170,13 @@ export class LicenceClient {
     return rows
   }
 
-  async setConditionsVersion(bookingId: number, conditionVersion: ConditionVersion): Promise<void> {
+  async setAdditionalConditionsVersion(
+    bookingId: number,
+    additionalConditionsVersion: AdditionalConditionsVersion
+  ): Promise<void> {
     const query = {
       text: `update licences l set additional_conditions_version = $1 where booking_id = $2`,
-      values: [conditionVersion, bookingId],
+      values: [additionalConditionsVersion, bookingId],
     }
 
     await db.query(query)

--- a/server/data/licenceClientTypes.ts
+++ b/server/data/licenceClientTypes.ts
@@ -2,6 +2,8 @@ import { Licence, LicenceStage } from './licenceTypes'
 
 export type ConditionVersion = 1 | 2
 
+export type StandardConditionsVersion = 1
+
 export type ConditionMetadata = {
   id: string
   text: string
@@ -20,6 +22,7 @@ export interface Case {
   stage: LicenceStage
   version: number
   additional_conditions_version: ConditionVersion
+  standard_conditions_version: StandardConditionsVersion
 }
 
 export interface CaseWithApprovedVersion extends Case {

--- a/server/data/licenceClientTypes.ts
+++ b/server/data/licenceClientTypes.ts
@@ -1,6 +1,6 @@
 import { Licence, LicenceStage } from './licenceTypes'
 
-export type ConditionVersion = 1 | 2
+export type AdditionalConditionsVersion = 1 | 2
 
 export type StandardConditionsVersion = 1
 
@@ -21,7 +21,7 @@ export interface Case {
   booking_id: number
   stage: LicenceStage
   version: number
-  additional_conditions_version: ConditionVersion
+  additional_conditions_version: AdditionalConditionsVersion
   standard_conditions_version: StandardConditionsVersion
 }
 

--- a/server/routes/conditions.ts
+++ b/server/routes/conditions.ts
@@ -117,7 +117,7 @@ export default ({
       const newVersion = conditionsServiceFactory.getNewVersion(res.locals.licence)
 
       if (newVersion) {
-        await licenceService.setConditionsVersion(Number(bookingId), newVersion)
+        await licenceService.setAdditionalConditionsVersion(Number(bookingId), newVersion)
       }
 
       res.redirect(`/hdc/licenceConditions/conditionsSummary/${destination}`)

--- a/server/routes/config/licenceConditions.ts
+++ b/server/routes/config/licenceConditions.ts
@@ -1,4 +1,4 @@
-import type { ConditionVersion } from '../../data/licenceClientTypes'
+import type { AdditionalConditionsVersion } from '../../data/licenceClientTypes'
 import { additionalConditionsV1 } from '../../services/config/conditions/v1/fieldConfig'
 import { additionalConditionsV2 } from '../../services/config/conditions/v2/fieldConfig'
 
@@ -14,7 +14,7 @@ export const standard = {
   modificationRequiresApproval: true,
 }
 
-export const additional = new Map<ConditionVersion, any>([
+export const additional = new Map<AdditionalConditionsVersion, any>([
   [1, additionalConditionsV1],
   [2, additionalConditionsV2],
 ])

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -8,7 +8,7 @@ import type { LicenceService } from '../services/licenceService'
 import type { Response } from 'express'
 import type { ConditionsServiceFactory } from '../services/conditionsService'
 import { Licence, LicenceStage } from '../data/licenceTypes'
-import { ConditionVersion } from '../data/licenceClientTypes'
+import { AdditionalConditionsVersion } from '../data/licenceClientTypes'
 import { LicenceStatus } from '../services/licence/licenceStatusTypes'
 
 function shouldValidate(role, stage, postApproval) {
@@ -36,7 +36,7 @@ export = ({
     showErrors,
     licence: Licence,
     stage: LicenceStage,
-    conditionVersion: ConditionVersion
+    conditionVersion: AdditionalConditionsVersion
   ) {
     const { decisions, tasks } = licenceStatus
     return showErrors ? licenceService.validateFormGroup({ licence, stage, decisions, tasks, conditionVersion }) : {}

--- a/server/services/conditionsService.ts
+++ b/server/services/conditionsService.ts
@@ -8,15 +8,15 @@ import {
 } from './config/conditionsConfig'
 import { AdditionalConditions, Licence } from '../data/licenceTypes'
 import { LicenceRecord } from './licenceService'
-import { ConditionMetadata, ConditionVersion } from '../data/licenceClientTypes'
+import { ConditionMetadata, AdditionalConditionsVersion } from '../data/licenceClientTypes'
 import { LicenceWithConditionsBuilder } from './licenceWithConditionsBuilder'
 
 export class ConditionsServiceFactory {
-  getVersion(licence: LicenceRecord): ConditionVersion {
+  getVersion(licence: LicenceRecord): AdditionalConditionsVersion {
     return licence.versionDetails?.additional_conditions_version || CURRENT_CONDITION_VERSION
   }
 
-  forVersion(version: ConditionVersion) {
+  forVersion(version: AdditionalConditionsVersion) {
     return new ConditionsService(version)
   }
 
@@ -25,7 +25,7 @@ export class ConditionsServiceFactory {
     return this.forVersion(version)
   }
 
-  getNewVersion(licence: LicenceRecord): ConditionVersion {
+  getNewVersion(licence: LicenceRecord): AdditionalConditionsVersion {
     const version = licence.versionDetails?.additional_conditions_version
     return version == null ? CURRENT_CONDITION_VERSION : null
   }
@@ -34,7 +34,7 @@ export class ConditionsServiceFactory {
 export class ConditionsService {
   private readonly builder: LicenceWithConditionsBuilder
 
-  constructor(readonly version: ConditionVersion) {
+  constructor(readonly version: AdditionalConditionsVersion) {
     this.builder = new LicenceWithConditionsBuilder(version)
   }
 

--- a/server/services/config/conditionsConfig.ts
+++ b/server/services/config/conditionsConfig.ts
@@ -1,4 +1,4 @@
-import { ConditionVersion, ConditionMetadata } from '../../data/licenceClientTypes'
+import { AdditionalConditionsVersion, ConditionMetadata } from '../../data/licenceClientTypes'
 import { AdditionalConditions } from '../../data/licenceTypes'
 import * as v1 from './conditions/v1/conditions'
 import * as v2 from './conditions/v2/conditions'
@@ -6,25 +6,26 @@ import { standardConditions as stdConditions } from './conditions/standardCondit
 
 export const standardConditions = stdConditions
 
-export const CURRENT_CONDITION_VERSION: ConditionVersion = 2
+export const CURRENT_CONDITION_VERSION: AdditionalConditionsVersion = 2
 
-const pssConditions: Map<ConditionVersion, string[]> = new Map([
+const pssConditions: Map<AdditionalConditionsVersion, string[]> = new Map([
   [1, v1.pssConditions],
   [2, v2.pssConditions],
 ])
-export const getPssConditions = (version: ConditionVersion) => pssConditions.get(version)
+export const getPssConditions = (version: AdditionalConditionsVersion) => pssConditions.get(version)
 
-const additionalConditions: Map<ConditionVersion, ConditionMetadata[]> = new Map([
+const additionalConditions: Map<AdditionalConditionsVersion, ConditionMetadata[]> = new Map([
   [1, v1.conditions],
   [2, v2.conditions],
 ])
-export const getAdditionalConditionsConfig = (version: ConditionVersion) => additionalConditions.get(version)
+export const getAdditionalConditionsConfig = (version: AdditionalConditionsVersion) => additionalConditions.get(version)
 
-const modifyAdditionalConditions: Map<ConditionVersion, (conditions: AdditionalConditions) => void> = new Map([
-  [1, v1.modifyAdditionalConditions],
-  [2, v2.modifyAdditionalConditions],
-])
-export const applyModifications = (version: ConditionVersion, conditions: AdditionalConditions) =>
+const modifyAdditionalConditions: Map<AdditionalConditionsVersion, (conditions: AdditionalConditions) => void> =
+  new Map([
+    [1, v1.modifyAdditionalConditions],
+    [2, v2.modifyAdditionalConditions],
+  ])
+export const applyModifications = (version: AdditionalConditionsVersion, conditions: AdditionalConditions) =>
   modifyAdditionalConditions.get(version)(conditions)
 
 export const multiFields = {

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -7,7 +7,7 @@ import * as formValidation from './utils/formValidation'
 import { LicenceClient } from '../data/licenceClient'
 import { Licence, LicenceConditions, LicenceStage, RiskManagement } from '../data/licenceTypes'
 import { pickCurfewAddressPath } from './utils/pdfFormatter'
-import { ConditionVersion } from '../data/licenceClientTypes'
+import { ConditionVersion, StandardConditionsVersion } from '../data/licenceClientTypes'
 import { Decisions, Tasks } from './licence/licenceStatusTypes'
 import { riskManagementVersion } from '../config'
 
@@ -37,7 +37,12 @@ export interface LicenceRecord {
   licence: Licence
   stage: LicenceStage
   version: string
-  versionDetails: { version: number; vary_version: number; additional_conditions_version: ConditionVersion }
+  versionDetails: {
+    version: number
+    vary_version: number
+    additional_conditions_version: ConditionVersion
+    standard_conditions_version: StandardConditionsVersion
+  }
   approvedVersion: string
   approvedVersionDetails: ApprovedVersionDetails
 }
@@ -100,6 +105,7 @@ export class LicenceService {
         version: rawLicence.version,
         vary_version: rawLicence.vary_version,
         additional_conditions_version: rawLicence.additional_conditions_version,
+        standard_conditions_version: rawLicence.standard_conditions_version,
       }
       const approvedVersion = isEmpty(approvedVersionDetails)
         ? ''
@@ -264,6 +270,7 @@ export class LicenceService {
         this.licenceClient.updateLicence(bookingId, {}, postRelease),
         this.licenceClient.updateStage(bookingId, LicenceStage.ELIGIBILITY),
         this.licenceClient.setConditionsVersion(bookingId, null),
+        this.licenceClient.setStandardConditionsVersion(bookingId, null),
       ])
     } catch (error) {
       logger.error('Error during licence reset', error.stack)
@@ -582,6 +589,10 @@ export class LicenceService {
 
   setConditionsVersion(bookingId: number, conditionVersion: ConditionVersion) {
     return this.licenceClient.setConditionsVersion(bookingId, conditionVersion)
+  }
+
+  setStandardConditionsVersion(bookingId: number, standardConditionVersion: StandardConditionsVersion) {
+    return this.licenceClient.setStandardConditionsVersion(bookingId, standardConditionVersion)
   }
 }
 

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -7,7 +7,7 @@ import * as formValidation from './utils/formValidation'
 import { LicenceClient } from '../data/licenceClient'
 import { Licence, LicenceConditions, LicenceStage, RiskManagement } from '../data/licenceTypes'
 import { pickCurfewAddressPath } from './utils/pdfFormatter'
-import { ConditionVersion, StandardConditionsVersion } from '../data/licenceClientTypes'
+import { AdditionalConditionsVersion, StandardConditionsVersion } from '../data/licenceClientTypes'
 import { Decisions, Tasks } from './licence/licenceStatusTypes'
 import { riskManagementVersion } from '../config'
 
@@ -40,7 +40,7 @@ export interface LicenceRecord {
   versionDetails: {
     version: number
     vary_version: number
-    additional_conditions_version: ConditionVersion
+    additional_conditions_version: AdditionalConditionsVersion
     standard_conditions_version: StandardConditionsVersion
   }
   approvedVersion: string
@@ -269,7 +269,7 @@ export class LicenceService {
       Promise.all([
         this.licenceClient.updateLicence(bookingId, {}, postRelease),
         this.licenceClient.updateStage(bookingId, LicenceStage.ELIGIBILITY),
-        this.licenceClient.setConditionsVersion(bookingId, null),
+        this.licenceClient.setAdditionalConditionsVersion(bookingId, null),
         this.licenceClient.setStandardConditionsVersion(bookingId, null),
       ])
     } catch (error) {
@@ -484,7 +484,7 @@ export class LicenceService {
     stage: LicenceStage
     decisions?: Decisions
     tasks?: Tasks
-    conditionVersion: ConditionVersion
+    conditionVersion: AdditionalConditionsVersion
   }) {
     const {
       addressUnsuitable,
@@ -587,8 +587,8 @@ export class LicenceService {
     return this.licenceClient.saveApprovedLicenceVersion(bookingId, template)
   }
 
-  setConditionsVersion(bookingId: number, conditionVersion: ConditionVersion) {
-    return this.licenceClient.setConditionsVersion(bookingId, conditionVersion)
+  setAdditionalConditionsVersion(bookingId: number, additionalConditionVersion: AdditionalConditionsVersion) {
+    return this.licenceClient.setAdditionalConditionsVersion(bookingId, additionalConditionVersion)
   }
 
   setStandardConditionsVersion(bookingId: number, standardConditionVersion: StandardConditionsVersion) {

--- a/server/services/licenceWithConditionsBuilder.ts
+++ b/server/services/licenceWithConditionsBuilder.ts
@@ -1,10 +1,10 @@
 import { getIn, isEmpty, interleave } from '../utils/functionalHelpers'
 import { getAdditionalConditionsConfig, applyModifications, multiFields } from './config/conditionsConfig'
 import { AdditionalConditions, Licence } from '../data/licenceTypes'
-import { ConditionVersion } from '../data/licenceClientTypes'
+import { AdditionalConditionsVersion } from '../data/licenceClientTypes'
 
 export class LicenceWithConditionsBuilder {
-  constructor(private readonly conditionVersion: ConditionVersion) {}
+  constructor(private readonly conditionVersion: AdditionalConditionsVersion) {}
 
   populateLicenceWithApprovedConditions(licence: Licence) {
     return this.populateLicenceWithConditions(licence, null, true)

--- a/server/services/utils/formValidation.ts
+++ b/server/services/utils/formValidation.ts
@@ -22,7 +22,7 @@ import reportingConfig from '../../routes/config/reporting'
 import bassConfig from '../../routes/config/bassReferral'
 import * as conditionsConfig from '../../routes/config/licenceConditions'
 import { Licence } from '../../data/licenceTypes'
-import { ConditionVersion } from '../../data/licenceClientTypes'
+import { AdditionalConditionsVersion } from '../../data/licenceClientTypes'
 
 const postcode = joi
   .string()
@@ -210,7 +210,7 @@ export function validateGroup({
   licence: Licence
   group: string
   bespokeConditions: any
-  conditionVersion: ConditionVersion
+  conditionVersion: AdditionalConditionsVersion
 }) {
   const groups = {
     ELIGIBILITY: [

--- a/test/data/licenceClient.test.ts
+++ b/test/data/licenceClient.test.ts
@@ -55,6 +55,16 @@ describe('licenceClient', () => {
     })
   })
 
+  describe('getLicence', () => {
+    test('should pass in the correct parameters', async () => {
+      await licenceClient.getLicence(10001)
+      expect(db.query).toHaveBeenCalledWith({
+        text: `select licence, booking_id, stage, version, vary_version, additional_conditions_version, standard_conditions_version from licences where booking_id = $1`,
+        values: [10001],
+      })
+    })
+  })
+
   describe('createLicence', () => {
     const LICENCE_SAMPLE: Licence = { eligibility: { excluded: { decision: 'Yes' } } }
 
@@ -312,6 +322,19 @@ describe('licenceClient', () => {
       expect(db.query).toHaveBeenCalledWith({
         text: 'update licences l set additional_conditions_version = $1 where booking_id = $2',
         values: [2, 10001],
+      })
+    })
+  })
+
+  describe('setStandardConditionsVersion', () => {
+    test('should pass in the correct parameters', async () => {
+      await licenceClient.setStandardConditionsVersion(10001, 1)
+
+      expect(db.query).toHaveBeenCalledWith({
+        text: `update licences l
+             set standard_conditions_version = $1
+             where booking_id = $2`,
+        values: [1, 10001],
       })
     })
   })

--- a/test/data/licenceClient.test.ts
+++ b/test/data/licenceClient.test.ts
@@ -315,9 +315,9 @@ describe('licenceClient', () => {
     })
   })
 
-  describe('setConditionsVersion', () => {
+  describe('setAdditionalConditionsVersion', () => {
     test('should pass in the correct parameters', async () => {
-      await licenceClient.setConditionsVersion(10001, 2)
+      await licenceClient.setAdditionalConditionsVersion(10001, 2)
 
       expect(db.query).toHaveBeenCalledWith({
         text: 'update licences l set additional_conditions_version = $1 where booking_id = $2',

--- a/test/mockServices.ts
+++ b/test/mockServices.ts
@@ -34,7 +34,7 @@ export const createLicenceServiceStub = () => ({
   withdrawBass: jest.fn(),
   reinstateBass: jest.fn(),
   resetLicence: jest.fn(),
-  setConditionsVersion: jest.fn(),
+  setAdditionalConditionsVersion: jest.fn(),
 })
 
 export const createLduServiceStub = () => ({

--- a/test/routes/licenceConditions.test.ts
+++ b/test/routes/licenceConditions.test.ts
@@ -321,7 +321,7 @@ describe('/hdc/licenceConditions', () => {
           .send({ bookingId: 2 })
           .expect(302)
           .expect(() => {
-            expect(licenceService.setConditionsVersion).toHaveBeenCalledWith(2, 1)
+            expect(licenceService.setAdditionalConditionsVersion).toHaveBeenCalledWith(2, 1)
           })
       })
 
@@ -335,7 +335,7 @@ describe('/hdc/licenceConditions', () => {
           .send({ bookingId: 2 })
           .expect(302)
           .expect(() => {
-            expect(licenceService.setConditionsVersion).toHaveBeenCalledWith(2, 1)
+            expect(licenceService.setAdditionalConditionsVersion).toHaveBeenCalledWith(2, 1)
           })
       })
 
@@ -349,7 +349,7 @@ describe('/hdc/licenceConditions', () => {
           .send({ bookingId: 2 })
           .expect(302)
           .expect(() => {
-            expect(licenceService.setConditionsVersion).not.toHaveBeenCalled()
+            expect(licenceService.setAdditionalConditionsVersion).not.toHaveBeenCalled()
           })
       })
     })

--- a/test/services/conditionsService.test.ts
+++ b/test/services/conditionsService.test.ts
@@ -1,4 +1,4 @@
-import { ConditionVersion } from '../../server/data/licenceClientTypes'
+import { AdditionalConditionsVersion } from '../../server/data/licenceClientTypes'
 import { Licence } from '../../server/data/licenceTypes'
 import { ConditionsService, ConditionsServiceFactory } from '../../server/services/conditionsService'
 import { pssConditions } from '../../server/services/config/conditions/v1/conditions'
@@ -31,7 +31,7 @@ describe('conditionsService', () => {
       test('reads version from licence when set', () => {
         const licence = {} as LicenceRecord
         licence.versionDetails = {} as any
-        licence.versionDetails.additional_conditions_version = 1234 as ConditionVersion
+        licence.versionDetails.additional_conditions_version = 1234 as AdditionalConditionsVersion
 
         const version = factory.getVersion(licence)
 
@@ -51,7 +51,7 @@ describe('conditionsService', () => {
       test('reads version from licence when set', () => {
         const licence = {} as LicenceRecord
         licence.versionDetails = {} as any
-        licence.versionDetails.additional_conditions_version = 1234 as ConditionVersion
+        licence.versionDetails.additional_conditions_version = 1234 as AdditionalConditionsVersion
 
         const version = factory.getNewVersion(licence)
 
@@ -61,7 +61,7 @@ describe('conditionsService', () => {
 
     describe('forVersion', () => {
       test('version for new service', () => {
-        const createdService = factory.forVersion(1234 as ConditionVersion)
+        const createdService = factory.forVersion(1234 as AdditionalConditionsVersion)
 
         expect(createdService.version).toBe(1234)
       })
@@ -79,7 +79,7 @@ describe('conditionsService', () => {
       test('version for new service reads version from licence when set', () => {
         const licence = {} as LicenceRecord
         licence.versionDetails = {} as any
-        licence.versionDetails.additional_conditions_version = 1234 as ConditionVersion
+        licence.versionDetails.additional_conditions_version = 1234 as AdditionalConditionsVersion
 
         const createdService = factory.forLicence(licence)
 

--- a/test/services/licenceService.test.ts
+++ b/test/services/licenceService.test.ts
@@ -92,6 +92,7 @@ describe('licenceService', () => {
           vary_version: 5,
           version: 2,
           additional_conditions_version: 3,
+          standard_conditions_version: 1,
         },
       })
     })
@@ -109,6 +110,7 @@ describe('licenceService', () => {
           vary_version: 5,
           version: 2,
           additional_conditions_version: 3,
+          standard_conditions_version: 1,
         },
       })
     })

--- a/test/services/licenceService.test.ts
+++ b/test/services/licenceService.test.ts
@@ -7,7 +7,7 @@ import {
 import * as varyConfig from '../../server/routes/config/vary'
 import * as formValidation from '../../server/services/utils/formValidation'
 import { LicenceClient } from '../../server/data/licenceClient'
-import { CaseWithVaryVersion, ConditionVersion } from '../../server/data/licenceClientTypes'
+import { CaseWithVaryVersion, ConditionVersion, StandardConditionsVersion } from '../../server/data/licenceClientTypes'
 import { Licence, LicenceStage, Risk, RiskManagement, RiskVersion } from '../../server/data/licenceTypes'
 import { TaskState } from '../../server/services/config/taskState'
 import { riskManagementVersion } from '../../server/config'
@@ -29,6 +29,7 @@ describe('licenceService', () => {
         version: 2,
         vary_version: 5,
         additional_conditions_version: 3 as ConditionVersion,
+        standard_conditions_version: 1 as StandardConditionsVersion,
       }),
       createLicence: jest.fn() as jest.Mock<Promise<number>>,
       updateSection: jest.fn() as jest.Mock<Promise<void>>,
@@ -43,6 +44,7 @@ describe('licenceService', () => {
       getLicencesInStageBetweenDates: undefined,
       getLicencesInStageBeforeDate: undefined,
       setConditionsVersion: jest.fn(),
+      setStandardConditionsVersion: jest.fn(),
     }
     service = createLicenceService(licenceClient)
   })

--- a/test/services/licenceService.test.ts
+++ b/test/services/licenceService.test.ts
@@ -7,7 +7,11 @@ import {
 import * as varyConfig from '../../server/routes/config/vary'
 import * as formValidation from '../../server/services/utils/formValidation'
 import { LicenceClient } from '../../server/data/licenceClient'
-import { CaseWithVaryVersion, ConditionVersion, StandardConditionsVersion } from '../../server/data/licenceClientTypes'
+import {
+  CaseWithVaryVersion,
+  AdditionalConditionsVersion,
+  StandardConditionsVersion,
+} from '../../server/data/licenceClientTypes'
 import { Licence, LicenceStage, Risk, RiskManagement, RiskVersion } from '../../server/data/licenceTypes'
 import { TaskState } from '../../server/services/config/taskState'
 import { riskManagementVersion } from '../../server/config'
@@ -28,7 +32,7 @@ describe('licenceService', () => {
         stage: undefined,
         version: 2,
         vary_version: 5,
-        additional_conditions_version: 3 as ConditionVersion,
+        additional_conditions_version: 3 as AdditionalConditionsVersion,
         standard_conditions_version: 1 as StandardConditionsVersion,
       }),
       createLicence: jest.fn() as jest.Mock<Promise<number>>,
@@ -43,7 +47,7 @@ describe('licenceService', () => {
       saveApprovedLicenceVersion: undefined,
       getLicencesInStageBetweenDates: undefined,
       getLicencesInStageBeforeDate: undefined,
-      setConditionsVersion: jest.fn(),
+      setAdditionalConditionsVersion: jest.fn(),
       setStandardConditionsVersion: jest.fn(),
     }
     service = createLicenceService(licenceClient)
@@ -1964,16 +1968,16 @@ describe('licenceService', () => {
       expect(licenceClient.updateStage).toBeCalledWith(100, LicenceStage.ELIGIBILITY)
     })
 
-    it('should call setConditionsVersion', () => {
+    it('should call setAdditionalConditionsVersion', () => {
       service.resetLicence(100, false)
-      expect(licenceClient.setConditionsVersion).toBeCalledWith(100, null)
+      expect(licenceClient.setAdditionalConditionsVersion).toBeCalledWith(100, null)
     })
   })
 
   describe('set conditions version', () => {
-    it('should call setConditionsVersion', () => {
-      service.setConditionsVersion(100, 1)
-      expect(licenceClient.setConditionsVersion).toBeCalledWith(100, 1)
+    it('should call setAdditionalConditionsVersion', () => {
+      service.setAdditionalConditionsVersion(100, 1)
+      expect(licenceClient.setAdditionalConditionsVersion).toBeCalledWith(100, 1)
     })
   })
 })


### PR DESCRIPTION
**Tasks**
- [x] ✨ Add Standard Condition via DB Migration
- [x] ✨ Add functionality to store/retreive standard licence version in `licenceClient.ts`
- [x] ✨ Add functionality to store/retreive standard licence version in `licenceService.ts`
- [x] ♻️ Refactor `ConditionsVersion` to more specific `AdditionalConditionVersion` throughout the application

**Notes**
- Most of the file changes are due to the renaming `AdditionalConditionVersion` - this has been done to clarify the difference between itself and `StandardConditionsVersion`
- This change is not user-facing; this PR only sets up the ability to retrieve and persist the `StandardConditionsVersion` - a different ticket will implement this in the user-facing journeys