### PR TITLE
CVSL-1489 bumped notifications-node-client to address axios vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "moment-business-days": "^1.2.0",
         "nocache": "^4.0.0",
         "node-schedule": "^2.1.1",
-        "notifications-node-client": "^7.0.3",
+        "notifications-node-client": "^7.0.6",
         "passport": "^0.6.0",
         "passport-oauth2": "^1.7.0",
         "path": "^0.12.7",
@@ -2669,11 +2669,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5370,9 +5372,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -9063,11 +9065,11 @@
       }
     },
     "node_modules/notifications-node-client": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.3.tgz",
-      "integrity": "sha512-uLuABa7ZK2XIP6aahHbtiCP4noyNIGclJ2idPh7cojnk2retajkpo0AZctSsDP18SUB0kUmHbBxOOJm2Gkb60g==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.6.tgz",
+      "integrity": "sha512-qo6eZMGdyaQnj/bkOnPb/d0a0sHIjiBzXlmICLPXYSD4pB3LYa537OhuZGuaFcSnkrM4NzbQhbQHAYX1NnbQgw==",
       "dependencies": {
-        "axios": "^0.25.0",
+        "axios": "^1.6.1",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -9984,6 +9986,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "moment-business-days": "^1.2.0",
     "nocache": "^4.0.0",
     "node-schedule": "^2.1.1",
-    "notifications-node-client": "^7.0.3",
+    "notifications-node-client": "^7.0.6",
     "passport": "^0.6.0",
     "passport-oauth2": "^1.7.0",
     "path": "^0.12.7",


### PR DESCRIPTION
Updated [notifications-node-client](https://github.com/alphagov/notifications-node-client) dependency to fix axios vulnerability:  
GHSA-wf5p-g6vw-rhxx | notifications-node-client>axios
https://github.com/alphagov/notifications-node-client/blob/main/CHANGELOG.md