### PR TITLE
DCS-2241 add new page to DM approval journey

### DIFF
--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/TaskListPage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/TaskListPage.groovy
@@ -33,6 +33,10 @@ class TaskListPage extends Page {
     addressFormPrintStatusText(required: false) { $('#addressFormPrintStatusText') }
     addressFormPrintStatusIcon(required: false) { $('#addressFormPrintStatusIcon') }
 
+    taskListLabel(required: false) { taskName, label ->
+      $('h2', text: contains(taskName)).closest('div').text().contains(label)
+    }
+
     taskListActions(required: false) { $('.taskListAction') }
 
     taskListAction(required: false) { taskName ->

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/decision/ApprovalConsiderationPage.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/pages/decision/ApprovalConsiderationPage.groovy
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.licences.pages.decision
+
+import geb.Page
+import geb.module.RadioButtons
+import uk.gov.justice.digital.hmpps.licences.modules.HeaderModule
+
+import java.awt.Button
+
+class ApprovalConsiderationPage extends Page {
+
+  static url = '/hdc/approval/consideration'
+
+  static at = {
+    browser.currentUrl.contains(url)
+  }
+
+  static content = {
+
+    header { module(HeaderModule) }
+
+    considerationRadios { $(name: "decision").module(RadioButtons) }
+
+    saveAndContinue(required: false){ $('#continueBtn')}
+
+  }
+}

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalConsiderationSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalConsiderationSpec.groovy
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.licences.util.Actions
 import uk.gov.justice.digital.hmpps.licences.util.TestData
 
 @Stepwise
-class ConsiderationSpec extends GebReportingSpec {
+class ApprovalConsiderationSpec extends GebReportingSpec {
 
   @Shared
   TestData testData = new TestData()

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ApprovalSpec.groovy
@@ -88,7 +88,7 @@ class ApprovalSpec extends GebReportingSpec {
     reasonsForm.isDisplayed()
 
     reasonsItem('insufficientTime').checked
-    
+
     !reasonsItem('addressUnsuitable').checked
     !reasonsItem('noAvailableAddress').checked
     !reasonsItem('outOfTime').checked

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ConsiderationSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/ConsiderationSpec.groovy
@@ -61,7 +61,7 @@ class ConsiderationSpec extends GebReportingSpec {
     at TaskListPage
 
     and: 'I see the correct label'
-    taskListLabel('Final decision', "You need to consider changes to the offender's circumstances first") == true
+    taskListLabel('Final decision', "Consider changes to offender's circumstances") == true
   }
 
   def 'Selecting Yes retains the Not Started task list label'() {

--- a/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/MandatoryCheckSpec.groovy
+++ b/licences-specs/src/test/groovy/uk/gov/justice/digital/hmpps/licences/specs/decision/MandatoryCheckSpec.groovy
@@ -6,6 +6,7 @@ import spock.lang.Stepwise
 import uk.gov.justice.digital.hmpps.licences.pages.TaskListPage
 import uk.gov.justice.digital.hmpps.licences.pages.decision.ApprovalMandatoryCheckPage
 import uk.gov.justice.digital.hmpps.licences.pages.decision.ApprovalReleasePage
+import uk.gov.justice.digital.hmpps.licences.pages.decision.ApprovalConsiderationPage
 import uk.gov.justice.digital.hmpps.licences.util.Actions
 import uk.gov.justice.digital.hmpps.licences.util.TestData
 
@@ -60,8 +61,8 @@ class MandatoryCheckSpec extends GebReportingSpec {
     when: 'I click the final decision continue button'
     taskListAction('Final decision').click()
 
-    then: 'I do not see the mandatory checks page and I go to the approval release page'
-    at ApprovalReleasePage
+    then: 'I do not see the mandatory checks page and I go to the approval consideration page'
+    at ApprovalConsiderationPage
   }
 
 }

--- a/licences-specs/src/test/resources/licences/decision/consideration.json
+++ b/licences-specs/src/test/resources/licences/decision/consideration.json
@@ -1,0 +1,138 @@
+{
+  "stage": "DECIDED",
+  "licence": {
+    "eligibility": {
+      "excluded": {
+        "decision": "No"
+      },
+      "suitability": {
+        "decision": "No"
+      },
+      "crdTime": {
+        "decision": "No"
+      }
+    },
+    "proposedAddress": {
+      "optOut": {
+        "decision": "No"
+      },
+      "bassReferral": {
+        "decision": "No"
+      },
+      "curfewAddress": {
+        "addressLine1": "Street",
+        "addressLine2": "",
+        "addressTown": "Town",
+        "postCode": "AB1 1AB",
+        "telephone": "0123 456789",
+        "occupier": {
+          "name": "Main Occupier",
+          "age": "21",
+          "relationship": "Brother"
+        },
+        "residents": [
+          {
+            "name": "Other Resident",
+            "age": "10",
+            "relationship": "Son"
+          },
+          {
+            "name": "",
+            "age": "",
+            "relationship": ""
+          },
+          {
+            "name": "Yet Another",
+            "age": "20",
+            "relationship": "Wife"
+          }
+        ],
+        "cautionedAgainstResident": "No"
+      }
+    },
+    "curfew": {
+      "curfewHours": {
+        "firstNightFrom": "18:30",
+        "firstNightUntil": "10:11",
+        "mondayFrom": "21:22",
+        "mondayUntil": "08:09",
+        "tuesdayFrom": "19:00",
+        "tuesdayUntil": "07:00",
+        "wednesdayFrom": "19:00",
+        "wednesdayUntil": "07:00",
+        "thursdayFrom": "19:00",
+        "thursdayUntil": "07:00",
+        "fridayFrom": "19:00",
+        "fridayUntil": "07:00",
+        "saturdayFrom": "19:00",
+        "saturdayUntil": "07:00",
+        "sundayFrom": "18:19",
+        "sundayUntil": "06:07"
+      },
+      "curfewAddressReview": {
+        "consent": "Yes",
+        "electricity": "Yes",
+        "homeVisitConducted": "Yes"
+      }
+    },
+    "licenceConditions": {
+      "standard": {
+        "additionalConditionsRequired": "Yes"
+      },
+      "additional": {
+        "NO_CAMERA_PHONE": {}
+      },
+      "bespoke": [
+        {
+          "text": "First bespoke condition",
+          "approved": "Yes"
+        }
+      ]
+    },
+    "risk": {
+      "riskManagement": {
+        "version": "1",
+        "planningActions": "No",
+        "awaitingInformation": "No",
+        "proposedAddressSuitable": "Yes"
+      }
+    },
+    "victim": {
+      "victimLiaison": {
+        "decision": "No"
+      }
+    },
+    "reporting": {
+      "reportingInstructions": {
+        "name": "Reporting Name",
+        "buildingAndStreet1": "Street",
+        "buildingAndStreet2": "",
+        "townOrCity": "Town",
+        "postcode": "AB1 1AB",
+        "telephone": "0123 456789"
+      }
+    },
+    "finalChecks": {
+      "onRemand": {
+        "decision": "No"
+      },
+      "seriousOffence": {
+        "decision": "No"
+      },
+      "confiscationOrder": {
+        "decision": "No"
+      },
+      "undulyLenientSentence": {
+        "decision": "No"
+      },
+      "segregation": {
+        "decision": "No"
+      }
+    },
+    "approval": {
+      "consideration": {
+        "decision": "Yes"
+      }
+    }
+  }
+}

--- a/server/routes/approval.js
+++ b/server/routes/approval.js
@@ -34,6 +34,7 @@ module.exports =
         res.render('approval/mandatoryCheck', { bookingId, prisonerInfo })
       })
     )
+    router.get('/consideration/:bookingId', asyncMiddleware(approvalGets('consideration')))
 
     function approvalGets(formName) {
       return async (req, res) => {
@@ -43,7 +44,7 @@ module.exports =
         const prisonerInfo = await prisonerService.getPrisonerDetails(bookingId, res.locals.token)
 
         const { nextPath, pageDataMap } = formConfig[formName]
-        const dataPath = pageDataMap || ['licence', 'approval', 'release']
+        const dataPath = pageDataMap || ['licence', 'approval', formName]
         const data = firstItem(req.flash('userInput')) || getIn(res.locals.licence, dataPath) || {}
         const errorObject = firstItem(req.flash('errors')) || {}
 

--- a/server/routes/config/approval.js
+++ b/server/routes/config/approval.js
@@ -1,4 +1,30 @@
 module.exports = {
+  consideration: {
+    licenceSection: 'consideration',
+    validate: true,
+    fields: [
+      {
+        decision: {
+          responseType: 'requiredYesNo',
+          validationMessage: 'Select yes or no',
+        },
+      },
+    ],
+
+    nextPath: {
+      decisions: [
+        {
+          discriminator: 'decision',
+          No: {
+            path: '/hdc/taskList/',
+          },
+          Yes: {
+            path: '/hdc/approval/release/',
+          },
+        },
+      ],
+    },
+  },
   release: {
     licenceSection: 'release',
     validate: true,

--- a/server/routes/viewModels/taskLists/tasks/dm/makeFinalDecision.js
+++ b/server/routes/viewModels/taskLists/tasks/dm/makeFinalDecision.js
@@ -12,7 +12,7 @@ module.exports = {
       label: getLabel(licenceStatus),
       action: {
         type: 'btn',
-        href: '/hdc/approval/release/',
+        href: '/hdc/approval/consideration/',
         text: 'Continue',
       },
     }

--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -122,6 +122,8 @@ const combiner = (acc, data) => {
 
 function getApprovalStageState(licence) {
   const approvalRelease = licence.approval?.release || {}
+  const dmConsideration = licence.approval?.consideration || {}
+
   const finalChecksRefusal = licence.finalChecks?.refusal || {}
 
   const dmRefusalReasonText = extractDmRefusalReasonsText(approvalRelease.reason)
@@ -135,6 +137,7 @@ function getApprovalStageState(licence) {
       approved: approvalRelease.decision === 'Yes' && finalChecksRefusal.decision !== 'Yes',
       refused: approvalRelease.decision === 'No' || finalChecksRefusal.decision === 'Yes',
       dmRefused: approvalRelease.decision === 'No',
+      dmNotConsidered: dmConsideration.decision === 'No',
       refusalReason,
       bassAccepted,
       decisionComments: approvalRelease.reasonForDecision ? approvalRelease.reasonForDecision.trim() : null,

--- a/server/services/licence/licenceStatusLabels.js
+++ b/server/services/licence/licenceStatusLabels.js
@@ -22,6 +22,10 @@ const status = {
   licenceCreated: { statusLabel: 'Licence created', activeCase: true },
   notComplete: { statusLabel: 'Not complete', activeCase: true },
   inProgress: { statusLabel: 'In progress', activeCase: true },
+  dmNotConsidered: {
+    statusLabel: "You need to consider changes to the offender's circumstances first",
+    activeCase: true,
+  },
 
   // inactive
   notEligible: { statusLabel: 'Not eligible', activeCase: false },
@@ -198,7 +202,10 @@ function roProcessingCaLabel(licenceStatus) {
 }
 
 function dmProcessingLabel(licenceStatus) {
-  const labels = [{ decision: 'insufficientTimeStop', label: status.awaitingRefusal }]
+  const labels = [
+    { decision: 'insufficientTimeStop', label: status.awaitingRefusal },
+    { decision: 'dmNotConsidered', label: status.dmNotConsidered },
+  ]
 
   return getLabel(labels, licenceStatus) || status.notStarted
 }

--- a/server/services/licence/licenceStatusLabels.js
+++ b/server/services/licence/licenceStatusLabels.js
@@ -23,7 +23,7 @@ const status = {
   notComplete: { statusLabel: 'Not complete', activeCase: true },
   inProgress: { statusLabel: 'In progress', activeCase: true },
   dmNotConsidered: {
-    statusLabel: "You need to consider changes to the offender's circumstances first",
+    statusLabel: "Consider changes to offender's circumstances",
     activeCase: true,
   },
 

--- a/server/services/licence/licenceStatusTypes.ts
+++ b/server/services/licence/licenceStatusTypes.ts
@@ -54,6 +54,7 @@ export type Decisions = {
   dmRefused?: boolean
   refusalReason?: string
   decisionComments?: string
+  dmNotConsidered?: boolean
 
   riskManagementNeeded?: boolean
   awaitingRiskInformation?: boolean

--- a/server/views/approval/consideration.pug
+++ b/server/views/approval/consideration.pug
@@ -1,0 +1,39 @@
+extends ../layout
+include ../includes/errorBannerWithDetail
+
+block content
+
+  - var decisionValue = data.decision || null;
+
+  div.pure-g.pure-u-1.largeMarginBottom
+
+    include ../includes/backToCheckList
+    +errorBannerWithDetail(errorObject, [
+      { field: 'decision' }
+    ])
+    include ../taskList/prisonerDetails
+
+    div.pure-u-md-1-2
+      h2.heading-large Have you considered whether the offender’s circumstances or behaviour have significantly changed since the COM’s assessment?
+
+
+      if errorObject.decision
+        p.error-message #{errorObject.decision}
+      form(method="post").largeMarginTop
+        input(type="hidden" name="_csrf" value=csrfToken)
+        input(type="hidden" name="bookingId" value=bookingId || '')
+        input(type="hidden" name="decisionMaker" value=user.name)
+        div.paddingBottom.largeMarginBottom
+
+          div#error-anchor.form-group
+            div.multiple-choice
+              input#considerationYes(type="radio" checked=decisionValue === 'Yes'  name="decision" value="Yes")
+              label(for="considerationYes") Yes
+            
+            div.multiple-choice
+              input#considerationNo(type="radio" checked=decisionValue === 'No'  name="decision" value="No")
+              label(for="considerationNo") No
+ 
+
+          div.paddingBottom.smallPaddingTop
+            input#continueBtn.requiredButton.button(type="submit" value="Save and continue")

--- a/server/views/approval/mandatoryCheck.pug
+++ b/server/views/approval/mandatoryCheck.pug
@@ -19,7 +19,7 @@ block content
 
           div.paddingBottom.smallPaddingTop
             div.pure-u-1.inlineButtons
-              a#continueBtn.requiredButton.button.smallMarginTop(href="/hdc/approval/release/" + bookingId role="button") Continue
+              a#continueBtn.requiredButton.button.smallMarginTop(href="/hdc/approval/consideration/" + bookingId role="button") Continue
               a#returnToChecklistBtn.requiredButton.button.button-secondary.smallMarginTop(href="/hdc/taskList/" + bookingId role="button") Return to task list
 
 block append scripts

--- a/test/routes/approval.test.js
+++ b/test/routes/approval.test.js
@@ -58,12 +58,29 @@ describe('/hdc/approval', () => {
       { url: '/hdc/approval/release/1', content: 'Do you approve HDC release for this offender?' },
       { url: '/hdc/approval/refuseReason/1', content: 'HDC refused' },
       { url: '/hdc/approval/mandatoryCheck/1', content: 'Mandatory address checks have not been completed' },
+      {
+        url: '/hdc/approval/consideration/1',
+        content:
+          'Have you considered whether the offender’s circumstances or behaviour have significantly changed since the COM’s assessment?',
+      },
     ]
 
     testFormPageGets(app, routes, service)
   })
 
   describe('GET /approval/routes/:bookingId', () => {
+    test('should display the offender details and question text- consideration', () => {
+      return request(app)
+        .get('/hdc/approval/consideration/1')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain('23/12/1971')
+          expect(res.text).toContain(
+            'Have you considered whether the offender’s circumstances or behaviour have significantly'
+          )
+        })
+    })
     test('should display the offender details - release', () => {
       return request(app)
         .get('/hdc/approval/release/1')

--- a/test/routes/viewModels/taskListModelsDM.test.js
+++ b/test/routes/viewModels/taskListModelsDM.test.js
@@ -73,7 +73,7 @@ describe('TaskList models', () => {
   const finalDecision = {
     title: 'Final decision',
     label: 'Not started',
-    action: { href: '/hdc/approval/release/', text: 'Continue', type: 'btn' },
+    action: { href: '/hdc/approval/consideration/', text: 'Continue', type: 'btn' },
   }
   const finalDecisionAwaitingRefusal = {
     title: 'Final decision',

--- a/test/services/licence/licenceStatus.test.ts
+++ b/test/services/licence/licenceStatus.test.ts
@@ -157,6 +157,9 @@ describe('getLicenceStatus', () => {
             release: {
               decision: 'Yes',
             },
+            consideration: {
+              decision: 'No',
+            },
           },
         },
       }
@@ -191,6 +194,7 @@ describe('getLicenceStatus', () => {
       expect(status.decisions.refused).toBe(false)
       expect(status.decisions.dmRefused).toBe(false)
       expect(status.decisions.offenderIsMainOccupier).toBe(true)
+      expect(status.decisions.dmNotConsidered).toBe(true)
     })
 
     test('should show false decisions when decision data is present for false', () => {
@@ -271,6 +275,9 @@ describe('getLicenceStatus', () => {
               decision: 'No',
               reason: ['noAvailableAddress', 'addressUnsuitable', 'outOfTime', 'insufficientTime'],
             },
+            consideration: {
+              decision: 'Yes',
+            },
           },
         },
       }
@@ -310,6 +317,7 @@ describe('getLicenceStatus', () => {
         'No available address, address unsuitable, out of time, insufficient time'
       )
       expect(status.decisions.approvedPremisesRequired).toBe(false)
+      expect(status.decisions.dmNotConsidered).toBe(false)
     })
 
     test('should show DM refusal reason if not in array', () => {

--- a/test/services/licence/licenceStatusLabels.test.js
+++ b/test/services/licence/licenceStatusLabels.test.js
@@ -418,7 +418,7 @@ describe('licenceStatusLabels', () => {
         const examples = [
           {
             status: { stage: LicenceStage.APPROVAL, decisions: { dmNotConsidered: true }, tasks: {} },
-            label: "You need to consider changes to the offender's circumstances first",
+            label: "Consider changes to offender's circumstances",
           },
           {
             status: { stage: LicenceStage.APPROVAL, decisions: {}, tasks: {} },

--- a/test/services/licence/licenceStatusLabels.test.js
+++ b/test/services/licence/licenceStatusLabels.test.js
@@ -417,6 +417,10 @@ describe('licenceStatusLabels', () => {
       describe('Approval stage', () => {
         const examples = [
           {
+            status: { stage: LicenceStage.APPROVAL, decisions: { dmNotConsidered: true }, tasks: {} },
+            label: "You need to consider changes to the offender's circumstances first",
+          },
+          {
             status: { stage: LicenceStage.APPROVAL, decisions: {}, tasks: {} },
             label: 'Not started',
           },


### PR DESCRIPTION
New page for a DM 'consideration' added

DM's Final decision task button will now go to new 'consideration' page instead of the refuse/allow page.
However if in previous questions, the answer to Mandatory Address checks is no, then the task list button will lead to the Mandatory Address Check warning page first (this is as per current behaviour)

**new page**

<img width="600" alt="Screenshot 2023-05-24 at 12 57 57" src="https://github.com/ministryofjustice/licences/assets/50441412/f532a59f-496f-4e70-b45a-e09d073b3c3e">



**new label for Final decision task if user answers No**

![Screenshot 2023-05-24 at 15 28 11](https://github.com/ministryofjustice/licences/assets/50441412/0f3036c6-4721-4765-9049-d96cc1cc2a9d)

**and in caselist**

![Screenshot 2023-05-24 at 15 31 09](https://github.com/ministryofjustice/licences/assets/50441412/1c1add90-29c1-429e-b1b0-bd8b39a5f902)




