### PR TITLE
CVSL-1210 curfew address rejection reason fix

### DIFF
--- a/server/views/proposedAddress/rejected.pug
+++ b/server/views/proposedAddress/rejected.pug
@@ -36,8 +36,8 @@ block content
 
       div.pure-u-1.pure-u-md-1-2.paddingBottom
         p.smallMarginBottom Reason for rejection:
-        if addressReview.consent === 'No'
-          p.bold The homeowner/landlord does not give informed consent
+        if addressReview.consent === 'No' || addressReview.consentHavingSpoken === 'No'
+          p#rejectionConsentNotGiven.bold The homeowner/landlord does not give informed consent
         if risk.proposedAddressSuitable === 'No'
           p.bold The address has been deemed unsuitable
           if risk.unsuitableReason

--- a/test/routes/proposedAddress.test.js
+++ b/test/routes/proposedAddress.test.js
@@ -293,6 +293,46 @@ describe('/hdc/proposedAddress', () => {
         })
     })
 
+    test('should display the rejection reason when curfewAddressReview version 1', () => {
+      const licenceService = createLicenceServiceStub()
+      licenceService.getLicence = jest.fn().mockReturnValue({
+        licence: {
+          curfew: { curfewAddressReview: { version: '1', consent: 'No' } },
+        },
+      })
+      const app = createApp({ licenceServiceStub: licenceService }, 'caUser')
+
+      return request(app)
+        .get('/hdc/proposedAddress/rejected/1')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain(
+            'id="rejectionConsentNotGiven">The homeowner/landlord does not give informed consent</p>'
+          )
+        })
+    })
+
+    test('should display the rejection reason when curfewAddressReview version 2', () => {
+      const licenceService = createLicenceServiceStub()
+      licenceService.getLicence = jest.fn().mockReturnValue({
+        licence: {
+          curfew: { curfewAddressReview: { version: '2', consentHavingSpoken: 'No' } },
+        },
+      })
+      const app = createApp({ licenceServiceStub: licenceService }, 'caUser')
+
+      return request(app)
+        .get('/hdc/proposedAddress/rejected/1')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect((res) => {
+          expect(res.text).toContain(
+            'id="rejectionConsentNotGiven">The homeowner/landlord does not give informed consent</p>'
+          )
+        })
+    })
+
     test('should show the form to enter new address', () => {
       const licenceService = createLicenceServiceStub()
       licenceService.getLicence.mockResolvedValue({


### PR DESCRIPTION
Small fix to pull through rejection reason to `Curfew address rejected` page following previous versioning work.

<img width="891" alt="Screenshot 2023-07-21 at 4 19 04 pm" src="https://github.com/ministryofjustice/licences/assets/48809053/77277320-843f-4a6e-90e2-5f0a3a27d17f">

