### PR TITLE
DCS-2245 update docker compose files

### DIFF
--- a/docker-compose-full.yml
+++ b/docker-compose-full.yml
@@ -110,7 +110,7 @@ services:
       test: [ "CMD", "curl", "-f", "http://localhost:8080/health/ping" ]
     environment:
       SPRING_PROFILES_ACTIVE: local-redis
-      SPRING_REDIS_HOST: token-verification-api-db
+      SPRING_DATA_REDIS_HOST: token-verification-api-db
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "http://hmpps-auth:8080/auth/.well-known/jwks.json"
 
   token-verification-api-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
     environment:
       SPRING_PROFILES_ACTIVE: local-redis
-      SPRING_REDIS_HOST: token-verification-api-db
+      SPRING_DATA_REDIS_HOST: token-verification-api-db
       SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI: "http://hmpps-auth:8080/auth/.well-known/jwks.json"
 
   token-verification-api-db:


### PR DESCRIPTION
The latest images that would be pulled down when doing a docker-compose pull will cause auth error when starting
the integration tests. This is because of a has been a change to the token-verification-api 

It now uses SPRING_DATA_REDIS_HOST rather than SPRING_REDIS_HOST