### PR TITLE
CVSL-4346 update devsec hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.4.1
+    rev: v2.0.2
     hooks:
       - id: baseline
         env:


### PR DESCRIPTION
This may require installing gitleaks if you don't already have it installed