### PR TITLE
CVSL-1271 update reject and reinstate proposed address with hasConsideredChecks

### DIFF
--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -460,6 +460,7 @@ export class LicenceService {
             'unsuitableReason',
             'manageInTheCommunity',
             'manageInTheCommunityNotPossibleReason',
+            'hasConsideredChecks',
           ],
           riskManagementInputs
         )
@@ -477,6 +478,7 @@ export class LicenceService {
         ['risk', 'riskManagement', 'unsuitableReason'],
         ['risk', 'riskManagement', 'manageInTheCommunity'],
         ['risk', 'riskManagement', 'manageInTheCommunityNotPossibleReason'],
+        ['risk', 'riskManagement', 'hasConsideredChecks'],
         ['curfew', 'curfewAddressReview'],
       ],
       licenceWithAddressRejection
@@ -505,6 +507,7 @@ export class LicenceService {
           ['risk', 'riskManagement', 'manageInTheCommunityNotPossibleReason'],
           getIn(riskManagement, ['manageInTheCommunityNotPossibleReason']),
         ],
+        [['risk', 'riskManagement', 'hasConsideredChecks'], getIn(riskManagement, ['hasConsideredChecks'])],
         [['curfew', 'curfewAddressReview'], curfewAddressReview],
       ].filter((argument) => argument[1]),
       licenceAfterRemoval

--- a/test/services/licenceService.test.ts
+++ b/test/services/licenceService.test.ts
@@ -1579,6 +1579,7 @@ describe('licenceService', () => {
             unsuitableReason: 'Reasons',
             manageInTheCommunity: 'No',
             manageInTheCommunityNotPossibleReason: 'reasons',
+            hasConsideredChecks: 'Yes',
           },
         },
       }
@@ -1598,6 +1599,7 @@ describe('licenceService', () => {
                 unsuitableReason: 'Reasons',
                 manageInTheCommunity: 'No',
                 manageInTheCommunityNotPossibleReason: 'reasons',
+                hasConsideredChecks: 'Yes',
               },
               withdrawalReason: 'consentWithdrawn',
             },


### PR DESCRIPTION
If a COM flags that an address is unsuitable in the risk section for any reason effectively rejecting the address then sends the case back to the CA. The CA then proposed a new address and returns the case to the COM. The risk section questions which relate the the previous address should then be cleared out as the COM should answer these again considering the new proposed address. The hasConsideredChecks Mandatory address checks question was previously not cleared but now is with this fix. This therefore also means the Mandatory address checks warning is displayed in the task list:

<img width="899" alt="Screenshot 2023-08-10 at 5 00 54 pm" src="https://github.com/ministryofjustice/licences/assets/48809053/b48024e8-0eca-4795-83b5-9f42f1ac51ca">
