### PR TITLE
Dcs 2239 risk management add pom consultation question

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/RiskManagementV3Page.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/assessment/RiskManagementV3Page.groovy
@@ -21,6 +21,7 @@ class RiskManagementV3Page extends Page {
     addressSuitableRadios { $(name: "proposedAddressSuitable").module(RadioButtons) }
     emsInformationRadios(required: false) { $(name: "emsInformation").module(RadioButtons) }
     manageInTheCommunityRadios { $(name: "manageInTheCommunity").module(RadioButtons) }
+    pomConsultationRadios { $(name: "pomConsultation").module(RadioButtons) }
     nonDisclosableInformationRadios { $(name: "nonDisclosableInformation").module(RadioButtons) }
 
     riskManagementForm { $("#riskManagementDetails") }

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/RiskManagementV3Spec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/RiskManagementV3Spec.groovy
@@ -148,6 +148,6 @@ class RiskManagementV3Spec extends GebReportingSpec {
     then: 'I see the previously entered values'
     hasConsideredChecksRadios.checked == 'Yes'
     addressSuitableRadios.checked == 'No'
-    pomConsultationRadios.checked = 'Yes'
+    pomConsultationRadios.checked == 'Yes'
   }
 }

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/RiskManagementV3Spec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/assessment/RiskManagementV3Spec.groovy
@@ -137,6 +137,7 @@ class RiskManagementV3Spec extends GebReportingSpec {
     when: 'I select new options'
     hasConsideredChecksRadios.checked = 'Yes'
     addressSuitableRadios.checked = 'No'
+    pomConsultationRadios.checked = 'Yes'
 
     and: 'I save and continue'
     find('#continueBtn').click()
@@ -147,5 +148,6 @@ class RiskManagementV3Spec extends GebReportingSpec {
     then: 'I see the previously entered values'
     hasConsideredChecksRadios.checked == 'Yes'
     addressSuitableRadios.checked == 'No'
+    pomConsultationRadios.checked = 'Yes'
   }
 }

--- a/server/data/licenceTypes.ts
+++ b/server/data/licenceTypes.ts
@@ -250,7 +250,7 @@ export interface Reporting {
   }
 }
 
-export type RiskManagement = RiskManagementV1 | RiskManagementV2
+export type RiskManagement = RiskManagementV1 | RiskManagementV2 | RiskManagementV3
 
 type RiskManagementV1 = {
   version: '1'
@@ -276,6 +276,22 @@ type RiskManagementV2 = {
   proposedAddressSuitable?: string
   riskManagementDetails?: string
   unsuitableReason?: string
+}
+
+type RiskManagementV3 = {
+  version: '3'
+  awaitingOtherInformation?: string
+  emsInformation?: string
+  emsInformationDetails?: string
+  hasConsideredChecks?: string
+  nonDisclosableInformation?: string
+  nonDisclosableInformationDetails?: string
+  proposedAddressSuitable?: string
+  riskManagementDetails?: string
+  unsuitableReason?: string
+  manageInTheCommunity?: string
+  manageInTheCommunityNotPossibleReason?: string
+  pomConsultation?: string
 }
 
 export interface Risk {

--- a/server/routes/config/risk.ts
+++ b/server/routes/config/risk.ts
@@ -76,6 +76,12 @@ export default {
         },
       },
       {
+        pomConsultation: {
+          responseType: 'requiredYesNoIf_version_3',
+          validationMessage: 'Say if you have consulted the POM about the offender’s progress in custody',
+        },
+      },
+      {
         nonDisclosableInformation: {
           responseType: 'requiredYesNo',
           validationMessage: 'Say if you want to add information that cannot be disclosed to the offender',

--- a/server/routes/viewModels/taskLists/tasks/riskManagement.js
+++ b/server/routes/viewModels/taskLists/tasks/riskManagement.js
@@ -5,10 +5,23 @@ const getLabel = ({ decisions, tasks }) => {
     riskManagementVersion,
     riskManagementNeeded,
     showMandatoryAddressChecksNotCompletedWarning,
+    pomNotConsulted,
     addressUnsuitable,
     awaitingRiskInformation,
   } = decisions
   const { riskManagement } = tasks
+
+  const labels = {
+    awaitingRiskInformation: { true: 'Still waiting for information' },
+    pomNotConsulted: { true: 'POM has not been consulted about offender’s progress' },
+  }
+
+  const warningLabel = [
+    labels.awaitingRiskInformation[awaitingRiskInformation],
+    labels.pomNotConsulted[pomNotConsulted],
+  ]
+    .filter(Boolean)
+    .join('||')
 
   if (addressUnsuitable) {
     return 'Address unsuitable'
@@ -29,8 +42,8 @@ const getLabel = ({ decisions, tasks }) => {
       return 'WARNING||Mandatory address checks not completed'
     }
 
-    if (awaitingRiskInformation) {
-      return 'WARNING||Still waiting for information'
+    if (warningLabel) {
+      return `WARNING||${warningLabel}`
     }
 
     if (riskManagement === 'DONE') {

--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -152,6 +152,7 @@ function getRoStageState(licence) {
     riskManagementNeeded,
     awaitingRiskInformation,
     showMandatoryAddressChecksNotCompletedWarning,
+    pomNotConsulted,
     riskManagementVersion,
   } = getRiskManagementState(licence)
   const { decision: victimLiaisonNeeded, task: victim } = getTaskState(licence.victim?.victimLiaison?.decision)
@@ -174,6 +175,7 @@ function getRoStageState(licence) {
       riskManagementNeeded,
       awaitingRiskInformation,
       showMandatoryAddressChecksNotCompletedWarning,
+      pomNotConsulted,
       victimLiaisonNeeded,
       standardOnly,
       additional,
@@ -255,20 +257,23 @@ function getRiskManagementState(licence) {
   const checksConsideredAnswer = riskManagement?.hasConsideredChecks
   const awaitingInformationAnswer = riskManagement?.awaitingInformation || riskManagement?.awaitingOtherInformation
   const manageInTheCommunityAnswer = riskManagement?.manageInTheCommunity
-  const { proposedAddressSuitable, manageInTheCommunity } = riskManagement || {}
+  const { proposedAddressSuitable, manageInTheCommunity, pomConsultation } = riskManagement || {}
   const { bassRequested } = getBassRequestState(licence)
 
   return {
     riskManagementVersion,
     riskManagementNeeded: riskManagementAnswer === 'Yes',
     showMandatoryAddressChecksNotCompletedWarning:
-      riskManagementVersion === '2' && checksConsideredAnswer !== 'Yes' && !bassRequested,
+      (riskManagementVersion === '2' || riskManagementVersion === '3') &&
+      checksConsideredAnswer !== 'Yes' &&
+      !bassRequested,
     proposedAddressSuitable:
       proposedAddressSuitable === 'Yes' || (riskManagementVersion === '3' && manageInTheCommunity === 'Yes'),
     awaitingRiskInformation: awaitingInformationAnswer === 'Yes',
     riskManagement: getState(),
     addressUnsuitable:
       proposedAddressSuitable === 'No' || (riskManagementVersion === '3' && manageInTheCommunity === 'No'),
+    pomNotConsulted: pomConsultation === 'No',
   }
 
   function getState() {

--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -257,6 +257,7 @@ function getRiskManagementState(licence) {
   const checksConsideredAnswer = riskManagement?.hasConsideredChecks
   const awaitingInformationAnswer = riskManagement?.awaitingInformation || riskManagement?.awaitingOtherInformation
   const manageInTheCommunityAnswer = riskManagement?.manageInTheCommunity
+  const pomConsultationAnswer = riskManagement?.pomConsultation
   const { proposedAddressSuitable, manageInTheCommunity, pomConsultation } = riskManagement || {}
   const { bassRequested } = getBassRequestState(licence)
 
@@ -290,7 +291,8 @@ function getRiskManagementState(licence) {
         (riskManagementAnswer || checksConsideredAnswer === 'Yes') &&
         awaitingInformationAnswer &&
         proposedAddressSuitable &&
-        manageInTheCommunityAnswer) ||
+        manageInTheCommunityAnswer &&
+        pomConsultationAnswer) ||
       (riskManagementVersion === '2' &&
         checksConsideredAnswer === 'No' &&
         awaitingInformationAnswer &&

--- a/server/services/licence/licenceStatusTypes.ts
+++ b/server/services/licence/licenceStatusTypes.ts
@@ -58,6 +58,7 @@ export type Decisions = {
   riskManagementNeeded?: boolean
   awaitingRiskInformation?: boolean
   showMandatoryAddressChecksNotCompletedWarning?: boolean
+  pomNotConsulted?: boolean
   victimLiaisonNeeded?: boolean
   optedOut?: boolean
 

--- a/server/views/forms/includes/riskV3.pug
+++ b/server/views/forms/includes/riskV3.pug
@@ -25,3 +25,7 @@ div.no-break.smallPaddingBottom#risk
   p Is it possible to manage the offender safely in the community if released to the proposed address?
     br
     span.entry #{riskManagement.manageInTheCommunity}
+
+  p Have you consulted the POM for information about the offender’s current progress in custody?
+    br
+    span.entry #{riskManagement.pomConsultation}

--- a/server/views/review/includes/riskManagementV3.pug
+++ b/server/views/review/includes/riskManagementV3.pug
@@ -76,6 +76,23 @@ div.pure-g.borderBottomLight.midPaddingTopBottom
 div.pure-g.borderBottomLight.midPaddingTopBottom
   div.pure-u-1-2
     div.pure-g
+      span.pure-u-3-4 Have you consulted the POM for information about the offender’s current progress in custody?
+
+  div.pure-u-1-2
+    if risk.pomConsultation === 'No'
+      div.pure-g
+        div.pure-u-1.pure-u-sm-3-5.notice-container
+          div.notice
+            i.icon.icon-important
+              span.visually-hidden Warning
+
+            strong.bold-small POM has not been consulted about offender’s progress
+    else
+      +itemAndError(risk.pomConsultation, errors.pomConsultation, "pomConsultation")
+
+div.pure-g.borderBottomLight.midPaddingTopBottom
+  div.pure-u-1-2
+    div.pure-g
       span.pure-u-3-4 Do you have information that cannot be disclosed to the offender?
   div.pure-u-1-2
     +itemAndError(risk.nonDisclosableInformation, errors.nonDisclosableInformation, "nonDisclosableInformation")

--- a/server/views/review/risk.pug
+++ b/server/views/review/risk.pug
@@ -71,6 +71,11 @@ block content
         div.smallPaddingTop
           p Explain why you made your decision
 
-          span#unsuitableReason.block.bold #{risk.manageInTheCommunityNotPossibleReason}
+          span#manageInTheCommunityNotPossibleReason.block.bold #{risk.manageInTheCommunityNotPossibleReason}
+      
+      div.smallPaddingTop
+        p Have you consulted the POM for information about the offender’s current progress in custody?
+
+        span#pomConsultation.block.bold #{risk.pomConsultation}
 
   +readOnlyNonDisclosableInformation(risk)

--- a/server/views/risk/riskManagementV3.pug
+++ b/server/views/risk/riskManagementV3.pug
@@ -98,6 +98,18 @@ block content
                   if data.manageInTheCommunityNotPossibleReason
                     | #{data.manageInTheCommunityNotPossibleReason}
 
+          div.form-group.inline.smallPaddingTop
+            h3.heading-small Prison offender manager (POM) consultation
+            p Have you consulted the POM for information about the offender’s current progress in custody?
+
+            div.multiple-choice
+              input#pomConsultationYes(type="radio" checked=data.pomConsultation === 'Yes' name="pomConsultation" value="Yes")
+              label(for="pomConsultationYes") Yes
+
+            div.multiple-choice
+              input#pomConsultationNo(type="radio" checked=data.pomConsultation === 'No' name="pomConsultation" value="No")
+              label(for="pomConsultationNo") No
+
           if user.role === 'RO'
             +nonDisclosableInformation(data)
           else

--- a/test/routes/viewModels/taskLists/tasks/riskManagement.test.js
+++ b/test/routes/viewModels/taskLists/tasks/riskManagement.test.js
@@ -111,6 +111,32 @@ describe('risk management task', () => {
     })
   })
 
+  test('should return warning if version 3 and pom not consulted about the offender’s current progress in custody', () => {
+    expect(
+      riskManagement.view({
+        decisions: { pomNotConsulted: true, riskManagementVersion: '3' },
+        tasks: {},
+      })
+    ).toStrictEqual({
+      action: { href: '/hdc/review/risk/', text: 'View', type: 'btn-secondary' },
+      label: 'WARNING||POM has not been consulted about offender’s progress',
+      title: 'Risk management',
+    })
+  })
+
+  test('should return multiple warnings if version 3, still waiting for information and pom not consulted about the offender’s current progress in custody', () => {
+    expect(
+      riskManagement.view({
+        decisions: { pomNotConsulted: true, awaitingRiskInformation: true, riskManagementVersion: '3' },
+        tasks: {},
+      })
+    ).toStrictEqual({
+      action: { href: '/hdc/review/risk/', text: 'View', type: 'btn-secondary' },
+      label: 'WARNING||Still waiting for information||POM has not been consulted about offender’s progress',
+      title: 'Risk management',
+    })
+  })
+
   test('should show continue btn to curfewAddressReview if curfewAddressReview: !DONE || UNSTARTED', () => {
     expect(
       riskManagement.view({

--- a/test/services/formValidation.test.ts
+++ b/test/services/formValidation.test.ts
@@ -350,6 +350,7 @@ describe('validation', () => {
               proposedAddressSuitable: '',
               nonDisclosableInformation: '',
               manageInTheCommunity: '',
+              pomConsultation: '',
             },
             outcome: {
               hasConsideredChecks:
@@ -359,6 +360,7 @@ describe('validation', () => {
               nonDisclosableInformation: 'Say if you want to add information that cannot be disclosed to the offender',
               manageInTheCommunity:
                 'Say if it is possible to manage the offender in the community safely at the proposed address',
+              pomConsultation: 'Say if you have consulted the POM about the offender’s progress in custody',
             },
           },
           {

--- a/test/services/licence/licenceStatus.test.ts
+++ b/test/services/licence/licenceStatus.test.ts
@@ -863,7 +863,7 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })
 
-      test('should show risk management version 3 DONE when mandatory address checks have been considered and proposedAddressSuitable, awaitingRiskInformation and manageInTheCommunity answered', () => {
+      test('should show risk management version 3 DONE when mandatory address checks have been considered and proposedAddressSuitable, awaitingRiskInformation, manageInTheCommunity and pomConsultation answered', () => {
         const licence = {
           stage: 'PROCESSING_RO',
           licence: {
@@ -874,6 +874,7 @@ describe('getLicenceStatus', () => {
                 awaitingOtherInformation: 'No',
                 proposedAddressSuitable: 'Yes',
                 manageInTheCommunity: 'Yes',
+                pomConsultation: 'Yes',
               },
             },
           },
@@ -915,7 +916,7 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })
 
-      test('should show risk management version 3 STARTED if all questions answered apart from manageInTheCommunity', () => {
+      test('should show risk management version 3 STARTED if all questions answered apart from manageInTheCommunity and pomConsultation', () => {
         const licence = {
           stage: 'PROCESSING_RO',
           licence: {


### PR DESCRIPTION
Added question required to confirm COM has consulted POM to the new version of the risk management section of the licence:

**COM checks view page:**
<img width="600" alt="Screenshot 2023-05-17 at 17 10 18" src="https://github.com/ministryofjustice/licences/assets/48809053/5e4355c6-8066-4fd6-b201-228563c52940">


**Validation message also added as shown on the review page before a COM sends a case back to the CA:**
<img width="1097" alt="Screenshot 2023-05-17 at 17 12 01" src="https://github.com/ministryofjustice/licences/assets/48809053/a5fead48-4fcc-4243-b359-b930e055dd63">


**Review page for risk section also updated following updates made is a user selects `Change` on the COM review page:**
<img width="699" alt="Screenshot 2023-05-17 at 17 12 25" src="https://github.com/ministryofjustice/licences/assets/48809053/ee6083b1-39f2-4dd2-be24-8544f68af03d">


**Task list now includes warning if user answers `No` to POM consultation question, also will display multiple warnings if required:**
<img width="1094" alt="Screenshot 2023-05-17 at 17 07 58" src="https://github.com/ministryofjustice/licences/assets/48809053/29e56dea-1bab-42ea-9272-ce436f3dec21">

<img width="1043" alt="Screenshot 2023-05-17 at 17 08 10" src="https://github.com/ministryofjustice/licences/assets/48809053/40ea5258-9410-41b3-b8c3-0798b0d08ccd">


**Curfew address check form accessed from the COM task list updated with new question:**
<img width="698" alt="Screenshot 2023-05-17 at 17 07 30" src="https://github.com/ministryofjustice/licences/assets/48809053/9ace0afd-7263-4b83-8aee-e6bc8ef9972c">


**CA review page also updated with new question and warning:**
<img width="1101" alt="Screenshot 2023-05-17 at 17 04 05" src="https://github.com/ministryofjustice/licences/assets/48809053/00efc55d-f4e2-48c6-bc61-38ba1ba24157">

