### PR TITLE
DCS-2259 add refusal reasons

### DIFF
--- a/server/views/finalChecks/refuse.pug
+++ b/server/views/finalChecks/refuse.pug
@@ -57,6 +57,14 @@ block content
             div.multiple-choice
               input(type='checkbox' name='outOfTimeReasons[]' id='onRemand' value='onRemand' checked=outOfTimeReasonsValue.indexOf('onRemand') !== -1)
               label(for='onRemand') The offender is currently on remand
+
+            div.multiple-choice
+              input(type='checkbox' name='outOfTimeReasons[]' id='ulsScheme' value='ulsScheme' checked=outOfTimeReasonsValue.indexOf('ulsScheme') !== -1)
+              label(for='ulsScheme') There is an outstanding application under the unduly lenient sentence (ULS) scheme for this offender
+
+            div.multiple-choice
+              input(type='checkbox' name='outOfTimeReasons[]' id='segregated' value='segregated' checked=outOfTimeReasonsValue.indexOf('segregated') !== -1)
+              label(for='segregated') The offender is currently segregated for a reason other than their own protection
             
             div.multiple-choice
               input(type='checkbox' name='outOfTimeReasons[]' id='riskManagement' value='riskManagement' checked=outOfTimeReasonsValue.indexOf('riskManagement') !== -1)


### PR DESCRIPTION
Added 2 new refusal reason check boxes:

**Before**
<img width="1030" alt="Screenshot 2023-06-19 at 14 45 23" src="https://github.com/ministryofjustice/licences/assets/48809053/a8aceb29-3162-4d9c-8660-95cf9971d8d6">

**After**
<img width="897" alt="Screenshot 2023-06-19 at 14 45 09" src="https://github.com/ministryofjustice/licences/assets/48809053/c1ab705d-e4f8-49af-beed-320bb49cd3e6">

Have checked the code and pretty sure new codes are not needed for updating NOMIS, as all refusal reasons in this category seem to be updated in NOMIS as `LIMITS`.
