### PR TITLE
DCS-2242, change reason text for Not Eligible form

### DIFF
--- a/server/services/config/formConfig.js
+++ b/server/services/config/formConfig.js
@@ -38,8 +38,8 @@ module.exports = {
   },
 
   ineligibleReasonlabels: {
-    sexOffenderRegister: 'of your conviction history',
-    convictedSexOffences: 'of the type of offence you were convicted of',
+    sexOffenderRegister: 'you will be subject to sex offender registration on release',
+    convictedSexOffences: 'you are serving an extended sentence',
     rotlFail: 'you did not return from release on temporary licence (ROTL)',
     communityCurfew: 'you breached your community order curfew',
     returnedAtRisk: 'you were returned to custody by the court during the at risk period',

--- a/test/services/formService.test.ts
+++ b/test/services/formService.test.ts
@@ -166,7 +166,7 @@ describe('formService', () => {
         EST_PREMISE: '',
         OFF_NAME: '',
         OFF_NOMS: '',
-        INELIGIBLE_REASON: 'of your conviction history',
+        INELIGIBLE_REASON: 'you will be subject to sex offender registration on release',
       }
 
       const data = await service.getTemplateData('ineligible', licence, prisoner)
@@ -191,14 +191,16 @@ describe('formService', () => {
 
     test('should map first excluded reason when multiple', async () => {
       const prisoner = {}
-      const licence = { eligibility: { excluded: { reason: ['sexOffenderRegister', 'other', 'other'] } } }
+      const licence = {
+        eligibility: { excluded: { reason: ['sexOffenderRegister', 'convictedSexOffences', 'other'] } },
+      }
 
       const expectedData = {
         CREATION_DATE: creationDate,
         EST_PREMISE: '',
         OFF_NAME: '',
         OFF_NOMS: '',
-        INELIGIBLE_REASON: 'of your conviction history',
+        INELIGIBLE_REASON: 'you will be subject to sex offender registration on release',
       }
 
       const data = await service.getTemplateData('ineligible', licence, prisoner)


### PR DESCRIPTION
The new text will show on the Not Eligible form. Note only one reason will appear at any time. 
![Screenshot 2023-05-24 at 14 22 49](https://github.com/ministryofjustice/licences/assets/50441412/3babdef7-7103-4432-a41f-9b82e0d585a4)
<img width="500" alt="Screenshot 2023-05-24 at 14 42 02" src="https://github.com/ministryofjustice/licences/assets/50441412/fca13dab-e1bb-497c-96ba-1d7d64795cd3">
