### PR TITLE
DCS-1959 update licence status DONE conditional for risk

### DIFF
--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -258,9 +258,14 @@ function getRiskManagementState(licence) {
     }
 
     if (
-      (riskManagementAnswer || checksConsideredAnswer === 'Yes') &&
-      awaitingInformationAnswer &&
-      proposedAddressSuitable
+      ((riskManagementAnswer || checksConsideredAnswer === 'Yes') &&
+        awaitingInformationAnswer &&
+        proposedAddressSuitable) ||
+      (riskManagementVersion === '2' &&
+        checksConsideredAnswer === 'No' &&
+        awaitingInformationAnswer &&
+        proposedAddressSuitable &&
+        bassAreaSuitable)
     ) {
       return TaskState.DONE
     }

--- a/test/services/licence/licenceStatus.test.ts
+++ b/test/services/licence/licenceStatus.test.ts
@@ -851,6 +851,40 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.riskManagementNeeded).toBe(false)
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })
+
+      test('should show risk management version 2 DONE if all questions answered when mandatory address checks answer is No but bass area is suitable', () => {
+        const licence = {
+          stage: 'PROCESSING_RO',
+          licence: {
+            bassReferral: {
+              bassAreaCheck: {
+                bassAreaSuitable: 'Yes',
+              },
+            },
+            risk: {
+              riskManagement: {
+                version: '2',
+                hasConsideredChecks: 'No',
+                awaitingOtherInformation: 'No',
+                emsInformation: 'Yes',
+                emsInformationDetails: 'some details',
+                nonDisclosableInformation: 'No',
+                nonDisclosableInformationDetails: '',
+                proposedAddressSuitable: 'Yes',
+                riskManagementDetails: 'some details',
+                unsuitableReason: '',
+              },
+            },
+          },
+        }
+
+        const status = getLicenceStatus(licence)
+
+        expect(status.tasks.riskManagement).toEqual(TaskState.DONE)
+        expect(status.decisions.showMandatoryAddressChecksNotCompletedWarning).toBe(false)
+        expect(status.decisions.riskManagementNeeded).toBe(false)
+        expect(status.decisions.awaitingRiskInformation).toBe(false)
+      })
     })
 
     describe('curfewAddressReview task', () => {


### PR DESCRIPTION
Fix to trigger risk section displaying as Completed in the task list when bass address is suitable and a user selects No to the mandatory address checks question. 

Previously under these circumstances the risk section appeared as incomplete in the task list:
<img width="828" alt="Screenshot 2022-12-14 at 15 04 24" src="https://user-images.githubusercontent.com/48809053/207644374-6e3f6f2c-d301-4b3f-9722-2f87e7fc0741.png">

With these changes when a user completes the risk section answering No to the mandatory checks and previously bass area suitable we now see a completed risk section in the task list:
<img width="944" alt="Screenshot 2022-12-14 at 15 56 33" src="https://user-images.githubusercontent.com/48809053/207644614-d0613990-0e4b-4369-98a7-0297af660b16.png">
