### PR TITLE
CVSL-1210 curfew address form fix

### DIFF
--- a/server/views/forms/includes/curfewAddressReview.pug
+++ b/server/views/forms/includes/curfewAddressReview.pug
@@ -6,9 +6,10 @@ div.no-break.smallPaddingBottom#curfewAddressReview
       td.entry
         if occupier.isOffender === 'Yes'
           | Offender is main occupier
-        else
+        else if curfewAddressReview.version === '1'
           | #{curfewAddressReview.consent}
-
+        else 
+          | #{curfewAddressReview.consentHavingSpoken}
     tr
       td Was a home visit conducted in this case?
       td.entry #{curfewAddressReview.homeVisitConducted}


### PR DESCRIPTION
Following the curfew address review versioning the consent question answer was not being populated on the Curfew address check form. This has now been fixed:

<img width="703" alt="Screenshot 2023-07-25 at 2 09 44 pm" src="https://github.com/ministryofjustice/licences/assets/48809053/70f46239-e01d-4b12-b378-64e581fb9153">

<img width="694" alt="Screenshot 2023-07-25 at 2 11 19 pm" src="https://github.com/ministryofjustice/licences/assets/48809053/5df54a73-6819-419c-b66a-fedff5744b08">
