### PR TITLE
DCS-2238 add risk management question for managing offender safely in community

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -53,4 +53,4 @@ EXIT_LOCATION_URL=/
 GLOBAL_SEARCH_URL=http://localhost:3002/global-search
 FEEDBACK_SUPPORT_URL=https://support-dev.hmpps.service.justice.gov.uk/feedback-and-support
 
-LICENCE_RISK_MANAGEMENT_VERSION=2
+LICENCE_RISK_MANAGEMENT_VERSION=3

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -44,4 +44,4 @@ env:
   TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
   FEEDBACK_SUPPORT_URL: "https://support-dev.hmpps.service.justice.gov.uk/feedback-and-support"
-  LICENCE_RISK_MANAGEMENT_VERSION: '2'
+  LICENCE_RISK_MANAGEMENT_VERSION: '3'

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -41,7 +41,7 @@ env:
   TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
   FEEDBACK_SUPPORT_URL: "https://support-preprod.hmpps.service.justice.gov.uk/feedback-and-support"
-  LICENCE_RISK_MANAGEMENT_VERSION: '2'
+  LICENCE_RISK_MANAGEMENT_VERSION: '3'
 
 allowlist:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -41,7 +41,7 @@ env:
   TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
   FEEDBACK_SUPPORT_URL: "https://support.hmpps.service.justice.gov.uk/feedback-and-support"
-  LICENCE_RISK_MANAGEMENT_VERSION: '2'
+  LICENCE_RISK_MANAGEMENT_VERSION: '3'
 
 allowlist:
   office: "217.33.148.210/32"

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/RiskManagementV3Page.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/RiskManagementV3Page.groovy
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.licences.pages.assessment
+
+import geb.Page
+import geb.module.RadioButtons
+import uk.gov.justice.digital.hmpps.licences.modules.HeaderModule
+
+class RiskManagementV3Page extends Page {
+
+  static url = '/hdc/risk/riskManagement'
+
+  static at = {
+    browser.currentUrl.contains(url)
+  }
+
+  static content = {
+    header { module(HeaderModule) }
+
+    hasConsideredChecksRadios { $(name: "hasConsideredChecks").module(RadioButtons) }
+    awaitingOtherInformationRadios { $(name: "awaitingOtherInformation").module(RadioButtons) }
+
+    addressSuitableRadios { $(name: "proposedAddressSuitable").module(RadioButtons) }
+    emsInformationRadios(required: false) { $(name: "emsInformation").module(RadioButtons) }
+    manageInTheCommunityRadios { $(name: "manageInTheCommunity").module(RadioButtons) }
+    nonDisclosableInformationRadios { $(name: "nonDisclosableInformation").module(RadioButtons) }
+
+    riskManagementForm { $("#riskManagementDetails") }
+    addressSuitableForm(required: false) { $("#unsuitableReason") }
+    emsInformationForm(required: false) { $("#emsInformationForm") }
+    emsInformationDetails(required: false) { $("#emsInformationDetails") }
+    manageInTheCommunityNotPossibleForm(required: false) { $("#manageInTheCommunityNotPossibleReason") }
+
+    nonDisclosableInformationForm (required: false) { $("#nonDisclosableInformationDetails") }
+    nonDisclosableInformationView (required: false) { $("#nonDisclosableInformationDetailsView") }
+  }
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/RiskManagementV3Spec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/RiskManagementV3Spec.groovy
@@ -1,0 +1,151 @@
+package uk.gov.justice.digital.hmpps.licences.specs.assessment
+
+import geb.spock.GebReportingSpec
+import spock.lang.Shared
+import spock.lang.Stepwise
+import uk.gov.justice.digital.hmpps.licences.pages.assessment.RiskManagementV3Page
+import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
+import uk.gov.justice.digital.hmpps.licences.util.Actions
+import uk.gov.justice.digital.hmpps.licences.util.TestData
+
+@Stepwise
+class RiskManagementV3Spec extends GebReportingSpec {
+
+  @Shared
+  TestData testData = new TestData()
+
+  @Shared
+  Actions actions = new Actions()
+
+  def setupSpec() {
+    testData.loadLicence('assessment/unstarted')
+    actions.logIn('RO')
+  }
+
+  def cleanupSpec() {
+    actions.logOut()
+  }
+
+  def 'Options initially blank'() {
+
+    given: 'At task list page'
+    to TaskListPage, testData.markAndrewsBookingId
+
+    when: 'I start the risk management task'
+    taskListAction('Risk management').click()
+
+    then: 'I see the risk management page'
+    at RiskManagementV3Page
+
+    and: 'The options are unset'
+    hasConsideredChecksRadios.checked == null
+    awaitingOtherInformationRadios.checked == null
+    addressSuitableRadios.checked == null
+    manageInTheCommunityRadios.checked == null
+    nonDisclosableInformationRadios.checked == null
+  }
+
+  def 'Address suitability reasons shown when No'() {
+
+    when: 'At risk management page'
+    at RiskManagementV3Page
+
+    then: 'I dont see the reason form'
+    !addressSuitableForm.isDisplayed()
+
+    when: 'I select no for address suitability'
+    addressSuitableRadios.checked = 'No'
+
+    then: 'I see the reason form'
+    addressSuitableForm.isDisplayed()
+  }
+
+  def 'EMS Information radios shown when address suitable is Yes'() {
+
+    when: 'At risk management page'
+    at RiskManagementV3Page
+
+    then: 'I dont see the EMS information radio buttons'
+    !emsInformationForm.isDisplayed()
+
+    when: 'I select Yes for address suitability'
+    addressSuitableRadios.checked = 'Yes'
+
+    then: 'I see the EMS Information buttons'
+    emsInformationForm.isDisplayed()
+  }
+
+  def 'EMS Information text box shown when address suitable is Yes'() {
+
+    when: 'At risk management page'
+    at RiskManagementV3Page
+    and: 'I select Yes for address suitability'
+    addressSuitableRadios.checked = 'Yes'
+
+    then: 'I see the EMS Information buttons'
+    emsInformationForm.isDisplayed()
+    !emsInformationDetails.isDisplayed()
+
+    when: 'I select No'
+    emsInformationRadios.checked = 'No'
+
+    then: 'I do not see the EMS information text box'
+    !emsInformationDetails.isDisplayed()
+
+    when: 'I select Yes'
+    emsInformationRadios.checked = 'Yes'
+
+    then: 'I see the EMS Information text box'
+    emsInformationDetails.isDisplayed()
+  }
+
+    def 'Managing offender in the community not possible reasons shown when No'() {
+
+    when: 'At risk management page'
+    at RiskManagementV3Page
+
+    then: 'I dont see the reason form'
+    !manageInTheCommunityNotPossibleForm.isDisplayed()
+
+    when: 'I select no for managing offender in the community'
+    manageInTheCommunityRadios.checked = 'No'
+
+    then: 'I see the reason form'
+    manageInTheCommunityNotPossibleForm.isDisplayed()
+  }
+
+  def 'Non-disclosable information shown when Yes'() {
+
+    when: 'At risk management page'
+    at RiskManagementV3Page
+
+    then: 'I don\'t see the non-disclosable text box'
+    !nonDisclosableInformationForm.isDisplayed()
+
+    when: 'I select yes for non-disclosable information'
+    nonDisclosableInformationRadios.checked = 'Yes'
+
+    then: 'I see the non-disclosable information text box'
+    nonDisclosableInformationForm.isDisplayed()
+  }
+
+  def 'Modified choices are saved after save and continue'() {
+
+    given: 'At risk management page'
+    at RiskManagementV3Page
+
+    when: 'I select new options'
+    hasConsideredChecksRadios.checked = 'Yes'
+    addressSuitableRadios.checked = 'No'
+
+    and: 'I save and continue'
+    find('#continueBtn').click()
+
+    and: 'I return to the risk management page'
+    to RiskManagementV3Page, testData.markAndrewsBookingId
+
+    then: 'I see the previously entered values'
+    hasConsideredChecksRadios.checked == 'Yes'
+    addressSuitableRadios.checked == 'No'
+  }
+}

--- a/server/config.js
+++ b/server/config.js
@@ -211,5 +211,5 @@ module.exports = {
     ),
   },
 
-  riskManagementVersion: get('LICENCE_RISK_MANAGEMENT_VERSION', '2'),
+  riskManagementVersion: get('LICENCE_RISK_MANAGEMENT_VERSION', '3'),
 }

--- a/server/routes/config/risk.ts
+++ b/server/routes/config/risk.ts
@@ -1,29 +1,31 @@
+import { riskManagementVersion } from '../../config'
+
 export default {
   riskManagement: {
     licenceSection: 'riskManagement',
     fields: [
       {
         planningActions: {
-          responseType: 'requiredYesNoIfNot_version_2',
+          responseType: 'requiredYesNoIf_version_1',
           validationMessage: 'Say if there are risk management actions',
         },
       },
       {
         awaitingInformation: {
-          responseType: 'requiredYesNoIfNot_version_2',
+          responseType: 'requiredYesNoIf_version_1',
           validationMessage: 'Say if you are still awaiting information',
         },
       },
       {
         hasConsideredChecks: {
-          responseType: 'requiredYesNoIf_version_2',
+          responseType: 'requiredYesNoIfNot_version_1',
           validationMessage:
             'Say if you have requested and considered risk information related to the proposed address',
         },
       },
       {
         awaitingOtherInformation: {
-          responseType: 'requiredYesNoIf_version_2',
+          responseType: 'requiredYesNoIfNot_version_1',
           validationMessage: 'Say if you are still awaiting information',
         },
       },

--- a/server/routes/config/risk.ts
+++ b/server/routes/config/risk.ts
@@ -61,6 +61,19 @@ export default {
         },
       },
       {
+        manageInTheCommunity: {
+          responseType: 'requiredYesNoIf_version_3',
+          validationMessage:
+            'Say if it is possible to manage the offender in the community safely at the proposed address',
+        },
+      },
+      {
+        manageInTheCommunityNotPossibleReason: {
+          responseType: 'requiredStringIf_manageInTheCommunity_No',
+          validationMessage: 'Provide details of why you made this decision',
+        },
+      },
+      {
         nonDisclosableInformation: {
           responseType: 'requiredYesNo',
           validationMessage: 'Say if you want to add information that cannot be disclosed to the offender',

--- a/server/routes/risk.ts
+++ b/server/routes/risk.ts
@@ -25,8 +25,10 @@ export default ({ licenceService }: { licenceService: LicenceService }) =>
 
       if (riskVersion === '1') {
         res.render(`risk/riskManagementV1`, viewData)
-      } else {
+      } else if (riskVersion === '2') {
         res.render(`risk/riskManagementV2`, viewData)
+      } else {
+        res.render(`risk/riskManagementV3`, viewData)
       }
     }
 

--- a/server/routes/viewModels/taskLists/tasks/riskManagement.js
+++ b/server/routes/viewModels/taskLists/tasks/riskManagement.js
@@ -24,7 +24,7 @@ const getLabel = ({ decisions, tasks }) => {
     }
   }
 
-  if (riskManagementVersion === '2') {
+  if (riskManagementVersion === '2' || riskManagementVersion === '3') {
     if (showMandatoryAddressChecksNotCompletedWarning) {
       return 'WARNING||Mandatory address checks not completed'
     }

--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -254,7 +254,7 @@ function getRiskManagementState(licence) {
   const riskManagementAnswer = riskManagement?.planningActions
   const checksConsideredAnswer = riskManagement?.hasConsideredChecks
   const awaitingInformationAnswer = riskManagement?.awaitingInformation || riskManagement?.awaitingOtherInformation
-  const { proposedAddressSuitable } = riskManagement || {}
+  const { proposedAddressSuitable, manageInTheCommunity } = riskManagement || {}
   const { bassRequested } = getBassRequestState(licence)
 
   return {
@@ -265,7 +265,7 @@ function getRiskManagementState(licence) {
     proposedAddressSuitable: proposedAddressSuitable === 'Yes',
     awaitingRiskInformation: awaitingInformationAnswer === 'Yes',
     riskManagement: getState(),
-    addressUnsuitable: proposedAddressSuitable === 'No',
+    addressUnsuitable: proposedAddressSuitable === 'No' || manageInTheCommunity === 'No',
   }
 
   function getState() {

--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -254,6 +254,7 @@ function getRiskManagementState(licence) {
   const riskManagementAnswer = riskManagement?.planningActions
   const checksConsideredAnswer = riskManagement?.hasConsideredChecks
   const awaitingInformationAnswer = riskManagement?.awaitingInformation || riskManagement?.awaitingOtherInformation
+  const manageInTheCommunityAnswer = riskManagement?.manageInTheCommunity
   const { proposedAddressSuitable, manageInTheCommunity } = riskManagement || {}
   const { bassRequested } = getBassRequestState(licence)
 
@@ -262,10 +263,12 @@ function getRiskManagementState(licence) {
     riskManagementNeeded: riskManagementAnswer === 'Yes',
     showMandatoryAddressChecksNotCompletedWarning:
       riskManagementVersion === '2' && checksConsideredAnswer !== 'Yes' && !bassRequested,
-    proposedAddressSuitable: proposedAddressSuitable === 'Yes',
+    proposedAddressSuitable:
+      proposedAddressSuitable === 'Yes' || (riskManagementVersion === '3' && manageInTheCommunity === 'Yes'),
     awaitingRiskInformation: awaitingInformationAnswer === 'Yes',
     riskManagement: getState(),
-    addressUnsuitable: proposedAddressSuitable === 'No' || manageInTheCommunity === 'No',
+    addressUnsuitable:
+      proposedAddressSuitable === 'No' || (riskManagementVersion === '3' && manageInTheCommunity === 'No'),
   }
 
   function getState() {
@@ -274,9 +277,15 @@ function getRiskManagementState(licence) {
     }
 
     if (
-      ((riskManagementAnswer || checksConsideredAnswer === 'Yes') &&
+      (riskManagementVersion !== '3' &&
+        (riskManagementAnswer || checksConsideredAnswer === 'Yes') &&
         awaitingInformationAnswer &&
         proposedAddressSuitable) ||
+      (riskManagementVersion === '3' &&
+        (riskManagementAnswer || checksConsideredAnswer === 'Yes') &&
+        awaitingInformationAnswer &&
+        proposedAddressSuitable &&
+        manageInTheCommunityAnswer) ||
       (riskManagementVersion === '2' &&
         checksConsideredAnswer === 'No' &&
         awaitingInformationAnswer &&

--- a/server/views/forms/curfewAddress.pug
+++ b/server/views/forms/curfewAddress.pug
@@ -26,8 +26,10 @@ block content
 
   if riskManagement.version === '1'
     include includes/riskV1
-  else
+  else if riskManagement.version === '2'
     include includes/riskV2
+  else
+    include includes/riskV3
 
   include includes/victim
 

--- a/server/views/forms/includes/riskV3.pug
+++ b/server/views/forms/includes/riskV3.pug
@@ -1,0 +1,27 @@
+div.no-break.smallPaddingBottom#risk
+  h2 Risk management
+  p Have you requested and considered current risk information from the police and children’s services related to the proposed address?
+    br
+    span.entry #{riskManagement.hasConsideredChecks}
+
+  p Are you waiting for any other information?
+    br
+    span.entry #{riskManagement.awaitingOtherInformation}
+
+  p Details of outstanding actions or information
+    br
+    if riskManagement.riskManagementDetails
+      span.entry #{riskManagement.riskManagementDetails}
+    else
+      span.entry None
+
+  p Additional information about the offender or the address to assist the EMS provider on the day of release
+    br
+    if riskManagement.emsInformation === 'Yes'
+      span.entry #{riskManagement.emsInformationDetails}
+    else
+      span.entry None
+
+  p Is it possible to manage the offender safely in the community if released to the proposed address?
+    br
+    span.entry #{riskManagement.manageInTheCommunity}

--- a/server/views/review/includes/licenceSummary.pug
+++ b/server/views/review/includes/licenceSummary.pug
@@ -1,5 +1,6 @@
 include additionalConditions
 -var riskVersion1 = data.risk && data.risk.riskManagement && data.risk && data.risk.riskManagement.version === '1'
+-var riskVersion2 = data.risk && data.risk.riskManagement && data.risk && data.risk.riskManagement.version === '2'
 
 mixin change(url, anchorId)
   a(id=anchorId href=url) Change
@@ -77,8 +78,10 @@ div.largeMarginBottom
       +errorMessageOrBlock(errorObject.risk && errorObject.risk.riskManagement, 'risk-error')
         if riskVersion1
           include riskManagementV1 
-        else
+        else if riskVersion2 
           include riskManagementV2
+        else 
+          include riskManagementV3
 
   if sections.victimLiaison
     div.borderBottom

--- a/server/views/review/includes/riskManagementV3.pug
+++ b/server/views/review/includes/riskManagementV3.pug
@@ -1,0 +1,83 @@
+
+include ./itemAndError
+-var risk = data.risk && data.risk.riskManagement || {}
+-var bass = data.bassReferral && data.bassReferral.bassAreaCheck || {}
+-var errors = errorObject.risk && errorObject.risk.riskManagement || {}
+
+div.pure-g.borderBottomLight.midPaddingTopBottom
+  div.pure-u-1-2
+    div.pure-g
+      span.pure-u-3-4 Have you requested and considered current risk information from the police and children’s services related to the proposed address?
+  div.pure-u-1-2
+    if risk.hasConsideredChecks === 'No' && bass.bassAreaSuitable !== 'Yes'
+      div.pure-g
+        div.pure-u-1.pure-u-sm-3-5.notice-container
+          div.notice
+            i.icon.icon-important
+              span.visually-hidden Warning
+
+            strong.bold-small Mandatory address checks not completed
+    else
+      +itemAndError(risk.hasConsideredChecks, errors.hasConsideredChecks, "hasConsideredChecks")
+
+div.pure-g.borderBottomLight.midPaddingTopBottom
+  div.pure-u-1-2
+    div.pure-g
+      span.pure-u-3-4 Are you waiting for any other information?
+
+  div.pure-u-1-2
+    if risk.awaitingOtherInformation === 'Yes'
+      div.pure-g
+        div.pure-u-1.pure-u-sm-3-5.notice-container
+          div.notice
+            i.icon.icon-important
+              span.visually-hidden Warning
+
+            strong.bold-small Still waiting for information
+    else
+      +itemAndError(risk.awaitingOtherInformation, errors.awaitingOtherInformation, "awaitingOtherInformation")
+
+if risk.riskManagementDetails
+  div.pure-g.borderBottomLight.midPaddingTopBottom
+    div.pure-u-1-2
+      div.pure-g
+        span.pure-u-3-4 Provide details of your checks
+    div.pure-u-1-2
+      +itemAndError(risk.riskManagementDetails, errors.riskManagementDetails, "riskManagementDetails")
+
+div.pure-g.borderBottomLight.midPaddingTopBottom
+  div.pure-u-1-2
+    div.pure-g
+      span.pure-u-3-4 Is the address proposed by the offender suitable?
+  div.pure-u-1-2
+    +itemAndError(risk.proposedAddressSuitable, errors.proposedAddressSuitable, "proposedAddressSuitable")
+    if risk.proposedAddressSuitable === 'No'
+      +itemAndError(risk.unsuitableReason, errors.unsuitableReason, "unsuitableReason")
+
+if risk.proposedAddressSuitable === 'Yes'
+  div.pure-g.borderBottomLight.midPaddingTopBottom
+    div.pure-u-1-2
+      div.pure-g
+        span.pure-u-3-4 Is there any additional information about the offender or the address (e.g. if it is difficult to access) to assist the EMS provider on the day of release?
+    div.pure-u-1-2
+      +itemAndError(risk.emsInformation, errors.emsInformation, 'emsInformation')
+      if risk.emsInformation ==='Yes'
+        +itemAndError(risk.emsInformationDetails, errors.emsInformationDetails, 'emsInformationDetails')
+
+div.pure-g.borderBottomLight.midPaddingTopBottom
+  div.pure-u-1-2
+    div.pure-g
+      span.pure-u-3-4 Is it possible to manage the offender safely in the community if released to the proposed address?
+  div.pure-u-1-2
+    +itemAndError(risk.manageInTheCommunity, errors.manageInTheCommunity, "manageInTheCommunity")
+    if risk.manageInTheCommunity === 'No'
+      +itemAndError(risk.manageInTheCommunityNotPossibleReason, errors.manageInTheCommunityNotPossibleReason, "manageInTheCommunityNotPossibleReason")
+
+div.pure-g.borderBottomLight.midPaddingTopBottom
+  div.pure-u-1-2
+    div.pure-g
+      span.pure-u-3-4 Do you have information that cannot be disclosed to the offender?
+  div.pure-u-1-2
+    +itemAndError(risk.nonDisclosableInformation, errors.nonDisclosableInformation, "nonDisclosableInformation")
+    if risk.nonDisclosableInformation === 'Yes' && errors.nonDisclosableInformationDetails
+      +itemAndError(risk.nonDisclosableInformationDetails, errors.nonDisclosableInformationDetails, "nonDisclosableInformationDetails")

--- a/server/views/review/risk.pug
+++ b/server/views/review/risk.pug
@@ -61,5 +61,16 @@ block content
       div.smallPaddingTop
         span#emsInformationDetails.block.bold #{risk.emsInformationDetails}
 
+    if risk.version == '3'
+      div.smallPaddingTop
+        p Is it possible to manage the offender safely in the community if released to the proposed address?
+
+        span#manageInTheCommunity.block.bold #{risk.manageInTheCommunity}
+
+      if risk.manageInTheCommunity === 'No'
+        div.smallPaddingTop
+          p Explain why you made your decision
+
+          span#unsuitableReason.block.bold #{risk.manageInTheCommunityNotPossibleReason}
 
   +readOnlyNonDisclosableInformation(risk)

--- a/server/views/risk/riskManagementV3.pug
+++ b/server/views/risk/riskManagementV3.pug
@@ -1,0 +1,111 @@
+extends ../layout
+
+include mixins
+
+block content
+
+  div.pure-g
+    .pure-u-1
+      include ../includes/backToTaskList
+      include ../includes/personalDetailsSummary
+
+      h2.heading-large Risk management
+
+    .pure-u-1.pure-u-md-1-2
+      form(method="post")
+        input(type="hidden" name="_csrf" value=csrfToken)
+        input(type="hidden" name="bookingId" value=bookingId || '')
+        input(type="hidden" name="version" value=version || '')
+        div.paddingBottom.largeMarginBottom
+
+          div.form-group.inline.smallPaddingTop
+            h3.heading-small Mandatory address checks
+            p Have you requested and considered current risk information from the police and children’s services related to the proposed address?
+
+            div.multiple-choice
+              input#consideredChecksYes(type="radio" checked=data.hasConsideredChecks === 'Yes' name="hasConsideredChecks" value="Yes")
+              label(for="consideredChecksYes") Yes
+
+            div.multiple-choice
+              input#consideredChecksNo(type="radio" checked=data.hasConsideredChecks === 'No' name="hasConsideredChecks" value="No")
+              label(for="consideredChecksNo") No
+
+          div.form-group.inline.smallPaddingTop
+            p.noMargin Are you waiting for any other information?
+            span.form-hint.smallMarginBottom.smallMarginTop For example, information from other agencies or their prison offender manager.
+
+            div.multiple-choice
+              input#awaitingOtherYes(type="radio" checked=data.awaitingOtherInformation === 'Yes' name="awaitingOtherInformation" value="Yes")
+              label(for="awaitingOtherYes") Yes
+            div.multiple-choice
+              input#awaitingOtherNo(type="radio" checked=data.awaitingOtherInformation === 'No' name="awaitingOtherInformation" value="No")
+              label(for="awaitingOtherNo") No
+
+          div.form-group
+            label(for='riskManagementDetails') Provide details of your checks
+              span.form-hint.midMarginBottom.smallMarginTop If you're waiting for information include details of what you're waiting for and when you should get it.
+            textarea(name='riskManagementDetails' id='riskManagementDetails' class='form-control' rows='5' aria-label="Provide details of when you expect to get the information")
+              if data.riskManagementDetails
+                | #{data.riskManagementDetails}
+
+          div.form-group.inline.smallPaddingTop
+            p Is the address proposed by the offender suitable?
+
+            div.multiple-choice(data-target='emsInformationForm')
+              input#suitableYes(type="radio" checked=data.proposedAddressSuitable === 'Yes' name="proposedAddressSuitable" value="Yes")
+              label(for="suitableYes") Yes
+            div.multiple-choice(data-target="reasonForm")
+              input#suitableNo(type="radio" checked=data.proposedAddressSuitable === 'No' name="proposedAddressSuitable" value="No")
+              label(for="suitableNo") No
+
+            div#reasonForm.panel.panel-border-narrow.js-hidden
+              label(for='unsuitableReason') Please explain why you have made this decision
+                textarea(name='unsuitableReason' id='unsuitableReason' class='form-control' rows='5' aria-label="Explain why the address is unsuitable")
+                  if data.unsuitableReason
+                    | #{data.unsuitableReason}
+
+          div#emsInformationForm.form-group.inline.smallPaddingTop.js-hidden
+            p Is there any additional information about the offender or the address (e.g. if it is difficult to access) to assist the EMS provider on the day of release?
+
+            div.multiple-choice(data-target="emsInformationFormDetails")
+              input#emsInformationYes(type="radio" checked=data.emsInformation === 'Yes' name="emsInformation" value="Yes")
+              label(for="emsInformationYes") Yes
+
+            div.multiple-choice
+              input#emsInformationNo(type="radio" checked=data.emsInformation === 'No' name="emsInformation" value="No")
+              label(for="emsInformationNo") No
+
+            div#emsInformationFormDetails.panel.panel-border-narrow.js-hidden
+              textarea(name='emsInformationDetails' id='emsInformationDetails' class='form-control' rows='5' aria-label='Provide the information')
+                if data.emsInformationDetails
+                  | #{data.emsInformationDetails}
+
+          div.form-group.inline.smallPaddingTop
+            h3.heading-small Managing offender in the community
+            p Is it possible to manage the offender safely in the community if released to the proposed address?
+
+            div.multiple-choice
+              input#manageInTheCommunityYes(type="radio" checked=data.manageInTheCommunity === 'Yes' name="manageInTheCommunity" value="Yes")
+              label(for="manageInTheCommunityYes") Yes
+
+            div.multiple-choice(data-target="reasonFormManageInTheCommunity")
+              input#manageInTheCommunityNo(type="radio" checked=data.manageInTheCommunity === 'No' name="manageInTheCommunity" value="No")
+              label(for="manageInTheCommunityNo") No
+
+            div#reasonFormManageInTheCommunity.panel.panel-border-narrow.js-hidden
+              label(for='manageInTheCommunityNotPossibleReason') Please explain why you have made this decision
+                textarea(name='manageInTheCommunityNotPossibleReason' id='manageInTheCommunityNotPossibleReason' class='form-control' rows='5' aria-label="Explain why it is not possible to manage the offender safely in the community at the proposed address")
+                  if data.manageInTheCommunityNotPossibleReason
+                    | #{data.manageInTheCommunityNotPossibleReason}
+
+          if user.role === 'RO'
+            +nonDisclosableInformation(data)
+          else
+            input(type="hidden" name='nonDisclosableInformation' id='nonDisclosableInformation' value=data.nonDisclosableInformation)
+            input(type="hidden" name='nonDisclosableInformationDetails'    id='nonDisclosableInformationDetails'    value=data.nonDisclosableInformationDetails)
+            +readOnlyNonDisclosableInformation(data)
+
+        if (action === 'change')
+          include ../includes/formSubmit
+        else
+          include ../includes/saveAndReturn

--- a/test/routes/viewModels/taskLists/tasks/riskManagement.test.js
+++ b/test/routes/viewModels/taskLists/tasks/riskManagement.test.js
@@ -27,13 +27,28 @@ describe('risk management task', () => {
     })
   })
 
-  test('should return Completed if risk management section is done and risk management version is 2', () => {
+  test('should return Completed if risk management section is done and risk management version is 2 or 3', () => {
     expect(
       riskManagement.view({
         decisions: {
           addressReviewFailed: false,
           showMandatoryAddressChecksNotCompletedWarning: false,
           riskManagementVersion: '2',
+        },
+        tasks: { riskManagement: 'DONE' },
+      })
+    ).toStrictEqual({
+      action: { href: '/hdc/review/risk/', text: 'View', type: 'btn-secondary' },
+      label: 'Completed',
+      title: 'Risk management',
+    })
+
+    expect(
+      riskManagement.view({
+        decisions: {
+          addressReviewFailed: false,
+          showMandatoryAddressChecksNotCompletedWarning: false,
+          riskManagementVersion: '3',
         },
         tasks: { riskManagement: 'DONE' },
       })

--- a/test/services/formValidation.test.ts
+++ b/test/services/formValidation.test.ts
@@ -344,6 +344,25 @@ describe('validation', () => {
           },
           {
             formResponse: {
+              version: '3',
+              hasConsideredChecks: '',
+              awaitingOtherInformation: '',
+              proposedAddressSuitable: '',
+              nonDisclosableInformation: '',
+              manageInTheCommunity: '',
+            },
+            outcome: {
+              hasConsideredChecks:
+                'Say if you have requested and considered risk information related to the proposed address',
+              awaitingOtherInformation: 'Say if you are still awaiting information',
+              proposedAddressSuitable: 'Say if the proposed address is suitable',
+              nonDisclosableInformation: 'Say if you want to add information that cannot be disclosed to the offender',
+              manageInTheCommunity:
+                'Say if it is possible to manage the offender in the community safely at the proposed address',
+            },
+          },
+          {
+            formResponse: {
               version: '1',
               planningActions: 'Yes',
               awaitingInformation: 'Yes',

--- a/test/services/licence/licenceStatus.test.ts
+++ b/test/services/licence/licenceStatus.test.ts
@@ -863,6 +863,29 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })
 
+      test('should show risk management version 3 DONE when mandatory address checks have been considered and proposedAddressSuitable, awaitingRiskInformation and manageInTheCommunity answered', () => {
+        const licence = {
+          stage: 'PROCESSING_RO',
+          licence: {
+            risk: {
+              riskManagement: {
+                version: '3',
+                hasConsideredChecks: 'Yes',
+                awaitingOtherInformation: 'No',
+                proposedAddressSuitable: 'Yes',
+                manageInTheCommunity: 'Yes',
+              },
+            },
+          },
+        }
+
+        const status = getLicenceStatus(licence)
+
+        expect(status.tasks.riskManagement).toEqual(TaskState.DONE)
+        expect(status.decisions.showMandatoryAddressChecksNotCompletedWarning).toBe(false)
+        expect(status.decisions.awaitingRiskInformation).toBe(false)
+      })
+
       test('should show risk management version 2 STARTED if all questions answered but mandatory address checks answer is No', () => {
         const licence = {
           stage: 'PROCESSING_RO',
@@ -888,6 +911,35 @@ describe('getLicenceStatus', () => {
 
         expect(status.tasks.riskManagement).toEqual(TaskState.STARTED)
         expect(status.decisions.showMandatoryAddressChecksNotCompletedWarning).toBe(true)
+        expect(status.decisions.riskManagementNeeded).toBe(false)
+        expect(status.decisions.awaitingRiskInformation).toBe(false)
+      })
+
+      test('should show risk management version 3 STARTED if all questions answered apart from manageInTheCommunity', () => {
+        const licence = {
+          stage: 'PROCESSING_RO',
+          licence: {
+            risk: {
+              riskManagement: {
+                version: '3',
+                hasConsideredChecks: 'Yes',
+                awaitingOtherInformation: 'No',
+                emsInformation: 'Yes',
+                emsInformationDetails: 'some details',
+                nonDisclosableInformation: 'No',
+                nonDisclosableInformationDetails: '',
+                proposedAddressSuitable: 'Yes',
+                riskManagementDetails: 'some details',
+                unsuitableReason: '',
+              },
+            },
+          },
+        }
+
+        const status = getLicenceStatus(licence)
+
+        expect(status.tasks.riskManagement).toEqual(TaskState.STARTED)
+        expect(status.decisions.showMandatoryAddressChecksNotCompletedWarning).toBe(false)
         expect(status.decisions.riskManagementNeeded).toBe(false)
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })


### PR DESCRIPTION
Added managing offender safely in the community question as a new version of the risk management section of the licence:

**COM checks view page:**
<img width="667" alt="Screenshot 2023-05-17 at 11 11 23" src="https://github.com/ministryofjustice/licences/assets/48809053/2254a77a-19b7-4680-a60d-3a4cf36e0443">

**With text box if user selects No:**
<img width="630" alt="Screenshot 2023-05-17 at 11 11 30" src="https://github.com/ministryofjustice/licences/assets/48809053/a9ad9593-457f-49ce-801c-43dfb8dafa72">

**Validation message also added as shown on the review page before a COM sends a case back to the CA:**
<img width="1118" alt="Screenshot 2023-05-17 at 11 13 22" src="https://github.com/ministryofjustice/licences/assets/48809053/0e36c483-1389-4cf3-b4ad-ff975f428e74">

**Review page for risk section also updated following updates made is a user selects `Change` on the COM review page:**
<img width="691" alt="Screenshot 2023-05-17 at 11 13 46" src="https://github.com/ministryofjustice/licences/assets/48809053/af490ee6-483c-4d42-a015-5220abbb97af">

**Curfew address check form accessed from the COM task list updated with new question:**
<img width="706" alt="Screenshot 2023-05-17 at 11 49 49" src="https://github.com/ministryofjustice/licences/assets/48809053/a8ff8819-3b64-4b17-8f2b-94da63ee9092">

**CA review page also updated with new question:**
<img width="1121" alt="Screenshot 2023-05-17 at 11 16 04" src="https://github.com/ministryofjustice/licences/assets/48809053/3200eefa-c6fe-45df-88df-76613f1e0520">

