### PR TITLE
DCS-2249 add migration script to set version value for curfew address…

### DIFF
--- a/migrations/20230530092632_add-curfewAddressReview-version-init-value.js
+++ b/migrations/20230530092632_add-curfewAddressReview-version-init-value.js
@@ -1,0 +1,13 @@
+exports.up = async function up(knex) {
+  await knex.schema.raw(`
+      update licences set licence = jsonb_set(licence,'{curfew, curfewAddressReview, version}','"1"')
+      where licence -> 'curfew' -> 'curfewAddressReview' ->> 'version' is null
+  `)
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.raw(`
+      update licences set licence = licence #- '{curfew, curfewAddressReview, version'
+      where licence -> 'curfew' -> 'curfewAddressReview' ->> 'version' = '"1"'
+  `)
+}

--- a/migrations/20230530092632_add-curfewAddressReview-version-init-value.js
+++ b/migrations/20230530092632_add-curfewAddressReview-version-init-value.js
@@ -7,7 +7,7 @@ exports.up = async function up(knex) {
 
 exports.down = async function down(knex) {
   await knex.schema.raw(`
-      update licences set licence = licence #- '{curfew, curfewAddressReview, version'
+      update licences set licence = licence #- '{curfew, curfewAddressReview, version}'
       where licence -> 'curfew' -> 'curfewAddressReview' ->> 'version' = '"1"'
   `)
 }


### PR DESCRIPTION
… review question for active/started licences

This will set  a curfewAddressReview version of '1' for all currently 'active' and 'already started but not completed' licences. 