### PR TITLE
DCS-2240 risk mental healthcare plan question fix

### DIFF
--- a/server/services/licence/licenceStatus.ts
+++ b/server/services/licence/licenceStatus.ts
@@ -261,8 +261,13 @@ function getRiskManagementState(licence) {
   const manageInTheCommunityAnswer = riskManagement?.manageInTheCommunity
   const pomConsultationAnswer = riskManagement?.pomConsultation
   const mentalHealthPlanAnswer = riskManagement?.mentalHealthPlan
-  const { proposedAddressSuitable, manageInTheCommunity, pomConsultation, prisonHealthcareConsultation } =
-    riskManagement || {}
+  const {
+    proposedAddressSuitable,
+    manageInTheCommunity,
+    pomConsultation,
+    mentalHealthPlan,
+    prisonHealthcareConsultation,
+  } = riskManagement || {}
   const { bassRequested } = getBassRequestState(licence)
 
   return {
@@ -279,7 +284,7 @@ function getRiskManagementState(licence) {
     addressUnsuitable:
       proposedAddressSuitable === 'No' || (riskManagementVersion === '3' && manageInTheCommunity === 'No'),
     pomNotConsulted: pomConsultation === 'No',
-    prisonHealthcareNotConsulted: prisonHealthcareConsultation === 'No',
+    prisonHealthcareNotConsulted: mentalHealthPlan === 'Yes' && prisonHealthcareConsultation === 'No',
   }
 
   function getState() {

--- a/test/services/licence/licenceStatus.test.ts
+++ b/test/services/licence/licenceStatus.test.ts
@@ -979,6 +979,36 @@ describe('getLicenceStatus', () => {
         expect(status.decisions.awaitingRiskInformation).toBe(false)
       })
 
+      test('should show risk management prisonHealthcareNotConsulted warning when version 3, mentalHealthPlan answered as Yes and prisonHealthcareConsultation answered as No', () => {
+        const licence = {
+          stage: 'PROCESSING_RO',
+          licence: {
+            risk: {
+              riskManagement: {
+                version: '3',
+                hasConsideredChecks: 'Yes',
+                awaitingOtherInformation: 'No',
+                emsInformation: 'Yes',
+                emsInformationDetails: 'some details',
+                nonDisclosableInformation: 'No',
+                nonDisclosableInformationDetails: '',
+                proposedAddressSuitable: 'Yes',
+                riskManagementDetails: 'some details',
+                unsuitableReason: '',
+                manageInTheCommunity: 'Yes',
+                mentalHealthPlan: 'Yes',
+                prisonHealthcareConsultation: 'No',
+                pomConsultation: 'Yes',
+              },
+            },
+          },
+        }
+
+        const status = getLicenceStatus(licence)
+
+        expect(status.decisions.prisonHealthcareNotConsulted).toBe(true)
+      })
+
       test('should show risk management version 2 DONE if all questions answered when mandatory address checks answer is No but bass property has been requested', () => {
         const licence = {
           stage: 'PROCESSING_RO',


### PR DESCRIPTION
Small fix to make sure that prison healthcare not consulted warning only displayed when a user selects Yes that it is essential for a mental healthcare plan to be in place and selects No to consulted with prison healthcare.

<img width="720" alt="Screenshot 2023-05-26 at 11 33 38" src="https://github.com/ministryofjustice/licences/assets/48809053/7e42c453-564c-470a-af69-91add126c408">
