### PR TITLE
Enforcing minimum npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "lint-staged": "^16.3.1",
         "nock": "14.0.10",
         "nodemon": "^3.1.14",
+        "npm-check-updates": "22.2.1",
         "openapi-typescript": "^7.13.0",
         "pdf-parse": "2.4.5",
         "prettier": "^3.8.3",
@@ -90,7 +91,7 @@
       },
       "engines": {
         "node": "^24",
-        "npm": "^11"
+        "npm": "^11.10"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -10403,6 +10404,21 @@
       "engines": {
         "node": ">=14.17.3",
         "npm": ">=6.14.13"
+      }
+    },
+    "node_modules/npm-check-updates": {
+      "version": "22.2.1",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.2.1.tgz",
+      "integrity": "sha512-mGdIJfhtg+q0BzhbOpbOL73zhMZlgBQMG4wnBwPMMD5k96028UCuV0753YeSYk9odoh7HWK6/cY69bWxT7o+yg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "ncu": "build/cli.js",
+        "npm-check-updates": "build/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/npm-install-checks": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "engines": {
     "node": "^24",
-    "npm": "^11"
+    "npm": "^11.10"
   },
   "scripts": {
     "compile-sass": "./bin/build-css -q --quiet-deps --no-source-map",
@@ -165,6 +165,7 @@
     "lint-staged": "^16.3.1",
     "nock": "14.0.10",
     "nodemon": "^3.1.14",
+    "npm-check-updates": "22.2.1",
     "openapi-typescript": "^7.13.0",
     "pdf-parse": "2.4.5",
     "prettier": "^3.8.3",


### PR DESCRIPTION
Also installing npm-check-updates as a dev dependency - this fixes the set of dependencies that will be installed and means we can manage it explicitly