### PR TITLE
DCS-2246 add migration file to add postpone version to active/started licences

### DIFF
--- a/migrations/20230602082059_add-postpone-version-init-value.js
+++ b/migrations/20230602082059_add-postpone-version-init-value.js
@@ -1,0 +1,13 @@
+exports.up = async function up(knex) {
+  await knex.schema.raw(`
+        update licences set licence = jsonb_set(licence,'{finalChecks, postpone, version}','"1"')
+        where licence -> 'finalChecks' -> 'postpone' ->> 'version' is null
+    `)
+}
+
+exports.down = async function down(knex) {
+  await knex.schema.raw(`
+        update licences set licence = licence #- '{finalChecks, postpone, version}'
+        where licence -> 'finalChecks' -> 'postpone' ->> 'version' = '"1"'
+    `)
+}


### PR DESCRIPTION
This will set a postpone version of '1' for all currently 'active' and 'already started but not completed' licences. Is this correct for to not add to completed licences in the case of a postpone version (checking as in the case of viewing the postponed pdf form if a postpone version of 1 doesn’t exist the service will show version 2 content in the PDF. A user can access the PDF forms prior to completing the relevant section therefore by default we want to show version 2 content and only version 1 if they have completed the postpone section prior to this versioning taking place. Therefore for completed licences version 2 of the postponed pdf will display if viewed but I think this is all good). 

Not sure if the timestamp at the start of the file has to be completely exact - hard to so with seconds 😅 