### PR TITLE
CVSL-4275 add functionality to download migration log table as csv

### DIFF
--- a/server/routes/admin/migrateToCvl.ts
+++ b/server/routes/admin/migrateToCvl.ts
@@ -94,6 +94,14 @@ export = (hdcService: HdcService) => (router) => {
                 successFilter,
                 pageable
             )
+
+            if (req.query.format === 'csv') {
+                const records = await hdcService.getMigrationLogsCsv(logs.content)
+                res.contentType('text/csv')
+                res.set('Content-Disposition', `attachment;filename=migration-logs.csv`)
+                return res.send(records)
+            }
+
             return res.render('admin/migrateToCvl/migrationLogs', {
                 logs,
                 licenceVersionId,

--- a/server/services/hdc/hdcService.ts
+++ b/server/services/hdc/hdcService.ts
@@ -1,4 +1,6 @@
 import * as os from 'node:os'
+import { createObjectCsvStringifier } from 'csv-writer'
+import moment from 'moment'
 import { HdcClient } from '../../data/hdcApiClient'
 import { ConvertedLicenseBatch, ConvertedLicenseConditions, Pageable, PageLicenceMigrationLogEntryDto } from '../../@types/hdcApiImport'
 import { LicenceService } from '../licenceService'
@@ -323,6 +325,32 @@ export class HdcService {
             throw error
         }
     }
+
+    async getMigrationLogsCsv(records: any): Promise<string> {
+      logger.info(`Getting migration logs CSV for records count: ${records.length}`)
+
+      const sortedRecords = records
+        .map((record) => ({
+          ...record,
+          date: moment(record.createdTimeStamp).format('DD/MM/YY'),
+          time: moment(record.createdTimeStamp).format('HH:mm'),
+        }))
+
+      const writer = createObjectCsvStringifier({
+        header: [
+          { id: 'id', title: 'ID' },
+          { id: 'date', title: 'Date' },
+          { id: 'time', title: 'Time' },
+          { id: 'bookingId', title: 'Booking ID' },
+          { id: 'licenceVersionId', title: 'Licence Version ID' },
+          { id: 'success', title: 'Success' },
+          { id: 'errorSource', title: 'Source' },
+          { id: 'message', title: 'Message' },
+          { id: 'retry', title: 'Retry' },
+        ],
+      })
+      return writer.getHeaderString() + writer.stringifyRecords(sortedRecords)
+  }
 
 
 }

--- a/server/views/admin/migrateToCvl/migrationLogs.pug
+++ b/server/views/admin/migrateToCvl/migrationLogs.pug
@@ -87,6 +87,10 @@ block content
                         name="action"
                         value="Filter"
                     )
+                    a.button(
+                        href=`/admin/migrateToCvl/migration-logs?format=csv`
+                        style="margin-left: 10px;"
+                    ) Download CSV
 
             if logs && logs.content && logs.content.length > 0
 
@@ -145,4 +149,3 @@ block content
 
     div.pure-g
         div.pure-u-1.largeSpacingTop
-

--- a/test/routes/admin/migrateToCvl.test.ts
+++ b/test/routes/admin/migrateToCvl.test.ts
@@ -1,0 +1,124 @@
+import request from 'supertest'
+import { startRoute } from '../../supertestSetup'
+import createMigrateToCvlRoute from '../../../server/routes/admin/migrateToCvl'
+
+describe('/migration-logs/', () => {
+  let hdcService
+  let mockLogs
+
+  beforeEach(() => {
+    mockLogs = {
+      content: [
+        {
+          id: 1,
+          licenceVersionId: 123,
+          bookingId: 456,
+          errorSource: 'Test',
+          success: false,
+          retry: false,
+          message: 'Test message',
+        },
+        {
+          id: 2,
+          licenceVersionId: 456,
+          bookingId: 789,
+          errorSource: null,
+          success: false,
+          retry: false,
+          message: null,
+        },
+      ],
+      totalElements: 2,
+      totalPages: 1,
+      number: 0,
+      size: 50,
+    }
+
+    hdcService = {
+      getMigrationLogs: jest.fn().mockResolvedValue(mockLogs),
+      getMigrationLogsCsv: jest.fn().mockResolvedValue('id,licenceVersionId,bookingId\n1,123,456'),
+    }
+  })
+
+  describe('GET', () => {
+    test('renders HTML output with default parameters', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/migrateToCvl/migration-logs')
+        .expect(200)
+        .expect('Content-Type', /html/)
+        .expect(() => {
+          expect(hdcService.getMigrationLogs).toHaveBeenCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { page: 0, size: 50 }
+          )
+        })
+    })
+
+    test('calls service with correct parameters from query string', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/migrateToCvl/migration-logs')
+        .query({
+          licenceVersionId: '123',
+          bookingId: '456',
+          errorSource: 'CVL',
+          success: 'false',
+          page: '2',
+          size: '100',
+        })
+        .expect(200)
+        .expect(() => {
+          expect(hdcService.getMigrationLogs).toHaveBeenCalledWith(
+            123,
+            456,
+            'CVL',
+            false,
+            { page: 2, size: 100 }
+          )
+        })
+    })
+
+    test('handles success being true filter', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/migrateToCvl/migration-logs')
+        .query({ success: 'true' })
+        .expect(200)
+        .expect(() => {
+          expect(hdcService.getMigrationLogs).toHaveBeenCalledWith(
+            undefined,
+            undefined,
+            undefined,
+            true,
+            { page: 0, size: 50 }
+          )
+        })
+    })
+
+    test('returns CSV when format=csv', () => {
+      const app = createApp('batchUser')
+      return request(app)
+        .get('/admin/migrateToCvl/migration-logs')
+        .query({ format: 'csv' })
+        .expect(200)
+        .expect('Content-Type', /text\/csv/)
+        .expect('Content-Disposition', /attachment;filename=migration-logs.csv/)
+        .expect((res) => {
+          expect(hdcService.getMigrationLogsCsv).toHaveBeenCalledWith(mockLogs.content)
+          expect(res.text).toContain('id,licenceVersionId,bookingId')
+        })
+    })
+
+    test('should throw if accessed by non-authorised user', () => {
+      const app = createApp('roUser')
+      return request(app).get('/admin/migrateToCvl/migration-logs').expect(403)
+    })
+  })
+
+  const createApp = (user) =>
+    startRoute(createMigrateToCvlRoute(hdcService), '/admin/migrateToCvl', user)
+})


### PR DESCRIPTION
This PR is to add functionality to download the migration log as a CSV. This now appears as an option on the migration log page.

<img width="1011" height="342" alt="Screenshot 2026-07-13 at 11 31 37" src="https://github.com/user-attachments/assets/05f4408b-cf1d-4bfe-9636-14bbf95be6bf" />
