### PR TITLE
DCS-1963 make risk view default content version 2

### DIFF
--- a/licences-specs/src/test/resources/licences/assessment/done.json
+++ b/licences-specs/src/test/resources/licences/assessment/done.json
@@ -92,6 +92,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "victimLiaison": "No"

--- a/licences-specs/src/test/resources/licences/assessment/risks-nonDisclosableInformation.json
+++ b/licences-specs/src/test/resources/licences/assessment/risks-nonDisclosableInformation.json
@@ -92,6 +92,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes",

--- a/licences-specs/src/test/resources/licences/assessment/risks-yes.json
+++ b/licences-specs/src/test/resources/licences/assessment/risks-yes.json
@@ -92,6 +92,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "Yes",
         "planningActionsDetails": "Risk management detail",
         "awaitingInformation": "Yes",

--- a/licences-specs/src/test/resources/licences/decision/approved-bass.json
+++ b/licences-specs/src/test/resources/licences/decision/approved-bass.json
@@ -76,6 +76,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "victimLiaison": "No"

--- a/licences-specs/src/test/resources/licences/decision/approved-missing.json
+++ b/licences-specs/src/test/resources/licences/decision/approved-missing.json
@@ -94,6 +94,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "victimLiaison": "No"

--- a/licences-specs/src/test/resources/licences/decision/approved.json
+++ b/licences-specs/src/test/resources/licences/decision/approved.json
@@ -91,6 +91,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/decision/refused.json
+++ b/licences-specs/src/test/resources/licences/decision/refused.json
@@ -3,6 +3,7 @@
   "licence": {
     "risk": {
       "riskManagement": {
+        "version": "1",
         "emsInformation": "No",
         "planningActions": "No",
         "unsuitableReason": "",

--- a/licences-specs/src/test/resources/licences/decision/risks-rejected.json
+++ b/licences-specs/src/test/resources/licences/decision/risks-rejected.json
@@ -60,6 +60,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "No"

--- a/licences-specs/src/test/resources/licences/decision/unstarted.json
+++ b/licences-specs/src/test/resources/licences/decision/unstarted.json
@@ -91,6 +91,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/finalchecks/approved-premises.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/approved-premises.json
@@ -102,6 +102,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/finalchecks/final-checks-done.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/final-checks-done.json
@@ -91,6 +91,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/finalchecks/final-checks.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/final-checks.json
@@ -91,6 +91,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/finalchecks/postponed.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/postponed.json
@@ -92,6 +92,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "victimLiaison": "No"

--- a/licences-specs/src/test/resources/licences/finalchecks/serious-offence-on-remand.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/serious-offence-on-remand.json
@@ -91,6 +91,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/finalchecks/serious-offence.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/serious-offence.json
@@ -91,6 +91,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/finalchecks/unstarted.json
+++ b/licences-specs/src/test/resources/licences/finalchecks/unstarted.json
@@ -92,6 +92,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes"

--- a/licences-specs/src/test/resources/licences/postDecision/address-withdrawn-new.json
+++ b/licences-specs/src/test/resources/licences/postDecision/address-withdrawn-new.json
@@ -3,6 +3,7 @@
   "licence": {
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No"
       }

--- a/licences-specs/src/test/resources/licences/postDecision/address-withdrawn.json
+++ b/licences-specs/src/test/resources/licences/postDecision/address-withdrawn.json
@@ -3,6 +3,7 @@
   "licence": {
     "risk": {
       "riskManagement": {
+        "version": "1",
         "victimLiaison": "No",
         "planningActions": "No",
         "awaitingInformation": "No"

--- a/licences-specs/src/test/resources/licences/review/address-rejected-electricity.json
+++ b/licences-specs/src/test/resources/licences/review/address-rejected-electricity.json
@@ -97,6 +97,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "victimLiaison": "No"

--- a/licences-specs/src/test/resources/licences/review/address-rejected.json
+++ b/licences-specs/src/test/resources/licences/review/address-rejected.json
@@ -97,6 +97,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "victimLiaison": "No"

--- a/licences-specs/src/test/resources/licences/review/no-conditions.json
+++ b/licences-specs/src/test/resources/licences/review/no-conditions.json
@@ -47,6 +47,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "Yes",
         "planningActionsDetails": "Risk details",
         "awaitingInformation": "Yes",

--- a/licences-specs/src/test/resources/licences/review/normal-ems.json
+++ b/licences-specs/src/test/resources/licences/review/normal-ems.json
@@ -98,6 +98,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes",

--- a/licences-specs/src/test/resources/licences/review/normal.json
+++ b/licences-specs/src/test/resources/licences/review/normal.json
@@ -101,6 +101,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "No",
         "awaitingInformation": "No",
         "proposedAddressSuitable": "Yes",

--- a/licences-specs/src/test/resources/licences/review/risks-nonDisclosable.json
+++ b/licences-specs/src/test/resources/licences/review/risks-nonDisclosable.json
@@ -48,6 +48,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "Yes",
         "awaitingInformation": "Yes",
         "riskManagementDetails": "Information details",

--- a/licences-specs/src/test/resources/licences/review/risks.json
+++ b/licences-specs/src/test/resources/licences/review/risks.json
@@ -48,6 +48,7 @@
     },
     "risk": {
       "riskManagement": {
+        "version": "1",
         "planningActions": "Yes",
         "awaitingInformation": "Yes",
         "riskManagementDetails": "Information details",

--- a/server/routes/risk.ts
+++ b/server/routes/risk.ts
@@ -23,10 +23,10 @@ export default ({ licenceService }: { licenceService: LicenceService }) =>
         version: riskVersion,
       }
 
-      if (riskVersion === '2') {
-        res.render(`risk/riskManagementV2`, viewData)
-      } else {
+      if (riskVersion === '1') {
         res.render(`risk/riskManagementV1`, viewData)
+      } else {
+        res.render(`risk/riskManagementV2`, viewData)
       }
     }
 

--- a/server/views/forms/curfewAddress.pug
+++ b/server/views/forms/curfewAddress.pug
@@ -24,10 +24,10 @@ block content
 
   include includes/conditions
 
-  if riskManagement.version === '2'
-    include includes/riskV2
-  else
+  if riskManagement.version === '1'
     include includes/riskV1
+  else
+    include includes/riskV2
 
   include includes/victim
 

--- a/server/views/review/risk.pug
+++ b/server/views/review/risk.pug
@@ -12,17 +12,7 @@ block content
   div.pure-u-1.pure-u-md-1-2.paddingBottom
     h2.heading-large Risk management
 
-    if risk.version == '2'
-      div.smallPaddingTop
-        p Have you requested and considered current risk information from the police and children’s services related to the proposed address?
-
-        span#hasConsideredChecks.block.bold #{risk.hasConsideredChecks}
-
-      div.smallPaddingTop
-        p Are you waiting for any other information?
-
-        span#awaitingOtherInformation.block.bold #{risk.awaitingOtherInformation}
-    else 
+    if risk.version == '1'
       div.smallPaddingTop
         p Are there any risk management planning actions that must take place prior to release?
 
@@ -32,6 +22,17 @@ block content
         p Are you still awaiting information?
 
         span#awaitingInformation.block.bold #{risk.awaitingInformation}
+
+    else 
+      div.smallPaddingTop
+        p Have you requested and considered current risk information from the police and children’s services related to the proposed address?
+
+        span#hasConsideredChecks.block.bold #{risk.hasConsideredChecks}
+
+      div.smallPaddingTop
+        p Are you waiting for any other information?
+
+        span#awaitingOtherInformation.block.bold #{risk.awaitingOtherInformation}
 
     if risk.riskManagementDetails
       div.smallPaddingTop


### PR DESCRIPTION
To avoid old risk section questions displaying if no risk version present have changed conditionals to check for risk version 1 which following the data migration should always be present for old or in progress licences. Now version 2 content will be displayed as default. 