### PR TITLE
DCS-1962 mandatory check banner fix

### DIFF
--- a/server/services/licence/bassAddressState.ts
+++ b/server/services/licence/bassAddressState.ts
@@ -8,10 +8,12 @@ export function getBassRequestState(licence) {
   const addressProposedAnswer = getIn(licence, ['proposedAddress', 'addressProposed', 'decision'])
 
   const bassReferralNeeded = bassRequestAnswer === 'Yes' && addressProposedAnswer === 'No'
+  const bassRequested = bassRequestAnswer && bassRequestAnswer === 'Yes'
   const bassAreaSpecified = getIn(licence, ['bassReferral', 'bassRequest', 'specificArea']) !== 'No'
   const bassRequest = getTaskState()
 
   return {
+    bassRequested,
     bassReferralNeeded,
     bassAreaSpecified,
     bassRequest,

--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -239,13 +239,13 @@ function getRiskManagementState(licence) {
   const checksConsideredAnswer = riskManagement?.hasConsideredChecks
   const awaitingInformationAnswer = riskManagement?.awaitingInformation || riskManagement?.awaitingOtherInformation
   const { proposedAddressSuitable } = riskManagement || {}
-  const { bassAreaSuitable } = getBassAreaState(licence)
+  const { bassRequested } = getBassRequestState(licence)
 
   return {
     riskManagementVersion,
     riskManagementNeeded: riskManagementAnswer === 'Yes',
     showMandatoryAddressChecksNotCompletedWarning:
-      riskManagementVersion === '2' && checksConsideredAnswer !== 'Yes' && !bassAreaSuitable,
+      riskManagementVersion === '2' && checksConsideredAnswer !== 'Yes' && !bassRequested,
     proposedAddressSuitable: proposedAddressSuitable === 'Yes',
     awaitingRiskInformation: awaitingInformationAnswer === 'Yes',
     riskManagement: getState(),
@@ -265,7 +265,7 @@ function getRiskManagementState(licence) {
         checksConsideredAnswer === 'No' &&
         awaitingInformationAnswer &&
         proposedAddressSuitable &&
-        bassAreaSuitable)
+        bassRequested)
     ) {
       return TaskState.DONE
     }

--- a/server/services/licence/licenceStatusTypes.ts
+++ b/server/services/licence/licenceStatusTypes.ts
@@ -20,6 +20,7 @@ export type Decisions = {
   insufficientTimeStop?: boolean
 
   // BASS address related
+  bassRequested?: boolean
   bassReferralNeeded?: boolean
   bassAreaSpecified?: boolean
   bassAreaSuitable?: boolean

--- a/test/routes/viewModels/taskLists/tasks/riskManagement.test.js
+++ b/test/routes/viewModels/taskLists/tasks/riskManagement.test.js
@@ -70,7 +70,7 @@ describe('risk management task', () => {
     })
   })
 
-  test('should return warning if mandatory address checks not completed and BASS address suitable is false', () => {
+  test('should return warning if mandatory address checks not completed and a bass property has not been requested', () => {
     expect(
       riskManagement.view({
         decisions: { showMandatoryAddressChecksNotCompletedWarning: true, riskManagementVersion: '2' },

--- a/test/services/licence/licenceStatus.test.ts
+++ b/test/services/licence/licenceStatus.test.ts
@@ -852,13 +852,13 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })
 
-      test('should show risk management version 2 DONE if all questions answered when mandatory address checks answer is No but bass area is suitable', () => {
+      test('should show risk management version 2 DONE if all questions answered when mandatory address checks answer is No but bass property has been requested', () => {
         const licence = {
           stage: 'PROCESSING_RO',
           licence: {
             bassReferral: {
-              bassAreaCheck: {
-                bassAreaSuitable: 'Yes',
+              bassRequest: {
+                bassRequested: 'Yes',
               },
             },
             risk: {


### PR DESCRIPTION
Changing bass property conditional to check bassRequested instead of bassAreaSuitable.