### PR TITLE
DCS-2218 versioning postpone pdf form

### DIFF
--- a/integration_test/routes/forms.test.ts
+++ b/integration_test/routes/forms.test.ts
@@ -123,6 +123,65 @@ describe('/forms/', () => {
       expect(pdfText).toContain('Mark Andrews You are eligible for early release')
       expect(pdfText).toContain('you could be released from prison on 23rd August 2019')
     })
+
+    test('Generates Postponed PDF - with postpone version 1 content only when postpone version is 1', async () => {
+      const licenceWithPostponeV2 = {
+        licence: {
+          finalChecks: { postpone: { version: '1', decision: 'Yes', postponeReason: 'investigation' } },
+          stage: 'PROCESSING_CA',
+        },
+      }
+      licenceService.getLicence = jest.fn().mockReturnValue(licenceWithPostponeV2)
+      app = createApp('caUser')
+
+      const res = await request(app).get('/hdc/forms/postponed/1')
+
+      const pdf = await pdfParse(res.body)
+      const pdfText = pdf.text.replace(/([\t\n])/gm, ' ') // The extracted PDF text has newline and tab characters
+
+      expect(pdfText).toContain('Home Detention Curfew (tagging): Postponed')
+      expect(pdfText).toContain(
+        'Mark Andrews We are still reviewing your case for release on home detention curfew (tagging)'
+      )
+      expect(pdfText).toContain('We will let you know our decision when we have all the information we need')
+    })
+
+    test('Generates Postponed PDF - with postpone version 2 content when postpone version is 2', async () => {
+      const licenceWithPostponeV2 = {
+        licence: {
+          finalChecks: { postpone: { version: '2', decision: 'Yes', postponeReason: 'awaitingInformation' } },
+          stage: 'PROCESSING_CA',
+        },
+      }
+      licenceService.getLicence = jest.fn().mockReturnValue(licenceWithPostponeV2)
+      app = createApp('caUser')
+
+      const res = await request(app).get('/hdc/forms/postponed/1')
+
+      const pdf = await pdfParse(res.body)
+      const pdfText = pdf.text.replace(/([\t\n])/gm, ' ') // The extracted PDF text has newline and tab characters
+
+      expect(pdfText).toContain('Home Detention Curfew (tagging): Postponed')
+      expect(pdfText).toContain('Mark Andrews The decision to release you on HDC has been postponed because')
+      expect(pdfText).toContain(
+        'If this is resolved in time to allow release, we will then make the decision and notify you'
+      )
+    })
+
+    test('Generates Postponed PDF - with postpone version 2 content as default', async () => {
+      app = createApp('caUser')
+
+      const res = await request(app).get('/hdc/forms/postponed/1')
+
+      const pdf = await pdfParse(res.body)
+      const pdfText = pdf.text.replace(/([\t\n])/gm, ' ') // The extracted PDF text has newline and tab characters
+
+      expect(pdfText).toContain('Home Detention Curfew (tagging): Postponed')
+      expect(pdfText).toContain('Mark Andrews The decision to release you on HDC has been postponed because')
+      expect(pdfText).toContain(
+        'If this is resolved in time to allow release, we will then make the decision and notify you'
+      )
+    })
   })
 
   describe('/forms/:bookingId/', () => {

--- a/server/services/config/formConfig.js
+++ b/server/services/config/formConfig.js
@@ -7,7 +7,7 @@ module.exports = {
   requiredFields: {
     eligible: [...headerFields, 'SENT_HDCED', 'SENT_CRD'],
     optout: [...headerFields, 'SENT_CRD'],
-    postponed: headerFields,
+    postponed: [...headerFields, 'POSTPONE_REASON'],
     refused: [...headerFields, 'REFUSAL_REASON', 'SENT_CRD'],
     approved: [...headerFields, 'CURFEW_ADDRESS', 'SENT_HDCED', 'SENT_CRD'],
     address_checks: [...headerFields, 'SENT_HDCED'],
@@ -59,5 +59,16 @@ module.exports = {
     historyOfTerrorism: 'of your terrorist or terrorist connected offending history',
     categoryA: 'you are a category A prisoner',
     serving4YearsOrMoreOverseas: 'your original sentence was of 4 or more years',
+  },
+
+  postponedReasonlabels: {
+    awaitingInformation: 'we are awaiting information in order to decide if you are suitable to release',
+    committedOffenceWhileInPrison:
+      'you committed an offence while you’ve been in prison and the criminal/Independent Adjudication proceedings are still outstanding',
+    remandedInCustodyOnOtherMatters: 'you are remanded in custody on other matters',
+    confiscationOrderOutstanding: 'we think you will frustrate your outstanding confiscation order proceedings',
+    segregatedForReasonsOtherThanProtection:
+      'you are currently segregated from the general population for reasons other than your own protection',
+    sentenceReviewedUnderULSScheme: 'your sentence is being reviewed under the unduly lenient sentence (ULS) scheme',
   },
 }

--- a/server/services/formService.ts
+++ b/server/services/formService.ts
@@ -6,6 +6,7 @@ import {
   refusalReasonlabels,
   ineligibleReasonlabels,
   unsuitableReasonlabels,
+  postponedReasonlabels,
 } from './config/formConfig'
 import logger from '../../log'
 import type { PrisonerService } from './prisonerService'
@@ -80,6 +81,7 @@ export default class FormService {
       REFUSAL_REASON: () => this.getRefusalReason(licence),
       INELIGIBLE_REASON: () => this.getIneligibleReason(licence),
       UNSUITABLE_REASON: () => this.getUnsuitableReason(licence),
+      POSTPONE_REASON: () => this.getPostponedReason(licence),
       CURFEW_HOURS: () => this.getValue(licence, ['curfew', 'curfewHours']),
       CURFEW_FIRST: () => this.getValue(licence, ['curfew', 'firstNight']),
     }
@@ -121,6 +123,10 @@ export default class FormService {
 
   private getUnsuitableReason(licence) {
     return this.getReasonLabel(licence, ['eligibility', 'suitability', 'reason'], unsuitableReasonlabels)
+  }
+
+  private getPostponedReason(licence) {
+    return this.getReasonLabel(licence, ['finalChecks', 'postpone', 'postponeReason'], postponedReasonlabels)
   }
 
   private getReasonLabel(licence, path, labels) {

--- a/server/views/forms/postponed.pug
+++ b/server/views/forms/postponed.pug
@@ -2,11 +2,17 @@ extends forms-layout
 
 block content
 
-  +header('postponed')
+  - var postpone = licence.licence.finalChecks && licence.licence.finalChecks.postpone ? licence.licence.finalChecks.postpone : {}
 
-  p We are still reviewing your case for release on home detention curfew (tagging).
 
-  p We will let you know our decision when we have all the information we need.
+  +header('Postponed')
+
+  if postpone.version == '1'
+     p We are still reviewing your case for release on home detention curfew (tagging).
+     p We will let you know our decision when we have all the information we need.
+  else
+     p The decision to release you on HDC has been postponed because #{POSTPONE_REASON}.
+     p If this is resolved in time to allow release, we will then make the decision and notify you.
 
   ul.byHand
     li Signed:

--- a/test/services/formService.test.ts
+++ b/test/services/formService.test.ts
@@ -255,6 +255,24 @@ describe('formService', () => {
       expect(data).toEqual(expectedData)
     })
 
+    test('should map postpone reason', async () => {
+      const prisoner = {}
+      const licence = {
+        finalChecks: { postpone: { version: '2', decision: 'Yes', postponeReason: 'awaitingInformation' } },
+      }
+
+      const expectedData = {
+        CREATION_DATE: creationDate,
+        EST_PREMISE: '',
+        OFF_NAME: '',
+        OFF_NOMS: '',
+        POSTPONE_REASON: 'we are awaiting information in order to decide if you are suitable to release',
+      }
+
+      const data = await service.getTemplateData('postponed', licence, prisoner)
+      expect(data).toEqual(expectedData)
+    })
+
     test('should format dates', async () => {
       const licence = {}
       const prisoner = { sentenceDetail: { homeDetentionCurfewEligibilityDate: '1/5/2019', releaseDate: '3/12/2019' } }


### PR DESCRIPTION
Added versioning to postpone PDF form to display content depending on postpone version. 

**If a licence has a postpone version of 1 the PDF content will be:**
<img width="559" alt="Screenshot 2023-06-01 at 22 07 35" src="https://github.com/ministryofjustice/licences/assets/48809053/c8cad026-8458-4329-b648-f20e525ceb7f">
**If a licence has a postpone version of 2 the PDF content will be:**
<img width="696" alt="Screenshot 2023-06-01 at 22 04 00" src="https://github.com/ministryofjustice/licences/assets/48809053/d64d54e1-8a7c-4739-a2c0-d86931228cb1">
**By default if no version is present yet (version only persisted when postpone section is completed) the PDF content will be as version 2 but not include the postpone reason:**
<img width="604" alt="Screenshot 2023-06-01 at 22 03 32" src="https://github.com/ministryofjustice/licences/assets/48809053/8bf3774c-5908-4fd3-94e4-1339f5d8a478">
**Note:** 
A migration updating all licences with a postpone section present with a postpone version of 1 is required. This is because if a postpone version of 1 doesn’t exist the service will show version 2 content in the PDF. A user can access the PDF forms prior to completing the relevant section therefore by default we want to show version 2 content and only version 1 if they have completed the postpone section prior to this versioning taking place. 